### PR TITLE
Add AspectRatio component for maintaining consistent aspect ratios

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -9,6 +9,7 @@ use gpuikit::markdown::{Markdown, MarkdownElement};
 use gpuikit::theme::{ActiveTheme, Themeable};
 use gpuikit::{
     elements::{
+        aspect_ratio::{aspect_ratio, aspect_ratio_photo, aspect_ratio_square, aspect_ratio_video},
         avatar::avatar,
         badge::badge,
         breadcrumb::{breadcrumb, breadcrumb_item, BreadcrumbSeparator},
@@ -641,6 +642,131 @@ impl Render for Showcase {
                                             .item(breadcrumb_item("Level 1"))
                                             .item(breadcrumb_item("Level 2"))
                                             .item(breadcrumb_item("Current")),
+                                    ),
+                            ),
+                    )
+                    .child(separator())
+                    .child(
+                        v_stack()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.fg_muted())
+                                    .child("AspectRatio"),
+                            )
+                            .child(
+                                h_stack()
+                                    .gap_4()
+                                    .items_start()
+                                    .child(
+                                        v_stack()
+                                            .gap_1()
+                                            .w(px(100.0))
+                                            .child(
+                                                div()
+                                                    .text_xs()
+                                                    .text_color(theme.fg_muted())
+                                                    .child("Square (1:1)"),
+                                            )
+                                            .child(
+                                                aspect_ratio_square().child(
+                                                    div()
+                                                        .size_full()
+                                                        .bg(theme.accent().opacity(0.2))
+                                                        .border_1()
+                                                        .border_color(theme.accent())
+                                                        .rounded(px(4.0))
+                                                        .flex()
+                                                        .items_center()
+                                                        .justify_center()
+                                                        .text_xs()
+                                                        .text_color(theme.accent())
+                                                        .child("1:1"),
+                                                ),
+                                            ),
+                                    )
+                                    .child(
+                                        v_stack()
+                                            .gap_1()
+                                            .w(px(160.0))
+                                            .child(
+                                                div()
+                                                    .text_xs()
+                                                    .text_color(theme.fg_muted())
+                                                    .child("Video (16:9)"),
+                                            )
+                                            .child(
+                                                aspect_ratio_video().child(
+                                                    div()
+                                                        .size_full()
+                                                        .bg(theme.accent().opacity(0.2))
+                                                        .border_1()
+                                                        .border_color(theme.accent())
+                                                        .rounded(px(4.0))
+                                                        .flex()
+                                                        .items_center()
+                                                        .justify_center()
+                                                        .text_xs()
+                                                        .text_color(theme.accent())
+                                                        .child("16:9"),
+                                                ),
+                                            ),
+                                    )
+                                    .child(
+                                        v_stack()
+                                            .gap_1()
+                                            .w(px(120.0))
+                                            .child(
+                                                div()
+                                                    .text_xs()
+                                                    .text_color(theme.fg_muted())
+                                                    .child("Photo (4:3)"),
+                                            )
+                                            .child(
+                                                aspect_ratio_photo().child(
+                                                    div()
+                                                        .size_full()
+                                                        .bg(theme.accent().opacity(0.2))
+                                                        .border_1()
+                                                        .border_color(theme.accent())
+                                                        .rounded(px(4.0))
+                                                        .flex()
+                                                        .items_center()
+                                                        .justify_center()
+                                                        .text_xs()
+                                                        .text_color(theme.accent())
+                                                        .child("4:3"),
+                                                ),
+                                            ),
+                                    )
+                                    .child(
+                                        v_stack()
+                                            .gap_1()
+                                            .w(px(100.0))
+                                            .child(
+                                                div()
+                                                    .text_xs()
+                                                    .text_color(theme.fg_muted())
+                                                    .child("Custom (2:1)"),
+                                            )
+                                            .child(
+                                                aspect_ratio(2.0).child(
+                                                    div()
+                                                        .size_full()
+                                                        .bg(theme.accent().opacity(0.2))
+                                                        .border_1()
+                                                        .border_color(theme.accent())
+                                                        .rounded(px(4.0))
+                                                        .flex()
+                                                        .items_center()
+                                                        .justify_center()
+                                                        .text_xs()
+                                                        .text_color(theme.accent())
+                                                        .child("2:1"),
+                                                ),
+                                            ),
                                     ),
                             ),
                     ),

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,3 +1,4 @@
+pub mod aspect_ratio;
 pub mod avatar;
 pub mod badge;
 pub mod breadcrumb;

