### PR TITLE
Add Label component showcase

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -26,6 +26,7 @@ use gpuikit::{
         icon_button::icon_button,
         input_group::{input_group, InputAddon},
         kbd::{kbd, kbd_combo, KbdSize},
+        label::label,
         textarea::textarea,
         loading_indicator::loading_indicator,
         progress::{progress, ProgressVariant},
@@ -759,6 +760,26 @@ impl Render for Showcase {
                                             .text_color(theme.fg_muted())
                                             .child("(small / default / large)"),
                                     ),
+                            ),
+                    )
+                    .child(separator())
+                    .child(
+                        v_stack()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.fg_muted())
+                                    .child("Label"),
+                            )
+                            .child(
+                                h_stack()
+                                    .gap_4()
+                                    .items_center()
+                                    .child(label("Default label"))
+                                    .child(label("Required").required(true))
+                                    .child(label("Disabled").disabled(true)),
                             ),
                     )
                     .child(separator())


### PR DESCRIPTION
## Summary

- Adds a Label showcase section to the examples demonstrating the Label component features

The Label component already existed in `src/elements/label.rs` and was exported from `src/elements.rs`. This PR completes the acceptance criteria by adding the showcase section.

## Features demonstrated

- Default label
- Required label (shows asterisk indicator)
- Disabled label (muted text color)

## Test plan

- [x] Build succeeds (`cargo build --example showcase`)
- [x] All tests pass (`cargo test --lib`)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)