### PR TITLE
Fix horizontal ScrollArea not scrolling

### DIFF
--- a/src/elements/scroll_area.rs
+++ b/src/elements/scroll_area.rs
@@ -168,7 +168,10 @@ impl RenderOnce for ScrollArea {
         let container = div()
             .id(self.id)
             .flex()
-            .flex_col()
+            .when(
+                self.direction == ScrollDirection::Vertical,
+                |this| this.flex_col(),
+            )
             .when(self.full_width, |this| this.w_full())
             .when(self.full_height, |this| this.h_full())
             .when_some(self.max_height, |this, height| this.max_h(height))


### PR DESCRIPTION
## Summary

- Fixed horizontal `ScrollArea` not scrolling by only applying `flex_col()` when the scroll direction is `Vertical`
- The unconditional `flex_col()` was constraining children to the container's width via flexbox cross-axis stretch, preventing horizontal overflow even though `overflow_x_scroll()` was set
- For `Horizontal` and `Both` directions, the container now uses the default flex-row layout, allowing children to maintain their natural width and overflow horizontally

## Test plan

- [ ] Run the showcase example and verify the horizontal scroll demo's tags are scrollable
- [ ] Verify vertical scroll still works correctly
- [ ] Verify "Both" direction scrolling works if used

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)