--- a/src/elements/aspect_ratio.rs
+++ b/src/elements/aspect_ratio.rs
@@ -1,0 +1,157 @@
+use gpui::{
+    div, AnyElement, App, IntoElement, ParentElement, RenderOnce, Styled, Window,
+};
+
+/// Creates a new AspectRatio container with the given ratio (width / height).
+///
+/// # Example
+/// ```
+/// use gpuikit::elements::aspect_ratio::aspect_ratio;
+///
+/// // 16:9 video aspect ratio
+/// let video = aspect_ratio(16.0 / 9.0).child(my_content);
+///
+/// // Using a preset
+/// let square = aspect_ratio_square().child(my_content);
+/// ```
+pub fn aspect_ratio(ratio: f32) -> AspectRatio {
+    AspectRatio::new(ratio)
+}
+
+/// Creates a square aspect ratio container (1:1).
+pub fn aspect_ratio_square() -> AspectRatio {
+    AspectRatio::square()
+}
+
+/// Creates a video aspect ratio container (16:9).
+pub fn aspect_ratio_video() -> AspectRatio {
+    AspectRatio::video()
+}
+
+/// Creates a photo aspect ratio container (4:3).
+pub fn aspect_ratio_photo() -> AspectRatio {
+    AspectRatio::photo()
+}
+
+/// Common aspect ratio presets.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AspectRatioPreset {
+    /// 1:1 square ratio
+    Square,
+    /// 16:9 widescreen video ratio
+    Video,
+    /// 4:3 traditional photo ratio
+    Photo,
+    /// 3:2 classic photo/35mm film ratio
+    Classic,
+    /// 21:9 ultrawide cinema ratio
+    Ultrawide,
+    /// 9:16 portrait/vertical video ratio
+    Portrait,
+}
+
+impl AspectRatioPreset {
+    /// Returns the ratio value (width / height) for this preset.
+    pub fn ratio(self) -> f32 {
+        match self {
+            AspectRatioPreset::Square => 1.0,
+            AspectRatioPreset::Video => 16.0 / 9.0,
+            AspectRatioPreset::Photo => 4.0 / 3.0,
+            AspectRatioPreset::Classic => 3.0 / 2.0,
+            AspectRatioPreset::Ultrawide => 21.0 / 9.0,
+            AspectRatioPreset::Portrait => 9.0 / 16.0,
+        }
+    }
+}
+
+/// A container element that maintains a specific aspect ratio.
+///
+/// The AspectRatio component wraps child content and ensures the container
+/// maintains the specified width-to-height ratio regardless of the content.
+#[derive(IntoElement)]
+pub struct AspectRatio {
+    ratio: f32,
+    child: Option<AnyElement>,
+}
+
+impl AspectRatio {
+    /// Creates a new AspectRatio container with the given ratio.
+    ///
+    /// The ratio is calculated as width divided by height.
+    /// For example, 16:9 would be `16.0 / 9.0 = 1.778`.
+    pub fn new(ratio: f32) -> Self {
+        AspectRatio { ratio, child: None }
+    }
+
+    /// Creates a square aspect ratio container (1:1).
+    pub fn square() -> Self {
+        Self::new(AspectRatioPreset::Square.ratio())
+    }
+
+    /// Creates a video aspect ratio container (16:9).
+    pub fn video() -> Self {
+        Self::new(AspectRatioPreset::Video.ratio())
+    }
+
+    /// Creates a photo aspect ratio container (4:3).
+    pub fn photo() -> Self {
+        Self::new(AspectRatioPreset::Photo.ratio())
+    }
+
+    /// Creates a classic photo aspect ratio container (3:2).
+    pub fn classic() -> Self {
+        Self::new(AspectRatioPreset::Classic.ratio())
+    }
+
+    /// Creates an ultrawide aspect ratio container (21:9).
+    pub fn ultrawide() -> Self {
+        Self::new(AspectRatioPreset::Ultrawide.ratio())
+    }
+
+    /// Creates a portrait aspect ratio container (9:16).
+    pub fn portrait() -> Self {
+        Self::new(AspectRatioPreset::Portrait.ratio())
+    }
+
+    /// Sets the ratio using a preset.
+    pub fn preset(mut self, preset: AspectRatioPreset) -> Self {
+        self.ratio = preset.ratio();
+        self
+    }
+
+    /// Sets the aspect ratio (width / height).
+    pub fn ratio(mut self, ratio: f32) -> Self {
+        self.ratio = ratio;
+        self
+    }
+
+    /// Sets the child element to display within the aspect ratio container.
+    pub fn child(mut self, child: impl IntoElement) -> Self {
+        self.child = Some(child.into_any_element());
+        self
+    }
+}
+
+impl Default for AspectRatio {
+    fn default() -> Self {
+        Self::square()
+    }
+}
+
+impl RenderOnce for AspectRatio {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let container = div()
+            .w_full()
+            .aspect_ratio(self.ratio)
+            .overflow_hidden();
+
+        match self.child {
+            Some(child) => container.child(
+                div()
+                    .size_full()
+                    .child(child),
+            ),
+            None => container,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds new `AspectRatio` component that wraps child content and maintains a specified width-to-height ratio
- Includes common presets: Square (1:1), Video (16:9), Photo (4:3), Classic (3:2), Ultrawide (21:9), Portrait (9:16)
- Provides factory functions: `aspect_ratio()`, `aspect_ratio_square()`, `aspect_ratio_video()`, `aspect_ratio_photo()`
- Adds showcase section demonstrating various aspect ratios

## Test plan

- [x] `cargo check` passes
- [x] `cargo check --example showcase` passes
- [ ] Run `cargo run --example showcase` to visually verify aspect ratio boxes

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)