### PR TITLE
Add Switch component for boolean toggle control

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -24,6 +24,7 @@ use gpuikit::{
         progress::{progress, ProgressVariant},
         radio_group::{radio_group, radio_option, RadioGroup},
         separator::{separator, vertical_separator},
+        switch::{switch, Switch},
         tooltip::tooltip,
     },
     layout::{h_stack, v_stack},
@@ -102,6 +103,9 @@ struct Showcase {
     checkbox_agree: Entity<Checkbox>,
     checkbox_newsletter: Entity<Checkbox>,
     radio_notifications: Entity<RadioGroup<NotificationPreference>>,
+    switch_wifi: Entity<Switch>,
+    switch_bluetooth: Entity<Switch>,
+    switch_airplane: Entity<Switch>,
 }
 
 impl Showcase {
@@ -150,6 +154,10 @@ impl Showcase {
             .selected(NotificationPreference::Important)
         });
 
+        let switch_wifi = cx.new(|_cx| switch("wifi-switch", true).label("Wi-Fi"));
+        let switch_bluetooth = cx.new(|_cx| switch("bluetooth-switch", false).label("Bluetooth"));
+        let switch_airplane = cx.new(|_cx| switch("airplane-switch", false).label("Airplane Mode").disabled(true));
+
         Self {
             focus_handle: cx.focus_handle(),
             click_count: 0,
@@ -160,6 +168,9 @@ impl Showcase {
             checkbox_agree,
             checkbox_newsletter,
             radio_notifications,
+            switch_wifi,
+            switch_bluetooth,
+            switch_airplane,
         }
     }
 }
@@ -665,6 +676,25 @@ impl Render for Showcase {
                                     .gap_2()
                                     .child(self.checkbox_agree.clone())
                                     .child(self.checkbox_newsletter.clone()),
+                            ),
+                    )
+                    .child(separator())
+                    .child(
+                        v_stack()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.fg_muted())
+                                    .child("Switch"),
+                            )
+                            .child(
+                                v_stack()
+                                    .gap_2()
+                                    .child(self.switch_wifi.clone())
+                                    .child(self.switch_bluetooth.clone())
+                                    .child(self.switch_airplane.clone()),
                             ),
                     )
                     .child(separator())

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -19,6 +19,7 @@ pub mod radio_group;
 pub mod separator;
 pub mod skeleton;
 pub mod slider;
+pub mod switch;
 pub mod toggle;
 pub mod tooltip;
 pub mod typography;

