### PR TITLE
Add Skeleton component showcase

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -32,6 +32,7 @@ use gpuikit::{
         loading_indicator::loading_indicator,
         progress::{progress, ProgressVariant},
         radio_group::{radio_group, radio_option, RadioGroup},
+        skeleton::{skeleton, skeleton_avatar, skeleton_card, skeleton_text},
         separator::{separator, vertical_separator},
         switch::{switch, Switch},
         tabs::{tab, tabs, Tabs},
@@ -826,6 +827,39 @@ impl Render for Showcase {
                                     .child(progress(0.75))
                                     .child(progress(1.0).variant(ProgressVariant::Danger)),
                             ),
+                    )
+                    .child(separator())
+                    .child(
+                        v_stack()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.fg_muted())
+                                    .child("Skeleton"),
+                            )
+                            .child(
+                                h_stack()
+                                    .gap_4()
+                                    .items_center()
+                                    .child(skeleton_avatar())
+                                    .child(
+                                        v_stack()
+                                            .gap_2()
+                                            .child(skeleton_text().w(px(150.0)))
+                                            .child(skeleton_text().w(px(100.0))),
+                                    ),
+                            )
+                            .child(
+                                h_stack()
+                                    .gap_4()
+                                    .mt_2()
+                                    .child(skeleton().w(px(80.0)).h(px(32.0)))
+                                    .child(skeleton().w(px(120.0)).h(px(32.0)))
+                                    .child(skeleton().w(px(60.0)).h(px(32.0)).circle()),
+                            )
+                            .child(div().mt_2().child(skeleton_card())),
                     )
                     .child(separator())
                     .child(


### PR DESCRIPTION
## Summary

- Adds a showcase section for the Skeleton loading placeholder component
- Demonstrates avatar, text line, button, and card skeleton variants
- The Skeleton component itself was already implemented in `src/elements/skeleton.rs`

Closes #48

## Test plan

- [ ] Run `cargo run --example showcase` and verify the Skeleton section renders
- [ ] Observe the animated shimmer/pulse effect on the skeletons
- [ ] Verify avatar (circle), text lines, buttons, and card shapes display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)