### PR TITLE
Add release CI workflows

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,0 +1,191 @@
+# Release Deploy Workflow
+# Triggered by the release workflow or tag pushes
+# Publishes crates to crates.io and creates GitHub releases
+
+name: Deploy Release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to deploy'
+        required: true
+        type: string
+      tag:
+        description: 'Git tag for the release'
+        required: true
+        type: string
+
+  # Allow manual trigger for recovery scenarios
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 0.3.0)'
+        required: true
+        type: string
+      tag:
+        description: 'Git tag for the release (e.g., v0.3.0)'
+        required: true
+        type: string
+      skip_publish:
+        description: 'Skip crates.io publish (for GitHub release only)'
+        required: false
+        type: boolean
+        default: false
+
+  # Trigger on tag push for automated deployments
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+jobs:
+  prepare:
+    name: Prepare Release Info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.info.outputs.version }}
+      tag: ${{ steps.info.outputs.tag }}
+    steps:
+      - name: Determine version and tag
+        id: info
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Extract from pushed tag
+            TAG="${{ github.ref_name }}"
+            VERSION="${TAG#v}"
+          else
+            # Use workflow inputs
+            TAG="${{ inputs.tag }}"
+            VERSION="${{ inputs.version }}"
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION, Tag: $TAG"
+
+  publish:
+    name: Publish to crates.io
+    needs: prepare
+    runs-on: ubuntu-latest
+    # Skip if manually triggered with skip_publish
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_publish }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Verify package version
+        run: |
+          EXPECTED="${{ needs.prepare.outputs.version }}"
+          ACTUAL=$(cargo pkgid | sed 's/.*@//')
+
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "Error: Version mismatch!"
+            echo "Expected: $EXPECTED"
+            echo "Actual: $ACTUAL"
+            exit 1
+          fi
+
+          echo "Version verified: $ACTUAL"
+
+      - name: Run cargo check
+        run: cargo check --all-features
+
+      - name: Dry run publish
+        run: cargo publish --dry-run
+
+      - name: Publish to crates.io
+        run: |
+          echo "Publishing gpuikit v${{ needs.prepare.outputs.version }} to crates.io..."
+          cargo publish
+          echo "Successfully published to crates.io!"
+
+      - name: Wait for crates.io propagation
+        run: |
+          echo "Waiting for crates.io to propagate the package..."
+          sleep 30
+
+  github-release:
+    name: Create GitHub Release
+    needs: [prepare, publish]
+    # Run even if publish was skipped (for workflow_dispatch with skip_publish)
+    if: ${{ always() && needs.prepare.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Download release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+          path: .
+        continue-on-error: true
+
+      - name: Generate release notes if not available
+        run: |
+          if [ ! -f RELEASE_NOTES.md ]; then
+            echo "Generating release notes from git log..."
+            TAG="${{ needs.prepare.outputs.tag }}"
+            PREV_TAG=$(git describe --tags --abbrev=0 ${TAG}^ 2>/dev/null || echo "")
+
+            if [ -z "$PREV_TAG" ]; then
+              COMMITS=$(git log --pretty=format:"- %s (%h)" --no-merges ${TAG})
+            else
+              COMMITS=$(git log ${PREV_TAG}..${TAG} --pretty=format:"- %s (%h)" --no-merges)
+            fi
+
+            cat > RELEASE_NOTES.md << EOF
+          ## What's Changed
+
+          ${COMMITS:-No changes recorded}
+
+          **Full Changelog**: ${PREV_TAG:+https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}}${PREV_TAG:-First release}
+          EOF
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          name: gpuikit ${{ needs.prepare.outputs.version }}
+          body_path: RELEASE_NOTES.md
+          draft: false
+          prerelease: ${{ contains(needs.prepare.outputs.version, '-') }}
+          generate_release_notes: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## Deployment Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ needs.prepare.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: ${{ needs.prepare.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **crates.io**: [gpuikit](https://crates.io/crates/gpuikit)" >> $GITHUB_STEP_SUMMARY
+          echo "- **GitHub Release**: [${{ needs.prepare.outputs.tag }}](https://github.com/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.tag }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,174 @@
+# Release Workflow
+# Triggered manually via workflow_dispatch to create a new release
+# Bumps versions, creates tags, and triggers the deploy workflow
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      custom_version:
+        description: 'Custom version (overrides version_type if set, e.g., 1.2.3)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run (skip actual release)'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      tag: ${{ steps.bump.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-edit
+        run: cargo install cargo-edit --features vendored-openssl
+
+      - name: Get current version
+        id: current
+        run: |
+          CURRENT_VERSION=$(cargo pkgid | sed 's/.*@//')
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $CURRENT_VERSION"
+
+      - name: Calculate new version
+        id: bump
+        run: |
+          CURRENT="${{ steps.current.outputs.version }}"
+
+          if [ -n "${{ inputs.custom_version }}" ]; then
+            # Use custom version if provided
+            NEW_VERSION="${{ inputs.custom_version }}"
+            # Validate semver format
+            if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+              echo "Error: Invalid version format. Expected semver (e.g., 1.2.3 or 1.2.3-beta.1)"
+              exit 1
+            fi
+          else
+            # Calculate version based on bump type
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            # Strip any pre-release suffix from PATCH
+            PATCH=$(echo "$PATCH" | sed 's/-.*//')
+
+            case "${{ inputs.version_type }}" in
+              major)
+                NEW_VERSION="$((MAJOR + 1)).0.0"
+                ;;
+              minor)
+                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+                ;;
+              patch)
+                NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+                ;;
+            esac
+          fi
+
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      - name: Update Cargo.toml version
+        if: ${{ !inputs.dry_run }}
+        run: |
+          cargo set-version ${{ steps.bump.outputs.version }}
+          echo "Updated Cargo.toml to version ${{ steps.bump.outputs.version }}"
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          TAG="${{ steps.bump.outputs.tag }}"
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          echo "Generating release notes..."
+
+          if [ -z "$PREV_TAG" ]; then
+            # First release - get all commits
+            COMMITS=$(git log --pretty=format:"- %s (%h)" --no-merges)
+          else
+            # Get commits since last tag
+            COMMITS=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
+          fi
+
+          # Create release notes file
+          cat > RELEASE_NOTES.md << EOF
+          ## What's Changed
+
+          ${COMMITS:-No changes recorded}
+
+          **Full Changelog**: ${PREV_TAG:+https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}}${PREV_TAG:-First release}
+          EOF
+
+          echo "Release notes generated"
+          cat RELEASE_NOTES.md
+
+      - name: Commit version bump
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git add Cargo.toml
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+
+      - name: Create and push tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git tag -a "${{ steps.bump.outputs.tag }}" -m "Release ${{ steps.bump.outputs.version }}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: RELEASE_NOTES.md
+          retention-days: 1
+
+      - name: Summary
+        run: |
+          echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous Version**: ${{ steps.current.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **New Version**: ${{ steps.bump.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: ${{ steps.bump.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dry Run**: ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+
+  deploy:
+    name: Deploy Release
+    needs: release
+    if: ${{ !inputs.dry_run }}
+    uses: ./.github/workflows/release-deploy.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+      tag: ${{ needs.release.outputs.tag }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add `release.yml` workflow with `workflow_dispatch` trigger for manual releases
- Add `release-deploy.yml` workflow (triggered workflow) for deployment
- Support version bumping (patch/minor/major) with optional custom version
- Auto-generate release notes from commit history
- Publish to crates.io and create GitHub releases

## Workflows

### Release (`release.yml`)
Triggered manually via **Actions > Release > Run workflow**

**Inputs:**
- `version_type`: patch, minor, or major (default: patch)
- `custom_version`: Optional explicit version (e.g., `1.2.3`)
- `dry_run`: Skip actual release for testing

**Actions:**
1. Calculates new version based on input
2. Updates `Cargo.toml` using `cargo-edit`
3. Generates release notes from commits since last tag
4. Creates version bump commit
5. Creates and pushes git tag
6. Triggers the deploy workflow

### Deploy Release (`release-deploy.yml`)
Can be triggered by:
- The release workflow (via `workflow_call`)
- Manual `workflow_dispatch` for recovery
- Tag push (v*.*.*)

**Actions:**
1. Verifies package version matches tag
2. Runs `cargo publish --dry-run` first
3. Publishes to crates.io
4. Creates GitHub Release with release notes

## Prerequisites
Add `CARGO_REGISTRY_TOKEN` secret with your crates.io API token.

## Test plan
- [ ] Verify workflows appear in Actions tab
- [ ] Test dry run release (no actual changes)
- [ ] Test actual release with patch bump

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)