--- a/src/elements/switch.rs
+++ b/src/elements/switch.rs
@@ -1,0 +1,213 @@
+//! Switch component for gpuikit
+//!
+//! A sliding switch control for toggling boolean values, similar to iOS-style switches.
+
+use crate::layout::h_stack;
+use crate::theme::{ActiveTheme, Themeable};
+use crate::traits::disableable::Disableable;
+use crate::traits::labelable::Labelable;
+use crate::traits::selectable::Selectable;
+use crate::utils::element_manager::ElementManagerExt;
+use gpui::{
+    div, prelude::*, rems, App, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
+};
+
+/// Event emitted when the switch state changes
+pub struct SwitchChanged {
+    pub on: bool,
+}
+
+/// A sliding switch component for toggling between on/off states
+///
+/// Similar to a toggle, but with a more pronounced sliding switch appearance.
+///
+/// # Example
+///
+/// ```ignore
+/// use gpuikit::elements::switch::switch;
+///
+/// switch("dark-mode", true).label("Dark Mode")
+/// ```
+pub struct Switch {
+    id: ElementId,
+    label: Option<SharedString>,
+    on: bool,
+    disabled: bool,
+}
+
+impl EventEmitter<SwitchChanged> for Switch {}
+
+impl Switch {
+    pub fn new(id: impl Into<ElementId>, on: bool) -> Self {
+        Self {
+            id: id.into(),
+            label: None,
+            on,
+            disabled: false,
+        }
+    }
+
+    pub fn label(mut self, label: impl Into<SharedString>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn is_on(&self) -> bool {
+        self.on
+    }
+
+    pub fn set_on(&mut self, on: bool, cx: &mut Context<Self>) {
+        if self.on != on {
+            self.on = on;
+            cx.emit(SwitchChanged { on: self.on });
+            cx.notify();
+        }
+    }
+
+    pub fn toggle(&mut self, cx: &mut Context<Self>) {
+        self.set_on(!self.on, cx);
+    }
+
+    fn on_click(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        if !self.disabled {
+            self.toggle(cx);
+        }
+    }
+}
+
+impl Render for Switch {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let on = self.on;
+        let disabled = self.disabled;
+        let label = self.label.clone();
+
+        // Switch dimensions - wider and shorter than toggle for a more pronounced switch look
+        let track_width = rems(2.75);
+        let track_height = rems(1.5);
+        let thumb_size = rems(1.25);
+        let thumb_margin = rems(0.125);
+
+        let track_bg = if disabled {
+            theme.surface_tertiary()
+        } else if on {
+            theme.accent()
+        } else {
+            theme.surface_secondary()
+        };
+
+        let thumb_bg = if disabled {
+            theme.fg_disabled()
+        } else {
+            theme.surface()
+        };
+
+        let track_border = if disabled {
+            theme.border_subtle()
+        } else if on {
+            theme.accent()
+        } else {
+            theme.border()
+        };
+
+        h_stack()
+            .id(self.id.clone())
+            .gap(rems(0.5))
+            .items_center()
+            .when(!disabled, |this| {
+                this.cursor_pointer()
+                    .on_mouse_down(MouseButton::Left, |_, window, _| window.prevent_default())
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.on_click(window, cx);
+                    }))
+            })
+            .when(disabled, |this| this.cursor_not_allowed().opacity(0.65))
+            .child(
+                div()
+                    .relative()
+                    .w(track_width)
+                    .h(track_height)
+                    .bg(track_bg)
+                    .border_1()
+                    .border_color(track_border)
+                    .rounded(track_height / 2.)
+                    .when(!disabled, |this| {
+                        this.hover(|style| {
+                            style.border_color(if on {
+                                theme.accent()
+                            } else {
+                                theme.border_secondary()
+                            })
+                        })
+                    })
+                    .child(
+                        div()
+                            .absolute()
+                            .top(thumb_margin)
+                            .when(on, |this| this.right(thumb_margin))
+                            .when(!on, |this| this.left(thumb_margin))
+                            .size(thumb_size)
+                            .bg(thumb_bg)
+                            .rounded_full()
+                            .shadow_md(),
+                    ),
+            )
+            .when_some(label, |this, label| {
+                this.child(
+                    div()
+                        .text_sm()
+                        .text_color(if disabled {
+                            theme.fg_disabled()
+                        } else {
+                            theme.fg()
+                        })
+                        .child(label),
+                )
+            })
+    }
+}
+
+/// Convenience function to create a switch
+pub fn switch(id: impl Into<ElementId>, on: bool) -> Switch {
+    Switch::new(id, on)
+}
+
+/// Convenience function to create a switch with auto-generated ID
+pub fn switch_auto(cx: &App, on: bool) -> Switch {
+    Switch::new(cx.next_id_named("switch"), on)
+}
+
+impl Disableable for Switch {
+    fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+impl Selectable for Switch {
+    fn is_selected(&self) -> bool {
+        self.on
+    }
+
+    fn selected(mut self, selected: bool) -> Self {
+        self.on = selected;
+        self
+    }
+}
+
+impl Labelable for Switch {
+    fn label(mut self, label: impl Into<SharedString>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+}


### PR DESCRIPTION
## Summary

- Add new Switch component as an alternative boolean toggle control
- Implement `Disableable`, `Labelable`, and `Selectable` traits
- Add Switch showcase section with example controls

## Details

The Switch component provides an iOS-style sliding switch with:
- Wider track and larger thumb than Toggle for a more pronounced visual
- Factory function (`switch`) and builder API pattern
- Auto-ID generation via `switch_auto`
- `SwitchChanged` event emission on state changes
- Theme-based styling for consistent appearance
- Disabled state support with visual feedback

## Test plan

- [x] Code compiles with `cargo check`
- [x] Showcase example compiles with `cargo check --example showcase`
- [ ] Run showcase example to visually verify Switch component appearance
- [ ] Test on/off toggling behavior
- [ ] Test disabled state rendering

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)