### PR TITLE
Update gpui to latest version from zed repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,9 @@ name = "input_sandbox"
 path = "examples/input/sandbox.rs"
 
 [dependencies]
-# GPUI framework
-gpui = "0.2.2"
+# GPUI framework (using latest from zed repo)
+gpui = { git = "https://github.com/zed-industries/zed", package = "gpui" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", package = "gpui_platform" }
 rust-embed = "8.2.0"
 anyhow = "1.0.79"
 serde = { version = "1.0", features = ["derive"] }
@@ -47,13 +48,13 @@ pulldown-cmark = { version = "0.12", default-features = false, features = ["simd
 
 # Editor dependencies (optional)
 syntect = { version = "5.3.0", optional = true }
-gpui_util = { version = "0.2.2", optional = true }
+gpui_util = { git = "https://github.com/zed-industries/zed", package = "gpui_util", optional = true }
 
 # Schema generation (optional)
 schemars = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gpui = { version = "0.2.2", features = ["test-support"] }
+gpui = { git = "https://github.com/zed-industries/zed", package = "gpui", features = ["test-support"] }
 tempfile = "3.8"
 pretty_assertions = "1.4"
 

--- a/examples/input/sandbox.rs
+++ b/examples/input/sandbox.rs
@@ -15,6 +15,7 @@ use gpui::{
     Background, Bounds, Context, DefiniteLength, Div, Entity, FocusHandle, Focusable, FontWeight,
     Hsla, KeyBinding, SharedString, Stateful, Window, WindowBounds, WindowOptions,
 };
+use gpui_platform;
 use gpuikit::elements::dropdown::{dropdown, DropdownChanged, DropdownState};
 use gpuikit::elements::input::{input, text_area};
 use gpuikit::elements::slider::{Slider, SliderChanged};
@@ -580,7 +581,7 @@ impl Render for InputSandbox {
 }
 
 fn main() {
-    Application::new().run(|cx: &mut App| {
+    Application::with_platform(gpui_platform::current_platform(false)).run(|cx: &mut App| {
         gpuikit::init(cx);
         bind_input_keys(cx, None);
 
@@ -595,7 +596,7 @@ fn main() {
             |window, cx| {
                 let view = cx.new(|cx| InputSandbox::new(window, cx));
                 let focus_handle = view.read(cx).active_input().focus_handle(cx);
-                window.focus(&focus_handle);
+                window.focus(&focus_handle, cx);
                 view
             },
         )

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -4,6 +4,7 @@ use gpui::{
     InteractiveElement, IntoElement, Menu, ParentElement, Render, StatefulInteractiveElement,
     Styled, TitlebarOptions, Window, WindowBounds, WindowOptions,
 };
+use gpui_platform;
 use gpuikit::markdown::{Markdown, MarkdownElement};
 use gpuikit::theme::{ActiveTheme, Themeable};
 use gpuikit::{
@@ -622,7 +623,7 @@ impl Render for Showcase {
 }
 
 fn main() {
-    Application::new()
+    Application::with_platform(gpui_platform::current_platform(false))
         .with_assets(gpuikit::assets())
         .run(|cx: &mut App| {
             gpuikit::init(cx);
@@ -630,6 +631,7 @@ fn main() {
             cx.set_menus(vec![Menu {
                 name: "GPUIKit Showcase".into(),
                 items: vec![],
+                disabled: false,
             }]);
 
             let window = cx
@@ -651,7 +653,7 @@ fn main() {
 
             window
                 .update(cx, |showcase, window, cx| {
-                    window.focus(&showcase.focus_handle);
+                    window.focus(&showcase.focus_handle, cx);
                     cx.activate(true);
                 })
                 .unwrap();

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -6,6 +6,7 @@ use gpui::{
     IntoElement, MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement,
     Styled, TitlebarOptions, Window, WindowBounds, WindowOptions,
 };
+use gpui_platform;
 use gpuikit::{
     elements::{
         badge::{badge, BadgeVariant},
@@ -677,7 +678,7 @@ fn pagination_button(
 }
 
 fn main() {
-    Application::new().run(|cx: &mut App| {
+    Application::with_platform(gpui_platform::current_platform(false)).run(|cx: &mut App| {
         gpuikit::init(cx);
         let bounds = Bounds::centered(None, size(px(900.), px(600.)), cx);
         cx.open_window(

--- a/src/elements/dropdown.rs
+++ b/src/elements/dropdown.rs
@@ -81,7 +81,7 @@ impl DropdownMenu {
     ) -> Entity<Self> {
         cx.new(|cx| {
             let focus_handle = cx.focus_handle();
-            window.focus(&focus_handle);
+            window.focus(&focus_handle, cx);
             Self {
                 options,
                 selected_index,

--- a/src/elements/input.rs
+++ b/src/elements/input.rs
@@ -7,6 +7,8 @@
 //!
 //! Use `input()` for single-line text fields and `text_area()` for multi-line text editing.
 
+use std::sync::Arc;
+
 use gpui::{
     fill, point, px, relative, size, Action, App, Bounds, ContentMask, Context, CursorStyle,
     DispatchPhase, Element, ElementId, Entity, FocusHandle, Focusable, GlobalElementId, Hitbox,
@@ -813,7 +815,7 @@ fn paint_multiline_placeholder(
         .text_system()
         .shape_line(placeholder.clone(), font_size, &[run], None);
     let line_height = text_style.line_height_in_pixels(window.rem_size());
-    let _ = shaped_line.paint(bounds.origin, line_height, window, cx);
+    let _ = shaped_line.paint(bounds.origin, line_height, TextAlign::Left, None, window, cx);
 }
 
 fn paint_multiline_text(
@@ -1036,7 +1038,7 @@ struct SingleLinePaintState {
     text_width: Pixels,
     is_focused: bool,
     char_positions: Vec<Pixels>,
-    wrapped_line: Option<WrappedLine>,
+    wrapped_line: Option<Arc<WrappedLine>>,
     direction: TextDirection,
 }
 
@@ -1204,7 +1206,7 @@ fn paint_singleline_placeholder(
     let y_offset = (bounds.size.height - line_height).max(px(0.)) / 2.0;
     let paint_origin = point(bounds.origin.x, bounds.origin.y + y_offset);
 
-    let _ = shaped_line.paint(paint_origin, line_height, window, cx);
+    let _ = shaped_line.paint(paint_origin, line_height, TextAlign::Left, None, window, cx);
 }
 
 fn paint_singleline_text(

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -427,7 +427,7 @@ pub mod dialog {
                     multiple: options.multiple,
                     prompt: None,
                 })
-            })?
+            })
             .await??;
 
         Ok(paths)
@@ -446,7 +446,7 @@ pub mod dialog {
         });
 
         let path = cx
-            .update(|cx| cx.prompt_for_new_path(&default_path, None))?
+            .update(|cx| cx.prompt_for_new_path(&default_path, None))
             .await??;
 
         Ok(path)

--- a/src/input/bindings.rs
+++ b/src/input/bindings.rs
@@ -425,7 +425,7 @@ impl InputBindings {
 
     /// Collects all `Some` bindings into a `Vec<KeyBinding>`.
     pub fn into_bindings(self) -> Vec<KeyBinding> {
-        let mut bindings: Vec<Option<KeyBinding>> = vec![
+        let bindings: Vec<Option<KeyBinding>> = vec![
             self.backspace,
             self.delete,
             self.delete_word_left,

--- a/src/input/blink.rs
+++ b/src/input/blink.rs
@@ -114,8 +114,7 @@ impl CursorBlink {
                     if this.generation == generation {
                         this.tick(cx);
                     }
-                })
-                .ok();
+                });
             }
         })
         .detach();

--- a/src/input/state.rs
+++ b/src/input/state.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use gpui::{
@@ -145,7 +146,7 @@ pub struct InputLineLayout {
     /// The byte range in the content string that this line covers.
     pub text_range: Range<usize>,
     /// The shaped and wrapped text for this line, if available.
-    pub wrapped_line: Option<WrappedLine>,
+    pub wrapped_line: Option<Arc<WrappedLine>>,
     /// The vertical offset from the top of the text area in pixels.
     pub y_offset: Pixels,
     /// The number of visual lines this logical line spans (due to wrapping).
@@ -866,7 +867,7 @@ impl InputState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        window.focus(&self.focus_handle);
+        window.focus(&self.focus_handle, cx);
         self.is_selecting = true;
 
         let is_same_position = self
@@ -1266,7 +1267,7 @@ impl InputState {
 
                     self.line_layouts.push(InputLineLayout {
                         text_range: current_pos..line_end,
-                        wrapped_line: Some(wrapped),
+                        wrapped_line: Some(Arc::new(wrapped)),
                         y_offset,
                         visual_line_count,
                         direction,


### PR DESCRIPTION
## Summary
- Updates gpui from crates.io v0.2.2 to the latest git version from zed-industries/zed repository
- Adds gpui_platform dependency required for the new Application creation API
- Fixes all breaking changes from the updated gpui version

## Breaking Changes Fixed
- `Application::new()` is now `Application::with_platform(gpui_platform::current_platform(false))`
- `window.focus(&handle)` now requires `&mut App` parameter: `window.focus(&handle, cx)`
- `ShapedLine::paint()` now takes additional `TextAlign` and `Option<Pixels>` arguments
- `AsyncApp::update()` no longer wraps return value in `Result`
- `WrappedLine` no longer implements `Clone` - using `Arc<WrappedLine>` instead
- `Menu` struct now requires `disabled` field

## Test plan
- [x] `cargo check` passes
- [x] `cargo check --examples` passes  
- [x] `cargo test --no-run` compiles successfully

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)