### PR TITLE
Add ToggleGroup component

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -27,6 +27,7 @@ use gpuikit::{
         radio_group::{radio_group, radio_option, RadioGroup},
         separator::{separator, vertical_separator},
         switch::{switch, Switch},
+        toggle_group::{toggle_group, toggle_option, ToggleGroup, ToggleGroupMode},
         tooltip::tooltip,
     },
     layout::{h_stack, v_stack},
@@ -95,6 +96,20 @@ enum NotificationPreference {
     None,
 }
 
+#[derive(Clone, PartialEq, Debug)]
+enum Alignment {
+    Left,
+    Center,
+    Right,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+enum TextStyle {
+    Bold,
+    Italic,
+    Underline,
+}
+
 struct Showcase {
     focus_handle: FocusHandle,
     click_count: usize,
@@ -111,6 +126,8 @@ struct Showcase {
     collapsible_basic: Entity<Collapsible>,
     collapsible_nested: Entity<Collapsible>,
     accordion: Entity<AccordionState>,
+    toggle_group_alignment: Entity<ToggleGroup<Alignment>>,
+    toggle_group_text_style: Entity<ToggleGroup<TextStyle>>,
 }
 
 impl Showcase {
@@ -159,6 +176,7 @@ impl Showcase {
             .selected(NotificationPreference::Important)
         });
 
+<<<<<<< HEAD
         let switch_wifi = cx.new(|_cx| switch("wifi-switch", true).label("Wi-Fi"));
         let switch_bluetooth = cx.new(|_cx| switch("bluetooth-switch", false).label("Bluetooth"));
         let switch_airplane = cx.new(|_cx| switch("airplane-switch", false).label("Airplane Mode").disabled(true));
@@ -222,6 +240,31 @@ impl Showcase {
             )
         });
 
+        let toggle_group_alignment = cx.new(|_cx| {
+            toggle_group(
+                "alignment",
+                vec![
+                    toggle_option(Alignment::Left, "Left"),
+                    toggle_option(Alignment::Center, "Center"),
+                    toggle_option(Alignment::Right, "Right"),
+                ],
+            )
+            .selected_value(Alignment::Center)
+        });
+
+        let toggle_group_text_style = cx.new(|_cx| {
+            toggle_group(
+                "text-style",
+                vec![
+                    toggle_option(TextStyle::Bold, "B"),
+                    toggle_option(TextStyle::Italic, "I"),
+                    toggle_option(TextStyle::Underline, "U"),
+                ],
+            )
+            .mode(ToggleGroupMode::Multiple)
+            .selected(vec![TextStyle::Bold])
+        });
+
         Self {
             focus_handle: cx.focus_handle(),
             click_count: 0,
@@ -238,6 +281,8 @@ impl Showcase {
             collapsible_basic,
             collapsible_nested,
             accordion,
+            toggle_group_alignment,
+            toggle_group_text_style,
         }
     }
 }
@@ -776,6 +821,48 @@ impl Render for Showcase {
                                     .child("RadioGroup"),
                             )
                             .child(self.radio_notifications.clone()),
