### PR TITLE
Add Kbd component for displaying keyboard shortcuts

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -17,6 +17,7 @@ use gpuikit::{
         checkbox::{checkbox, Checkbox},
         dropdown::{dropdown, DropdownState},
         icon_button::icon_button,
+        kbd::{kbd, kbd_combo, KbdSize},
         loading_indicator::loading_indicator,
         progress::{progress, ProgressVariant},
         radio_group::{radio_group, radio_option, RadioGroup},
@@ -444,6 +445,42 @@ impl Render for Showcase {
                                     .child(badge("Secondary").secondary())
                                     .child(badge("Outline").outline())
                                     .child(badge("Destructive").destructive()),
+                            ),
+                    )
+                    .child(separator())
+                    .child(
+                        v_stack()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.fg_muted())
+                                    .child("Kbd"),
+                            )
+                            .child(
+                                h_stack()
+                                    .gap_2()
+                                    .items_center()
+                                    .child(kbd("Esc"))
+                                    .child(kbd("Enter"))
+                                    .child(kbd("Tab"))
+                                    .child(kbd_combo(&["Ctrl", "C"]))
+                                    .child(kbd_combo(&["Cmd", "Shift", "P"])),
+                            )
+                            .child(
+                                h_stack()
+                                    .gap_2()
+                                    .items_center()
+                                    .mt_2()
+                                    .child(kbd("S").size(KbdSize::Small))
+                                    .child(kbd("M"))
+                                    .child(kbd("L").size(KbdSize::Large))
+                                    .child(
+                                        div()
+                                            .text_color(theme.fg_muted())
+                                            .child("(small / default / large)"),
+                                    ),
                             ),
                     )
                     .child(separator())

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -7,6 +7,7 @@ pub mod checkbox;
 pub mod dropdown;
 pub mod icon_button;
 pub mod input;
+pub mod kbd;
 pub mod loading_indicator;
 pub mod progress;
 pub mod radio_group;

--- a/src/elements/kbd.rs
+++ b/src/elements/kbd.rs
@@ -1,0 +1,91 @@
+use crate::theme::{ActiveTheme, Themeable};
+use gpui::{
+    div, px, rems, App, FontWeight, IntoElement, ParentElement, RenderOnce, SharedString, Styled,
+    Window,
+};
+
+/// Creates a keyboard key display element.
+pub fn kbd(key: impl Into<SharedString>) -> Kbd {
+    Kbd::new(key)
+}
+
+/// Creates a keyboard key combination display (e.g., "Ctrl+C").
+pub fn kbd_combo(keys: &[impl AsRef<str>]) -> Kbd {
+    let combined = keys
+        .iter()
+        .map(|k| k.as_ref())
+        .collect::<Vec<_>>()
+        .join("+");
+    Kbd::new(combined)
+}
+
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub enum KbdSize {
+    Small,
+    #[default]
+    Default,
+    Large,
+}
+
+#[derive(IntoElement)]
+pub struct Kbd {
+    key: SharedString,
+    size: KbdSize,
+}
+
+impl Kbd {
+    pub fn new(key: impl Into<SharedString>) -> Self {
+        Kbd {
+            key: key.into(),
+            size: KbdSize::Default,
+        }
+    }
+
+    pub fn size(mut self, size: KbdSize) -> Self {
+        self.size = size;
+        self
+    }
+
+    pub fn small(mut self) -> Self {
+        self.size = KbdSize::Small;
+        self
+    }
+
+    pub fn large(mut self) -> Self {
+        self.size = KbdSize::Large;
+        self
+    }
+}
+
+impl RenderOnce for Kbd {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let theme = cx.theme();
+
+        let (text_size, px_val, py_val, min_width) = match self.size {
+            KbdSize::Small => (rems(0.625), rems(0.25), px(1.0), rems(1.0)),
+            KbdSize::Default => (rems(0.75), rems(0.375), px(2.0), rems(1.25)),
+            KbdSize::Large => (rems(0.875), rems(0.5), px(3.0), rems(1.5)),
+        };
+
+        div()
+            .px(px_val)
+            .py(py_val)
+            .min_w(min_width)
+            .rounded(rems(0.25))
+            .text_size(text_size)
+            .font_weight(FontWeight::MEDIUM)
+            .font_family("Monaco, Consolas, monospace")
+            .line_height(rems(1.0))
+            .bg(theme.surface())
+            .text_color(theme.fg_muted())
+            .border_1()
+            .border_color(theme.border())
+            .border_b_2()
+            .shadow_sm()
+            .whitespace_nowrap()
+            .flex()
+            .items_center()
+            .justify_center()
+            .child(self.key)
+    }
+}


### PR DESCRIPTION
## Summary

- Implements a new `Kbd` component for displaying keyboard keys and shortcuts
- Adds `kbd()` function for single key display
- Adds `kbd_combo()` function for key combinations with `+` separator
- Supports three size variants: `Small`, `Default`, and `Large`
- Uses theme-aware styling with monospace font, rounded corners, border, and subtle shadow

## Usage

```rust
// Single key
kbd("Ctrl")

// Key combination  
kbd_combo(&["Ctrl", "C"])

// With size
kbd("Enter").size(KbdSize::Small)
kbd("Tab").large()
```

## Test plan

- [x] Cargo check passes
- [x] All existing tests pass
- [x] Component added to showcase example for visual verification

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)