### PR TITLE
Add Textarea component for styled multi-line text input

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -25,6 +25,7 @@ use gpuikit::{
         icon_button::icon_button,
         input_group::{input_group, InputAddon},
         kbd::{kbd, kbd_combo, KbdSize},
+        textarea::textarea,
         loading_indicator::loading_indicator,
         progress::{progress, ProgressVariant},
         radio_group::{radio_group, radio_option, RadioGroup},
@@ -35,6 +36,7 @@ use gpuikit::{
         tooltip::tooltip,
     },
     layout::{h_stack, v_stack},
+    traits::disableable::Disableable,
     traits::labelable::Labelable,
     traits::orientable::Orientable,
     DefaultIcons,
@@ -137,6 +139,7 @@ struct Showcase {
     input_with_icon: Entity<InputState>,
     input_with_text: Entity<InputState>,
     input_with_button: Entity<InputState>,
+    textarea_example: Entity<InputState>,
 }
 
 impl Showcase {
@@ -284,6 +287,7 @@ impl Showcase {
         let input_with_icon = cx.new(|cx| InputState::new_singleline(cx));
         let input_with_text = cx.new(|cx| InputState::new_singleline(cx));
         let input_with_button = cx.new(|cx| InputState::new_singleline(cx));
+        let textarea_example = cx.new(|cx| InputState::new_multiline(cx));
 
         Self {
             focus_handle: cx.focus_handle(),
@@ -307,6 +311,7 @@ impl Showcase {
             input_with_icon,
             input_with_text,
             input_with_button,
+            textarea_example,
         }
     }
 }
@@ -1091,6 +1096,36 @@ impl Render for Showcase {
                                                     .right_addon(InputAddon::button(
                                                         button("go-btn", "Go"),
                                                     )),
+                                            ),
+                                    ),
+                            ),
+                    )
+                    // Textarea
+                    .child(
+                        card()
+                            .title("Textarea")
+                            .description("Multi-line text input for longer content")
+                            .body(
+                                v_stack()
+                                    .gap_4()
+                                    .child(
+                                        field()
+                                            .label("Message")
+                                            .description("Tell us what's on your mind")
+                                            .child(
+                                                textarea(&self.textarea_example, cx)
+                                                    .placeholder("Type your message here...")
+                                                    .rows(4),
+                                            ),
+                                    )
+                                    .child(
+                                        field()
+                                            .label("Disabled")
+                                            .child(
+                                                textarea(&self.textarea_example, cx)
+                                                    .placeholder("This is disabled...")
+                                                    .rows(2)
+                                                    .disabled(true),
                                             ),
                                     ),
                             ),

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -25,6 +25,7 @@ pub mod skeleton;
 pub mod slider;
 pub mod switch;
 pub mod tabs;
+pub mod textarea;
 pub mod toggle;
 pub mod toggle_group;
 pub mod tooltip;

--- a/src/elements/textarea.rs
+++ b/src/elements/textarea.rs
@@ -1,0 +1,187 @@
+//! Textarea component for multi-line text input.
+//!
+//! A styled wrapper around the `text_area()` element that provides form-friendly
+//! styling with borders, padding, and theme colors.
+
+use gpui::{
+    div, prelude::*, px, rems, App, Entity, FocusHandle, Focusable, IntoElement, ParentElement,
+    Pixels, RenderOnce, SharedString, Styled, Window,
+};
+
+use crate::elements::input::text_area;
+use crate::input::InputState;
+use crate::theme::{ActiveTheme, Themeable};
+use crate::traits::disableable::Disableable;
+
+/// Default number of visible text rows.
+const DEFAULT_ROWS: u32 = 3;
+
+/// Approximate line height in rems for calculating min-height.
+const LINE_HEIGHT_REMS: f32 = 1.5;
+
+/// Creates a new Textarea component.
+///
+/// # Example
+///
+/// ```ignore
+/// let state = cx.new(|cx| InputState::new_multiline(cx));
+///
+/// textarea(&state, cx)
+///     .placeholder("Enter your message...")
+///     .rows(4)
+///     .disabled(false)
+/// ```
+pub fn textarea(state: &Entity<InputState>, cx: &App) -> Textarea {
+    Textarea::new(state, cx)
+}
+
+/// A styled multi-line text input component.
+///
+/// Wraps the raw `text_area()` element with form-friendly styling including
+/// borders, padding, background colors, and focus states.
+#[derive(IntoElement)]
+pub struct Textarea {
+    state: Entity<InputState>,
+    focus_handle: FocusHandle,
+    placeholder: Option<SharedString>,
+    rows: u32,
+    disabled: bool,
+    read_only: bool,
+    max_height: Option<Pixels>,
+}
+
+impl Textarea {
+    /// Creates a new Textarea wrapping the given InputState.
+    ///
+    /// The InputState should be created with `InputState::new_multiline(cx)`.
+    pub fn new(state: &Entity<InputState>, cx: &App) -> Self {
+        Self {
+            state: state.clone(),
+            focus_handle: state.focus_handle(cx),
+            placeholder: None,
+            rows: DEFAULT_ROWS,
+            disabled: false,
+            read_only: false,
+            max_height: None,
+        }
+    }
+
+    /// Sets the placeholder text shown when the textarea is empty.
+    pub fn placeholder(mut self, placeholder: impl Into<SharedString>) -> Self {
+        self.placeholder = Some(placeholder.into());
+        self
+    }
+
+    /// Sets the number of visible text rows (affects min-height).
+    ///
+    /// Defaults to 3 rows.
+    pub fn rows(mut self, rows: u32) -> Self {
+        self.rows = rows.max(1);
+        self
+    }
+
+    /// Sets a maximum height for the textarea.
+    ///
+    /// When set, the textarea will scroll vertically if content exceeds this height.
+    pub fn max_height(mut self, height: impl Into<Pixels>) -> Self {
+        self.max_height = Some(height.into());
+        self
+    }
+
+    /// Sets the read-only state.
+    ///
+    /// When read-only, the textarea is visually styled to indicate it cannot be edited,
+    /// but the user can still select and copy text.
+    ///
+    /// Note: This currently only affects visual styling. Full read-only behavior
+    /// would require InputState-level support.
+    pub fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+}
+
+impl Disableable for Textarea {
+    fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+impl Focusable for Textarea {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl RenderOnce for Textarea {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let theme = cx.theme();
+        let is_focused = self.focus_handle.is_focused(window);
+        let disabled = self.disabled;
+        let read_only = self.read_only;
+
+        // Calculate min-height based on rows
+        let min_height = rems(self.rows as f32 * LINE_HEIGHT_REMS + 1.0); // +1.0 for padding
+
+        // Determine colors based on state
+        let bg_color = if disabled {
+            theme.surface_tertiary()
+        } else if read_only {
+            theme.surface_secondary()
+        } else {
+            theme.input_bg()
+        };
+
+        let border_color = if disabled {
+            theme.border_subtle()
+        } else if is_focused {
+            theme.input_border_focused()
+        } else {
+            theme.input_border()
+        };
+
+        let text_color = if disabled {
+            theme.fg_disabled()
+        } else {
+            theme.input_text()
+        };
+
+        // Build the inner text_area element
+        let mut inner = text_area(&self.state, cx)
+            .size_full()
+            .text_color(text_color);
+
+        if let Some(placeholder) = self.placeholder {
+            inner = inner.placeholder(placeholder);
+        }
+
+        // Build the container
+        div()
+            .id("textarea")
+            .min_h(min_height)
+            .when_some(self.max_height, |this, max_h| this.max_h(max_h))
+            .w_full()
+            .px(rems(0.75))
+            .py(rems(0.5))
+            .bg(bg_color)
+            .border_1()
+            .border_color(border_color)
+            .rounded(px(6.))
+            .overflow_hidden()
+            .text_sm()
+            .when(disabled, |this| this.cursor_not_allowed().opacity(0.65))
+            .when(!disabled && !read_only, |this| {
+                this.cursor_text()
+                    .when(!is_focused, |this| {
+                        this.hover(|style| style.border_color(theme.input_border_hover()))
+                    })
+            })
+            .when(read_only && !disabled, |this| this.cursor_default())
+            .child(inner)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a styled Textarea component that wraps the existing `text_area()` element.

- Styled multi-line text input with border, padding, and theme colors
- Configurable rows (min-height)
- Placeholder text support
- Disabled and read-only states (visual styling)
- Works with Field component

## Changes

- Added `src/elements/textarea.rs` with the Textarea component
- Exported the textarea module in `src/elements.rs`
- Added Textarea example to the showcase

## Usage

```rust
let state = cx.new(|cx| InputState::new_multiline(cx));

textarea(&state, cx)
    .placeholder("Enter your message...")
    .rows(4)
    .disabled(false)
```

## Notes

- The read-only state currently only affects visual styling. Full read-only behavior would require InputState-level support.
- Resize handle is noted as a stretch goal in the issue and not implemented (would require drag handling).

## Test plan

- [x] Library compiles without errors
- [x] Examples compile without errors
- [x] All existing tests pass
- [ ] Visual testing with showcase example

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)