### PR TITLE
Add grain/noise texture overlay element

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -37,6 +37,7 @@ use gpuikit::{
         scroll_area::scroll_area,
         select::{select, SelectState},
         separator::separator,
+        grain::grain,
         skeleton::{skeleton, skeleton_avatar, skeleton_card, skeleton_text},
         switch::{switch, Switch},
         tabs::{tab, tabs, Tabs},
@@ -1223,6 +1224,97 @@ impl Showcase {
             .child(div().mt_2().child(skeleton_card()))
     }
 
+    fn render_grain_page(&self, cx: &Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        v_stack()
+            .gap_2()
+            .child(
+                div()
+                    .text_lg()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(theme.fg_muted())
+                    .child("Grain"),
+            )
+            .child(
+                h_stack().gap_4().child(
+                    // Dark surface with light grain
+                    div()
+                        .relative()
+                        .w(px(200.0))
+                        .h(px(120.0))
+                        .rounded_lg()
+                        .bg(theme.surface())
+                        .border_1()
+                        .border_color(theme.border())
+                        .child(div().p_3().text_color(theme.fg_muted()).child("Default grain"))
+                        .child(grain().size_full().absolute()),
+                )
+                .child(
+                    div()
+                        .relative()
+                        .w(px(200.0))
+                        .h(px(120.0))
+                        .rounded_lg()
+                        .bg(gpui::hsla(0.6, 0.4, 0.15, 1.0))
+                        .border_1()
+                        .border_color(theme.border())
+                        .child(
+                            div()
+                                .p_3()
+                                .text_color(gpui::hsla(0.0, 0.0, 0.9, 1.0))
+                                .child("Light grain"),
+                        )
+                        .child(grain().size_full().absolute().light()),
+                )
+                .child(
+                    div()
+                        .relative()
+                        .w(px(200.0))
+                        .h(px(120.0))
+                        .rounded_lg()
+                        .bg(theme.surface())
+                        .border_1()
+                        .border_color(theme.border())
+                        .child(div().p_3().text_color(theme.fg_muted()).child("High intensity"))
+                        .child(grain().size_full().absolute().intensity(0.15)),
+                ),
+            )
+            .child(
+                h_stack().gap_4().child(
+                    // Dense grain
+                    div()
+                        .relative()
+                        .w(px(200.0))
+                        .h(px(120.0))
+                        .rounded_lg()
+                        .bg(theme.surface())
+                        .border_1()
+                        .border_color(theme.border())
+                        .child(div().p_3().text_color(theme.fg_muted()).child("Dense (2px)"))
+                        .child(grain().size_full().absolute().spacing(2.0)),
+                )
+                .child(
+                    div()
+                        .relative()
+                        .w(px(200.0))
+                        .h(px(120.0))
+                        .rounded_lg()
+                        .bg(theme.surface())
+                        .border_1()
+                        .border_color(theme.border())
+                        .child(div().p_3().text_color(theme.fg_muted()).child("Large dots"))
+                        .child(
+                            grain()
+                                .size_full()
+                                .absolute()
+                                .dot_size(2.0)
+                                .spacing(3.0)
+                                .intensity(0.08),
+                        ),
+                ),
+            )
+    }
+
     fn render_alert_page(&self, cx: &Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         v_stack()
@@ -1803,6 +1895,7 @@ impl Render for Showcase {
                 .child(self.render_loading_indicator_page(cx))
                 .child(self.render_progress_page(cx))
                 .child(self.render_skeleton_page(cx))
+                .child(self.render_grain_page(cx))
                 .child(self.render_alert_page(cx))
                 .child(self.render_tooltip_page(cx))
                 .child(self.render_card_page(cx))

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -14,6 +14,7 @@ pub mod dialog;
 pub mod dropdown;
 pub mod empty;
 pub mod field;
+pub mod grain;
 pub mod icon_button;
 pub mod input;
 pub mod input_group;

--- a/src/elements/grain.rs
+++ b/src/elements/grain.rs
@@ -1,0 +1,220 @@
+//! Grain/noise texture overlay element for gpuikit
+//!
+//! Adds a subtle film-grain or noise pattern on top of UI content,
+//! useful for adding texture and depth to surfaces.
+
+use gpui::{
+    canvas, div, point, prelude::FluentBuilder, px, size, App, Bounds, Div, IntoElement,
+    ParentElement, Pixels, RenderOnce, Styled, Window,
+};
+
+use crate::theme::{ActiveTheme, Themeable};
+
+/// Create a grain overlay with default settings.
+pub fn grain() -> Grain {
+    Grain::new()
+}
+
+/// A procedural noise/grain texture overlay.
+///
+/// Place this as a sibling of content inside a relative-positioned container,
+/// or use it as a standalone textured surface.
+///
+/// # Example
+///
+/// ```ignore
+/// div()
+///     .relative()
+///     .size_full()
+///     .child(your_content)
+///     .child(grain().size_full())
+/// ```
+#[derive(IntoElement)]
+pub struct Grain {
+    width: Option<Pixels>,
+    height: Option<Pixels>,
+    full_width: bool,
+    full_height: bool,
+    absolute: bool,
+    /// Opacity multiplier for the grain dots (0.0 to 1.0).
+    intensity: f32,
+    /// Spacing between grain dots in pixels. Lower = denser.
+    spacing: f32,
+    /// Size of each grain dot in pixels.
+    dot_size: f32,
+    /// Use foreground color (light grain on dark). If false, uses dark grain.
+    light: bool,
+}
+
+impl Grain {
+    pub fn new() -> Self {
+        Self {
+            width: None,
+            height: None,
+            full_width: false,
+            full_height: false,
+            absolute: false,
+            intensity: 0.06,
+            spacing: 4.0,
+            dot_size: 1.0,
+            light: false,
+        }
+    }
+
+    pub fn w(mut self, width: Pixels) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    pub fn h(mut self, height: Pixels) -> Self {
+        self.height = Some(height);
+        self
+    }
+
+    pub fn size(mut self, size: Pixels) -> Self {
+        self.width = Some(size);
+        self.height = Some(size);
+        self
+    }
+
+    pub fn w_full(mut self) -> Self {
+        self.full_width = true;
+        self
+    }
+
+    pub fn h_full(mut self) -> Self {
+        self.full_height = true;
+        self
+    }
+
+    /// Make this a full-size absolute overlay (common usage).
+    pub fn size_full(mut self) -> Self {
+        self.full_width = true;
+        self.full_height = true;
+        self
+    }
+
+    /// Position absolutely within a relative container.
+    pub fn absolute(mut self) -> Self {
+        self.absolute = true;
+        self
+    }
+
+    /// Set the grain intensity (0.0 to 1.0). Default: 0.06.
+    ///
+    /// Lower values produce a subtle texture, higher values are more pronounced.
+    pub fn intensity(mut self, intensity: f32) -> Self {
+        self.intensity = intensity.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Set the spacing between grain dots in pixels. Default: 4.0.
+    ///
+    /// Lower values produce denser grain. Minimum: 2.0.
+    pub fn spacing(mut self, spacing: f32) -> Self {
+        self.spacing = spacing.max(2.0);
+        self
+    }
+
+    /// Set the size of each grain dot in pixels. Default: 1.0.
+    pub fn dot_size(mut self, dot_size: f32) -> Self {
+        self.dot_size = dot_size.max(0.5);
+        self
+    }
+
+    /// Use light-colored grain (for dark backgrounds). Default: false.
+    pub fn light(mut self) -> Self {
+        self.light = true;
+        self
+    }
+}
+
+impl Default for Grain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Simple hash-based pseudo-random for deterministic grain pattern.
+/// Uses a variant of the xxhash finalizer for good distribution.
+fn hash_position(x: u32, y: u32) -> f32 {
+    let mut h = x.wrapping_mul(374761393).wrapping_add(y.wrapping_mul(668265263));
+    h = (h ^ (h >> 13)).wrapping_mul(1274126177);
+    h = h ^ (h >> 16);
+    (h & 0xFFFF) as f32 / 65535.0
+}
+
+impl RenderOnce for Grain {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let theme = cx.theme();
+        let base_color = if self.light {
+            theme.fg()
+        } else {
+            gpui::hsla(0.0, 0.0, 0.0, 1.0)
+        };
+        let intensity = self.intensity;
+        let spacing = self.spacing;
+        let dot_size = self.dot_size;
+
+        let paint_canvas = canvas(
+            move |bounds, _, _cx| bounds,
+            move |bounds: Bounds<Pixels>, _, window: &mut Window, _cx| {
+                paint_grain(window, bounds, base_color, intensity, spacing, dot_size);
+            },
+        )
+        .size_full();
+
+        div()
+            .overflow_hidden()
+            .when(self.absolute, |this: Div| {
+                this.absolute().top_0().left_0()
+            })
+            .when(self.full_width, |this: Div| this.w_full())
+            .when(self.full_height, |this: Div| this.h_full())
+            .when_some(self.width, |this: Div, w| this.w(w))
+            .when_some(self.height, |this: Div, h| this.h(h))
+            .child(paint_canvas)
+    }
+}
+
+fn paint_grain(
+    window: &mut Window,
+    bounds: Bounds<Pixels>,
+    base_color: gpui::Hsla,
+    intensity: f32,
+    spacing: f32,
+    dot_size: f32,
+) {
+    let origin_x: f32 = bounds.origin.x.into();
+    let origin_y: f32 = bounds.origin.y.into();
+    let width: f32 = bounds.size.width.into();
+    let height: f32 = bounds.size.height.into();
+
+    let dot_px = px(dot_size);
+
+    let mut y_offset = 0.0_f32;
+    let mut row: u32 = 0;
+    while y_offset < height {
+        let mut x_offset = 0.0_f32;
+        let mut col: u32 = 0;
+        while x_offset < width {
+            let rand_val = hash_position(col, row);
+            // Vary opacity per dot using the hash
+            let alpha = rand_val * intensity;
+            if alpha > 0.005 {
+                let color = gpui::hsla(base_color.h, base_color.s, base_color.l, alpha);
+                window.paint_quad(gpui::fill(
+                    Bounds {
+                        origin: point(px(origin_x + x_offset), px(origin_y + y_offset)),
+                        size: size(dot_px, dot_px),
+                    },
+                    color,
+                ));
+            }
+            x_offset += spacing;
+            col += 1;
+        }
+        y_offset += spacing;
+        row += 1;
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -32,6 +32,7 @@
 - Select
 - Separator
 - Skeleton
+- Grain
 - Slider
 - Switch
 - Tabs


### PR DESCRIPTION
## Summary

- Adds a new `Grain` element that renders a procedural noise/grain texture overlay using GPUI's canvas `paint_quad` API
- Configurable: `intensity` (opacity), `spacing` (density), `dot_size`, and `light()` mode for dark backgrounds
- Uses a deterministic hash-based pseudo-random pattern (no external deps)
- Includes showcase demo in the Display category with 5 variants

## Usage

```rust
// Overlay on a surface
div()
    .relative()
    .size_full()
    .bg(theme.surface())
    .child(your_content)
    .child(grain().size_full().absolute())

// Light grain on dark background
grain().size_full().absolute().light()

// Customize density and intensity
grain().size_full().absolute().spacing(2.0).intensity(0.12)
```

## Test plan

- [x] `cargo check` passes
- [x] `cargo check --example showcase` passes
- [ ] Visual verification via `cargo run --example showcase` (Display category)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)