### PR TITLE
Remove redundant disabled method from Tab impl block

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -35,6 +35,7 @@ use gpuikit::{
         tooltip::tooltip,
     },
     layout::{h_stack, v_stack},
+    traits::disableable::Disableable,
     traits::labelable::Labelable,
     traits::orientable::Orientable,
     DefaultIcons,

--- a/src/elements/tabs.rs
+++ b/src/elements/tabs.rs
@@ -36,12 +36,6 @@ impl Tab {
             disabled: false,
         }
     }
-
-    /// Set whether this tab is disabled
-    pub fn disabled(mut self, disabled: bool) -> Self {
-        self.disabled = disabled;
-        self
-    }
 }
 
 impl Disableable for Tab {


### PR DESCRIPTION
## Summary

- Removes the redundant inline `disabled()` method from the `Tab` impl block
- The `Disableable` trait implementation already provides this functionality
- Adds `Disableable` trait import to `examples/showcase.rs` to maintain compatibility

## Changes

The `Tab` struct had both:
1. An inline `disabled()` method in `impl Tab` (lines 40-44)
2. A `Disableable` trait implementation providing the same `disabled()` method (lines 47-55)

This PR removes the redundant inline method. Callers that use `tab.disabled()` now need to have the `Disableable` trait in scope.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (165 unit tests)
- [x] `cargo check --examples` passes

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)