### PR TITLE
Add Collapsible component for expandable/collapsible content sections

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -17,6 +17,7 @@ use gpuikit::{
         button_group::button_group,
         card::card,
         checkbox::{checkbox, Checkbox},
+        collapsible::{collapsible, Collapsible},
         dropdown::{dropdown, DropdownState},
         icon_button::icon_button,
         kbd::{kbd, kbd_combo, KbdSize},
@@ -106,6 +107,8 @@ struct Showcase {
     switch_wifi: Entity<Switch>,
     switch_bluetooth: Entity<Switch>,
     switch_airplane: Entity<Switch>,
+    collapsible_basic: Entity<Collapsible>,
+    collapsible_nested: Entity<Collapsible>,
 }
 
 impl Showcase {
@@ -158,6 +161,41 @@ impl Showcase {
         let switch_bluetooth = cx.new(|_cx| switch("bluetooth-switch", false).label("Bluetooth"));
         let switch_airplane = cx.new(|_cx| switch("airplane-switch", false).label("Airplane Mode").disabled(true));
 
+        let collapsible_basic = cx.new(|_cx| {
+            collapsible("collapsible-basic")
+                .trigger_label("Click to expand")
+                .content(|_window, _cx| {
+                    div()
+                        .text_sm()
+                        .child("This is the collapsible content. It can contain any elements you want.")
+                        .into_any_element()
+                })
+                .default_open(false)
+        });
+
+        let collapsible_nested = cx.new(|_cx| {
+            collapsible("collapsible-nested")
+                .trigger_label("Settings")
+                .content(|_window, _cx| {
+                    v_stack()
+                        .gap_2()
+                        .child(
+                            div()
+                                .text_sm()
+                                .child("Configure your preferences below:"),
+                        )
+                        .child(
+                            h_stack()
+                                .gap_2()
+                                .child(badge("Option 1"))
+                                .child(badge("Option 2"))
+                                .child(badge("Option 3")),
+                        )
+                        .into_any_element()
+                })
+                .default_open(true)
+        });
+
         Self {
             focus_handle: cx.focus_handle(),
             click_count: 0,
@@ -171,6 +209,8 @@ impl Showcase {
             switch_wifi,
             switch_bluetooth,
             switch_airplane,
+            collapsible_basic,
+            collapsible_nested,
         }
     }
 }
@@ -744,6 +784,24 @@ impl Render for Showcase {
                                             .item(breadcrumb_item("Level 2"))
                                             .item(breadcrumb_item("Current")),
                                     ),
+                            ),
+                    )
+                    .child(separator())
+                    .child(
+                        v_stack()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.fg_muted())
+                                    .child("Collapsible"),
+                            )
+                            .child(
+                                v_stack()
+                                    .gap_2()
+                                    .child(self.collapsible_basic.clone())
+                                    .child(self.collapsible_nested.clone()),
                             ),
                     ),
             )

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -7,6 +7,7 @@ pub mod button;
 pub mod button_group;
 pub mod card;
 pub mod checkbox;
+pub mod collapsible;
 pub mod dropdown;
 pub mod empty;
 pub mod icon_button;

