### PR TITLE
Add ButtonGroup component for grouping related buttons

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -14,6 +14,7 @@ use gpuikit::{
         badge::badge,
         breadcrumb::{breadcrumb, breadcrumb_item, BreadcrumbSeparator},
         button::button,
+        button_group::button_group,
         card::card,
         checkbox::{checkbox, Checkbox},
         dropdown::{dropdown, DropdownState},
@@ -26,6 +27,7 @@ use gpuikit::{
         tooltip::tooltip,
     },
     layout::{h_stack, v_stack},
+    traits::orientable::Orientable,
     DefaultIcons,
 };
 
@@ -217,6 +219,47 @@ impl Render for Showcase {
                                             .text_color(theme.accent())
                                             .font_weight(FontWeight::BOLD)
                                             .child(format!("{}", self.click_count)),
+                                    ),
+                            ),
+                    )
+                    .child(separator())
+                    .child(
+                        v_stack()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.fg_muted())
+                                    .child("ButtonGroup"),
+                            )
+                            .child(
+                                h_stack()
+                                    .gap_4()
+                                    .items_center()
+                                    .child(
+                                        button_group("btn-group-1")
+                                            .child(button("group-1-a", "Left"))
+                                            .child(button("group-1-b", "Center"))
+                                            .child(button("group-1-c", "Right")),
+                                    )
+                                    .child(
+                                        button_group("btn-group-2")
+                                            .vertical()
+                                            .child(button("group-2-a", "Top"))
+                                            .child(button("group-2-b", "Middle"))
+                                            .child(button("group-2-c", "Bottom")),
+                                    ),
+                            )
+                            .child(
+                                h_stack()
+                                    .gap_2()
+                                    .items_center()
+                                    .mt_2()
+                                    .child(
+                                        div()
+                                            .text_color(theme.fg_muted())
+                                            .child("(horizontal / vertical)"),
                                     ),
                             ),
                     )

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -4,6 +4,7 @@ pub mod avatar;
 pub mod badge;
 pub mod breadcrumb;
 pub mod button;
+pub mod button_group;
 pub mod card;
 pub mod checkbox;
 pub mod dropdown;

--- a/src/elements/button_group.rs
+++ b/src/elements/button_group.rs
@@ -1,0 +1,138 @@
+//! ButtonGroup component for gpuikit
+//!
+//! A component for grouping related buttons together with connected borders.
+
+use crate::theme::{ActiveTheme, Themeable};
+use crate::traits::disableable::Disableable;
+use crate::traits::orientable::{Orientable, Orientation};
+use gpui::{
+    div, rems, AnyElement, App, ElementId, InteractiveElement, IntoElement, ParentElement,
+    RenderOnce, Styled, Window,
+};
+
+/// Create a new button group with the given ID.
+pub fn button_group(id: impl Into<ElementId>) -> ButtonGroup {
+    ButtonGroup::new(id)
+}
+
+/// A component for grouping related buttons together.
+///
+/// Buttons in a group are visually connected with shared borders.
+/// The first and last buttons have rounded corners on their outer edges.
+#[derive(IntoElement)]
+pub struct ButtonGroup {
+    id: ElementId,
+    children: Vec<AnyElement>,
+    orientation: Orientation,
+    disabled: bool,
+}
+
+impl ButtonGroup {
+    /// Create a new button group with the given ID.
+    pub fn new(id: impl Into<ElementId>) -> Self {
+        Self {
+            id: id.into(),
+            children: Vec::new(),
+            orientation: Orientation::Horizontal,
+            disabled: false,
+        }
+    }
+
+    /// Add a child element to the button group.
+    pub fn child(mut self, child: impl IntoElement) -> Self {
+        self.children.push(child.into_any_element());
+        self
+    }
+
+    /// Add multiple children to the button group.
+    pub fn children(mut self, children: impl IntoIterator<Item = impl IntoElement>) -> Self {
+        self.children
+            .extend(children.into_iter().map(|c| c.into_any_element()));
+        self
+    }
+}
+
+impl RenderOnce for ButtonGroup {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let theme = cx.theme();
+        let child_count = self.children.len();
+        let is_horizontal = self.orientation == Orientation::Horizontal;
+
+        let mut container = div()
+            .id(self.id)
+            .flex()
+            .flex_none()
+            .overflow_hidden()
+            .border_1()
+            .border_color(theme.button_border())
+            .rounded(rems(0.25));
+
+        container = if is_horizontal {
+            container.flex_row()
+        } else {
+            container.flex_col()
+        };
+
+        if self.disabled {
+            container = container.opacity(0.65).cursor_not_allowed();
+        }
+
+        container.children(self.children.into_iter().enumerate().map(|(index, child)| {
+            let is_first = index == 0;
+            let is_last = index == child_count - 1;
+
+            let mut wrapper = div()
+                .flex()
+                .items_center()
+                .justify_center()
+                .bg(theme.button_bg())
+                .text_color(theme.fg());
+
+            // Add internal borders between buttons
+            if !is_last {
+                wrapper = if is_horizontal {
+                    wrapper.border_r_1().border_color(theme.button_border())
+                } else {
+                    wrapper.border_b_1().border_color(theme.button_border())
+                };
+            }
+
+            // Rounded corners for first/last items
+            if is_horizontal {
+                if is_first {
+                    wrapper = wrapper.rounded_l(rems(0.2));
+                }
+                if is_last {
+                    wrapper = wrapper.rounded_r(rems(0.2));
+                }
+            } else {
+                if is_first {
+                    wrapper = wrapper.rounded_t(rems(0.2));
+                }
+                if is_last {
+                    wrapper = wrapper.rounded_b(rems(0.2));
+                }
+            }
+
+            wrapper.child(child)
+        }))
+    }
+}
+
+impl Orientable for ButtonGroup {
+    fn orientation(mut self, orientation: Orientation) -> Self {
+        self.orientation = orientation;
+        self
+    }
+}
+
+impl Disableable for ButtonGroup {
+    fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `ButtonGroup` component for grouping related buttons together with connected borders.

- Created `src/elements/button_group.rs` with factory function and builder API
- Implements `Orientable` trait for horizontal/vertical orientation
- Handles border radius for first/last items
- Uses theme colors for styling
- Supports disabled state via `Disableable` trait
- Added ButtonGroup showcase section in `examples/showcase.rs`

## Test plan

- [x] `cargo check` passes
- [x] All existing tests pass (`cargo test`)
- [x] Showcase example compiles (`cargo check --example showcase`)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)