+                    )
+                    .child(separator())
+                    .child(
+                        v_stack()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.fg_muted())
+                                    .child("ToggleGroup"),
+                            )
+                            .child(
+                                v_stack()
+                                    .gap_3()
+                                    .child(
+                                        h_stack()
+                                            .gap_2()
+                                            .items_center()
+                                            .child(
+                                                div()
+                                                    .text_sm()
+                                                    .text_color(theme.fg_muted())
+                                                    .w_20()
+                                                    .child("Single:"),
+                                            )
+                                            .child(self.toggle_group_alignment.clone()),
+                                    )
+                                    .child(
+                                        h_stack()
+                                            .gap_2()
+                                            .items_center()
+                                            .child(
+                                                div()
+                                                    .text_sm()
+                                                    .text_color(theme.fg_muted())
+                                                    .w_20()
+                                                    .child("Multiple:"),
+                                            )
+                                            .child(self.toggle_group_text_style.clone()),
+                                    ),
+                            ),
                     )
                     .child(separator())
                     .child(

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -23,5 +23,6 @@ pub mod skeleton;
 pub mod slider;
 pub mod switch;
 pub mod toggle;
+pub mod toggle_group;
 pub mod tooltip;
 pub mod typography;

--- a/src/elements/toggle_group.rs
+++ b/src/elements/toggle_group.rs
@@ -1,0 +1,320 @@
+//! Toggle group component for gpuikit
+//!
+//! A toggle group allows selecting one or multiple options from a group of toggle buttons.
+
+use crate::theme::{ActiveTheme, Themeable};
+use crate::traits::disableable::Disableable;
+use crate::traits::orientable::{Orientable, Orientation};
+use gpui::{
+    div, prelude::*, rems, Context, Div, ElementId, EventEmitter, FontWeight, Hsla,
+    InteractiveElement, IntoElement, MouseButton, ParentElement, Render, SharedString, Stateful,
+    StatefulInteractiveElement, Styled, Window,
+};
+
+/// Selection mode for the toggle group
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ToggleGroupMode {
+    /// Only one item can be selected at a time (like radio buttons)
+    #[default]
+    Single,
+    /// Multiple items can be selected simultaneously
+    Multiple,
+}
+
+/// Event emitted when the toggle group selection changes
+pub struct ToggleGroupChanged<T: Clone> {
+    /// Currently selected values
+    pub selected: Vec<T>,
+}
+
+/// A single toggle option in the group
+#[derive(Clone)]
+pub struct ToggleOption<T: Clone> {
+    /// The value associated with this option
+    pub value: T,
+    /// Display label for the option
+    pub label: SharedString,
+    /// Whether this option is disabled
+    pub disabled: bool,
+}
+
+impl<T: Clone> ToggleOption<T> {
+    /// Create a new toggle option with a value and label
+    pub fn new(value: T, label: impl Into<SharedString>) -> Self {
+        Self {
+            value,
+            label: label.into(),
+            disabled: false,
+        }
+    }
+
+    /// Set whether this option is disabled
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+impl<T: Clone> Disableable for ToggleOption<T> {
+    fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+/// A toggle group component for selecting one or multiple options
+///
+/// # Example
+///
+/// ```ignore
+/// // Single-select mode (default)
+/// let single = toggle_group(
+///     "alignment",
+///     vec![
+///         toggle_option("left", "Left"),
+///         toggle_option("center", "Center"),
+///         toggle_option("right", "Right"),
+///     ],
+/// ).selected(vec!["center"]);
+///
+/// // Multi-select mode
+/// let multi = toggle_group(
+///     "features",
+///     vec![
+///         toggle_option("bold", "B"),
+///         toggle_option("italic", "I"),
+///         toggle_option("underline", "U"),
+///     ],
+/// ).mode(ToggleGroupMode::Multiple)
+///  .selected(vec!["bold", "italic"]);
+/// ```
+pub struct ToggleGroup<T: Clone + PartialEq + 'static> {
+    id: ElementId,
+    options: Vec<ToggleOption<T>>,
+    selected: Vec<T>,
+    mode: ToggleGroupMode,
+    disabled: bool,
+    orientation: Orientation,
+}
+
+impl<T: Clone + PartialEq + 'static> EventEmitter<ToggleGroupChanged<T>> for ToggleGroup<T> {}
+
+impl<T: Clone + PartialEq + 'static> ToggleGroup<T> {
+    /// Create a new toggle group with an ID and options
+    pub fn new(id: impl Into<ElementId>, options: Vec<ToggleOption<T>>) -> Self {
+        Self {
+            id: id.into(),
+            options,
+            selected: Vec::new(),
+            mode: ToggleGroupMode::default(),
+            disabled: false,
+            orientation: Orientation::Horizontal,
+        }
+    }
+
+    /// Set the selection mode (single or multiple)
+    pub fn mode(mut self, mode: ToggleGroupMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Set the selected values
+    pub fn selected(mut self, values: Vec<T>) -> Self {
+        self.selected = values;
+        self
+    }
+
+    /// Set a single selected value (convenience for single-select mode)
+    pub fn selected_value(mut self, value: T) -> Self {
+        self.selected = vec![value];
+        self
+    }
+
+    /// Get the currently selected values
+    pub fn get_selected(&self) -> &[T] {
+        &self.selected
+    }
+
+    /// Check if a value is selected
+    pub fn is_value_selected(&self, value: &T) -> bool {
+        self.selected.contains(value)
+    }
+
+    /// Set the selected values programmatically
+    pub fn set_selected(&mut self, values: Vec<T>, cx: &mut Context<Self>) {
+        if self.selected != values {
+            self.selected = values.clone();
+            cx.emit(ToggleGroupChanged { selected: values });
+            cx.notify();
+        }
+    }
+
+    fn toggle_option(&mut self, index: usize, cx: &mut Context<Self>) {
+        if let Some(option) = self.options.get(index) {
+            if option.disabled || self.disabled {
+                return;
+            }
+
+            let value = option.value.clone();
+            let is_selected = self.selected.contains(&value);
+
+            match self.mode {
+                ToggleGroupMode::Single => {
+                    // In single mode, always select the clicked option (unless it's already selected)
+                    if !is_selected {
+                        self.selected = vec![value.clone()];
+                        cx.emit(ToggleGroupChanged {
+                            selected: vec![value],
+                        });
+                        cx.notify();
+                    }
+                }
+                ToggleGroupMode::Multiple => {
+                    // In multiple mode, toggle the selection
+                    if is_selected {
+                        self.selected.retain(|v| v != &value);
+                    } else {
+                        self.selected.push(value);
+                    }
+                    cx.emit(ToggleGroupChanged {
+                        selected: self.selected.clone(),
+                    });
+                    cx.notify();
+                }
+            }
+        }
+    }
+}
+
+impl<T: Clone + PartialEq + 'static> Render for ToggleGroup<T> {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let group_disabled = self.disabled;
+        let selected = self.selected.clone();
+        let orientation = self.orientation;
+        let num_options = self.options.len();
+
+        let container = if orientation == Orientation::Vertical {
+            div().flex().flex_col()
+        } else {
+            div().flex().flex_row()
+        };
+
+        container
+            .id(self.id.clone())
+            .bg(theme.surface_secondary())
+            .border_1()
+            .border_color(theme.border())
+            .rounded_md()
+            .p(rems(0.125))
+            .gap(rems(0.125))
+            .children(
+                self.options
+                    .iter()
+                    .enumerate()
+                    .map(|(index, option)| {
+                        let is_selected = selected.contains(&option.value);
+                        let is_disabled = group_disabled || option.disabled;
+                        let label = option.label.clone();
+                        let is_first = index == 0;
+                        let is_last = index == num_options - 1;
+
+                        let bg: Option<Hsla> = if is_disabled {
+                            Some(theme.surface_tertiary())
+                        } else if is_selected {
+                            Some(theme.surface())
+                        } else {
+                            None
+                        };
+
+                        let text_color = if is_disabled {
+                            theme.fg_disabled()
+                        } else if is_selected {
+                            theme.fg()
+                        } else {
+                            theme.fg_muted()
+                        };
+
+                        div()
+                            .id(ElementId::NamedInteger("toggle-option".into(), index as u64))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .px(rems(0.75))
+                            .py(rems(0.375))
+                            .text_sm()
+                            .font_weight(FontWeight::MEDIUM)
+                            .when_some(bg, |this, bg| this.bg(bg))
+                            .text_color(text_color)
+                            .when(is_selected && !is_disabled, |this: Stateful<Div>| {
+                                this.shadow_sm()
+                            })
+                            // Apply rounded corners based on orientation and position
+                            .when(orientation == Orientation::Horizontal, |this| {
+                                this.when(is_first, |t| t.rounded_l_sm())
+                                    .when(is_last, |t| t.rounded_r_sm())
+                                    .when(!is_first && !is_last, |t| t.rounded_none())
+                            })
+                            .when(orientation == Orientation::Vertical, |this| {
+                                this.when(is_first, |t| t.rounded_t_sm())
+                                    .when(is_last, |t| t.rounded_b_sm())
+                                    .when(!is_first && !is_last, |t| t.rounded_none())
+                            })
+                            .when(!is_disabled, |this| {
+                                this.cursor_pointer()
+                                    .hover(|style| {
+                                        if is_selected {
+                                            style
+                                        } else {
+                                            style.bg(theme.surface_tertiary())
+                                        }
+                                    })
+                                    .on_mouse_down(MouseButton::Left, |_, window, _| {
+                                        window.prevent_default()
+                                    })
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        this.toggle_option(index, cx);
+                                    }))
+                            })
+                            .when(is_disabled, |this| this.cursor_not_allowed().opacity(0.65))
+                            .child(label)
+                    })
+                    .collect::<Vec<_>>(),
+            )
+    }
+}
+
+/// Convenience function to create a toggle group
+pub fn toggle_group<T: Clone + PartialEq + 'static>(
+    id: impl Into<ElementId>,
+    options: Vec<ToggleOption<T>>,
+) -> ToggleGroup<T> {
+    ToggleGroup::new(id, options)
+}
+
+/// Convenience function to create a toggle option
+pub fn toggle_option<T: Clone>(value: T, label: impl Into<SharedString>) -> ToggleOption<T> {
+    ToggleOption::new(value, label)
+}
+
+impl<T: Clone + PartialEq + 'static> Disableable for ToggleGroup<T> {
+    fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+impl<T: Clone + PartialEq + 'static> Orientable for ToggleGroup<T> {
+    fn orientation(mut self, orientation: Orientation) -> Self {
+        self.orientation = orientation;
+        self
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ToggleGroup` component for selecting one or multiple options from a group of toggle buttons
- Support single-select mode (like radio buttons) and multi-select mode
- Implement `Orientable` trait for horizontal/vertical layouts
- Implement `Disableable` trait for the group and individual options
- Visual indication of selected items using theme colors
- Add showcase section demonstrating both selection modes

## Test plan

- [ ] Run `cargo check` - passes
- [ ] Run `cargo test --lib` - passes
- [ ] Run `cargo run --example showcase` to see the ToggleGroup in action
- [ ] Verify single-select mode only allows one selection
- [ ] Verify multi-select mode allows multiple selections
- [ ] Verify disabled state prevents interaction

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)