--- a/src/elements/collapsible.rs
+++ b/src/elements/collapsible.rs
@@ -1,0 +1,220 @@
+//! Collapsible component for expandable/collapsible content sections
+
+use crate::icons::Icons;
+use crate::layout::h_stack;
+use crate::theme::{ActiveTheme, Themeable};
+use crate::traits::disableable::Disableable;
+use gpui::{
+    div, prelude::*, px, rems, AnyElement, App, Context, ElementId, EventEmitter, InteractiveElement,
+    IntoElement, MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement,
+    Styled, Window,
+};
+use std::rc::Rc;
+
+/// Event emitted when the collapsible open state changes
+pub struct CollapsibleChanged {
+    pub open: bool,
+}
+
+/// A render callback that produces an element
+pub type RenderCallback = Rc<dyn Fn(&mut Window, &mut App) -> AnyElement>;
+
+/// A collapsible component for expandable/collapsible content sections
+pub struct Collapsible {
+    id: ElementId,
+    trigger_label: Option<SharedString>,
+    trigger_render: Option<RenderCallback>,
+    content_render: Option<RenderCallback>,
+    open: bool,
+    disabled: bool,
+    show_indicator: bool,
+    on_toggle: Option<Rc<dyn Fn(bool, &mut Window, &mut App)>>,
+}
+
+impl EventEmitter<CollapsibleChanged> for Collapsible {}
+
+impl Collapsible {
+    pub fn new(id: impl Into<ElementId>) -> Self {
+        Self {
+            id: id.into(),
+            trigger_label: None,
+            trigger_render: None,
+            content_render: None,
+            open: false,
+            disabled: false,
+            show_indicator: true,
+            on_toggle: None,
+        }
+    }
+
+    /// Set a custom trigger element via a render callback
+    pub fn trigger(mut self, render: impl Fn(&mut Window, &mut App) -> AnyElement + 'static) -> Self {
+        self.trigger_render = Some(Rc::new(render));
+        self
+    }
+
+    /// Set a simple text label as the trigger
+    pub fn trigger_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.trigger_label = Some(label.into());
+        self
+    }
+
+    /// Set the collapsible content via a render callback
+    pub fn content(mut self, render: impl Fn(&mut Window, &mut App) -> AnyElement + 'static) -> Self {
+        self.content_render = Some(Rc::new(render));
+        self
+    }
+
+    /// Set the initial open state (for uncontrolled mode)
+    pub fn default_open(mut self, open: bool) -> Self {
+        self.open = open;
+        self
+    }
+
+    /// Set whether to show the chevron indicator
+    pub fn show_indicator(mut self, show: bool) -> Self {
+        self.show_indicator = show;
+        self
+    }
+
+    /// Register a callback for when the open state changes
+    pub fn on_toggle(mut self, handler: impl Fn(bool, &mut Window, &mut App) + 'static) -> Self {
+        self.on_toggle = Some(Rc::new(handler));
+        self
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub fn set_open(&mut self, open: bool, window: &mut Window, cx: &mut Context<Self>) {
+        if self.open != open {
+            self.open = open;
+            if let Some(on_toggle) = &self.on_toggle {
+                let on_toggle = on_toggle.clone();
+                on_toggle(self.open, window, cx);
+            }
+            cx.emit(CollapsibleChanged { open: self.open });
+            cx.notify();
+        }
+    }
+
+    pub fn toggle(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.set_open(!self.open, window, cx);
+    }
+
+    fn on_click(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.disabled {
+            self.toggle(window, cx);
+        }
+    }
+}
+
+impl Render for Collapsible {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let open = self.open;
+        let disabled = self.disabled;
+        let show_indicator = self.show_indicator;
+
+        // Extract theme colors before any callbacks to avoid borrow issues
+        let theme = cx.theme();
+        let fg_color = theme.fg();
+        let fg_muted = theme.fg_muted();
+        let surface_secondary = theme.surface_secondary();
+
+        // Build trigger element
+        let trigger_element = if let Some(ref render) = self.trigger_render {
+            render(window, cx)
+        } else if let Some(ref label) = self.trigger_label {
+            div()
+                .text_sm()
+                .font_weight(gpui::FontWeight::MEDIUM)
+                .text_color(fg_color)
+                .child(label.clone())
+                .into_any_element()
+        } else {
+            div()
+                .text_sm()
+                .text_color(fg_color)
+                .child("Toggle")
+                .into_any_element()
+        };
+
+        // Build content element if open
+        let content_element = if open {
+            self.content_render.as_ref().map(|render| render(window, cx))
+        } else {
+            None
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .w_full()
+            .child(
+                h_stack()
+                    .id(self.id.clone())
+                    .w_full()
+                    .gap(rems(0.5))
+                    .items_center()
+                    .py(rems(0.5))
+                    .when(!disabled, |this| {
+                        this.cursor_pointer()
+                            .on_mouse_down(MouseButton::Left, |_, window, _| {
+                                window.prevent_default()
+                            })
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.on_click(window, cx);
+                            }))
+                            .hover(move |style| style.bg(surface_secondary))
+                    })
+                    .when(disabled, |this| this.cursor_not_allowed().opacity(0.65))
+                    .rounded(rems(0.25))
+                    .px(rems(0.5))
+                    .when(show_indicator, |this| {
+                        this.child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .size(px(16.))
+                                .child(if open {
+                                    Icons::chevron_down()
+                                        .size(px(14.))
+                                        .text_color(fg_muted)
+                                } else {
+                                    Icons::chevron_right()
+                                        .size(px(14.))
+                                        .text_color(fg_muted)
+                                }),
+                        )
+                    })
+                    .child(div().flex_1().child(trigger_element)),
+            )
+            .when_some(content_element, |this, content| {
+                this.child(
+                    div()
+                        .pl(if show_indicator { rems(1.5) } else { rems(0.5) })
+                        .pr(rems(0.5))
+                        .pb(rems(0.5))
+                        .child(content),
+                )
+            })
+    }
+}
+
+/// Convenience function to create a collapsible
+pub fn collapsible(id: impl Into<ElementId>) -> Collapsible {
+    Collapsible::new(id)
+}
+
+impl Disableable for Collapsible {
+    fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}


### PR DESCRIPTION
## Summary

- Add new `Collapsible` component for expandable/collapsible content sections
- Export the collapsible module from `src/elements.rs`
- Add Collapsible showcase section in the showcase example

## Details

The Collapsible component provides:
- **Trigger element**: Simple text label via `.trigger_label()` or custom render callback via `.trigger()`
- **Content section**: Uses render callback pattern via `.content()` to support dynamic content
- **Visual indicator**: Chevron icon that changes direction based on open/closed state
- **State management**: Built-in open/closed state with `.default_open()` for initial state
- **Controlled mode**: `on_toggle` callback and `CollapsibleChanged` event emission
- **Disabled support**: Implements `Disableable` trait for consistent API

### Usage

```rust
// Basic usage with trigger label
let collapsible = cx.new(|_cx| {
    collapsible("my-collapsible")
        .trigger_label("Click to expand")
        .content(|_window, _cx| {
            div().child("Collapsible content here").into_any_element()
        })
        .default_open(false)
});

// With on_toggle callback
let collapsible = cx.new(|_cx| {
    collapsible("controlled-collapsible")
        .trigger_label("Settings")
        .content(|_window, _cx| { /* ... */ })
        .on_toggle(|open, _window, _cx| {
            println!("Collapsible is now: {}", if open { "open" } else { "closed" });
        })
});
```

## Test plan

- [x] Code compiles without errors
- [x] All existing tests pass
- [x] Showcase example builds successfully
- [ ] Manual testing: Run `cargo run --example showcase` to verify the Collapsible section works correctly

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)