### PR TITLE
Update todo.md: mark Dialog, Select, Textarea as implemented

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -13,6 +13,7 @@
 - Card
 - Checkbox
 - Collapsible
+- Dialog
 - Dropdown Menu
 - Empty
 - Field
@@ -24,11 +25,13 @@
 - Loading Indicator
 - Progress
 - Radio Group
+- Select
 - Separator
 - Skeleton
 - Slider
 - Switch
 - Tabs
+- Textarea
 - Toggle
 - Toggle Group
 - Tooltip
@@ -41,13 +44,10 @@
 These share the `anchored()`/`deferred()` pattern already used by Dropdown.
 
 - Popover — general-purpose positioned overlay, building block for many others
-- Dialog — modal overlay with backdrop
-- Select — form selection dropdown (close to existing Dropdown)
 - Context Menu — right-click positioned menu
 
 ### Next Up — No New Infra Needed
 
-- Textarea — styled wrapper around existing `text_area()` element
 - Scroll Area — styled wrapper around gpui overflow scrolling
 - Toast — notification queue system
 


### PR DESCRIPTION
## Summary

- Move Dialog, Select, and Textarea to the "Implemented" section in todo.md
- These components were implemented in recent PRs (#84, #85, #87) but todo.md wasn't updated

## Test plan

- [x] Verified component files exist in `src/elements/`
- [x] Verified PRs merged for each component

Relates to #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)