### PR TITLE
markdown: inline links and code stay inline; opt-in hard soft-breaks

### DIFF
--- a/src/markdown/elements/heading.rs
+++ b/src/markdown/elements/heading.rs
@@ -1,10 +1,11 @@
 //! Heading element for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, rems, App, ParentElement, SharedString, Styled, StyledText};
+use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, Styled};
 
-use super::super::inline_style::RichText;
+use super::super::inline_style::{InlinePalette, RichText};
 use super::super::style::TextStyle;
+use super::paragraph::rich_text_run;
 
 /// Heading level (h1-h6).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -46,13 +47,17 @@ pub fn heading(text: impl Into<String>, style: &TextStyle, cx: &App) -> impl Int
         .child(text)
 }
 
-/// Render a heading element with rich text (supporting bold, italic, strikethrough).
-pub fn rich_heading(rich_text: &RichText, style: &TextStyle, cx: &App) -> impl IntoElement {
+/// Render a heading element with rich text (bold, italic, strikethrough,
+/// inline code, and clickable links).
+pub fn rich_heading(
+    id: impl Into<ElementId>,
+    rich_text: &RichText,
+    style: &TextStyle,
+    palette: &InlinePalette,
+    cx: &App,
+) -> impl IntoElement {
     let theme = cx.theme();
     let text_color = style.color.unwrap_or(theme.fg());
-    let (text, highlights) = rich_text.to_highlights();
-
-    let styled_text: SharedString = text.into();
 
     div()
         .w_full()
@@ -61,5 +66,5 @@ pub fn rich_heading(rich_text: &RichText, style: &TextStyle, cx: &App) -> impl I
         .font_weight(style.weight)
         .text_color(text_color)
         .mt(rems(style.margin_top))
-        .child(StyledText::new(styled_text).with_highlights(highlights))
+        .child(rich_text_run(id, rich_text, palette))
 }

--- a/src/markdown/elements/list.rs
+++ b/src/markdown/elements/list.rs
@@ -1,10 +1,11 @@
 //! List elements for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, rems, App, ParentElement, SharedString, Styled, StyledText};
+use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, Styled};
 
-use super::super::inline_style::RichText;
+use super::super::inline_style::{InlinePalette, RichText};
 use super::super::style::TextStyle;
+use super::paragraph::rich_text_run;
 
 /// Render a list item element with plain text.
 pub fn list_item(
@@ -31,20 +32,20 @@ pub fn list_item(
         .child(div().flex_1().child(text))
 }
 
-/// Render a list item element with rich text (supporting bold, italic, strikethrough).
+/// Render a list item element with rich text (bold, italic, strikethrough,
+/// inline code, and clickable links).
 pub fn rich_list_item(
+    id: impl Into<ElementId>,
     rich_text: &RichText,
     marker: String,
     indent_level: usize,
     style: &TextStyle,
+    palette: &InlinePalette,
     cx: &App,
 ) -> impl IntoElement {
     let indent = rems(indent_level as f32 * 1.5);
     let theme = cx.theme();
     let text_color = style.color.unwrap_or(theme.fg());
-    let (text, highlights) = rich_text.to_highlights();
-
-    let styled_text: SharedString = text.into();
 
     div()
         .flex()
@@ -55,11 +56,7 @@ pub fn rich_list_item(
         .line_height(rems(style.size * style.line_height))
         .text_color(text_color)
         .child(div().flex_none().child(marker))
-        .child(
-            div()
-                .flex_1()
-                .child(StyledText::new(styled_text).with_highlights(highlights)),
-        )
+        .child(div().flex_1().child(rich_text_run(id, rich_text, palette)))
 }
 
 /// Get the marker for an unordered list item.

--- a/src/markdown/elements/paragraph.rs
+++ b/src/markdown/elements/paragraph.rs
@@ -1,9 +1,12 @@
 //! Paragraph element for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, rems, App, ParentElement, SharedString, Styled, StyledText};
+use gpui::{
+    div, prelude::*, rems, App, ElementId, InteractiveText, ParentElement, SharedString, Styled,
+    StyledText,
+};
 
-use super::super::inline_style::RichText;
+use super::super::inline_style::{InlinePalette, RichText};
 use super::super::style::TextStyle;
 
 /// Render a paragraph element with plain text.
@@ -20,18 +23,48 @@ pub fn paragraph(text: impl Into<String>, style: &TextStyle, cx: &App) -> impl I
         .child(text)
 }
 
-/// Render a paragraph element with rich text (supporting bold, italic, strikethrough).
-pub fn rich_paragraph(rich_text: &RichText, style: &TextStyle, cx: &App) -> impl IntoElement {
+/// One rich text run: a `StyledText` carrying the span highlights, wrapped in
+/// `InteractiveText` when any span is a link so the link ranges are clickable
+/// (opening in the default browser) without breaking the text into blocks.
+pub(crate) fn rich_text_run(
+    id: impl Into<ElementId>,
+    rich_text: &RichText,
+    palette: &InlinePalette,
+) -> gpui::AnyElement {
+    let (text, highlights) = rich_text.to_highlights_with(palette);
+    let styled: SharedString = text.into();
+    let styled = StyledText::new(styled).with_highlights(highlights);
+
+    let links = rich_text.link_ranges();
+    if links.is_empty() {
+        return styled.into_any_element();
+    }
+    let (ranges, urls): (Vec<_>, Vec<_>) = links.into_iter().unzip();
+    InteractiveText::new(id, styled)
+        .on_click(ranges, move |range_ix, _window, cx| {
+            if let Some(url) = urls.get(range_ix) {
+                cx.open_url(url);
+            }
+        })
+        .into_any_element()
+}
+
+/// Render a paragraph element with rich text (bold, italic, strikethrough,
+/// inline code, and clickable links).
+pub fn rich_paragraph(
+    id: impl Into<ElementId>,
+    rich_text: &RichText,
+    style: &TextStyle,
+    palette: &InlinePalette,
+    cx: &App,
+) -> impl IntoElement {
     let theme = cx.theme();
     let text_color = style.color.unwrap_or(theme.fg());
-    let (text, highlights) = rich_text.to_highlights();
-
-    let styled_text: SharedString = text.into();
 
     div()
         .w_full()
         .text_size(rems(style.size))
         .line_height(rems(style.size * style.line_height))
         .text_color(text_color)
-        .child(StyledText::new(styled_text).with_highlights(highlights))
+        .child(rich_text_run(id, rich_text, palette))
 }

--- a/src/markdown/elements/quote.rs
+++ b/src/markdown/elements/quote.rs
@@ -1,10 +1,11 @@
 //! Block quote element for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, px, rems, App, ParentElement, SharedString, Styled, StyledText};
+use gpui::{div, prelude::*, px, rems, App, ElementId, ParentElement, Styled};
 
-use super::super::inline_style::RichText;
+use super::super::inline_style::{InlinePalette, RichText};
 use super::super::style::TextStyle;
+use super::paragraph::rich_text_run;
 
 /// Render a block quote element with plain text.
 pub fn block_quote(
@@ -29,18 +30,18 @@ pub fn block_quote(
         .child(text)
 }
 
-/// Render a block quote element with rich text (supporting bold, italic, strikethrough).
+/// Render a block quote element with rich text (bold, italic, strikethrough,
+/// inline code, and clickable links).
 pub fn rich_block_quote(
+    id: impl Into<ElementId>,
     rich_text: &RichText,
     style: &TextStyle,
     border_color: Option<gpui::Hsla>,
     text_color: Option<gpui::Hsla>,
+    palette: &InlinePalette,
     cx: &App,
 ) -> impl IntoElement {
     let theme = cx.theme();
-    let (text, highlights) = rich_text.to_highlights();
-
-    let styled_text: SharedString = text.into();
 
     div()
         .w_full()
@@ -51,5 +52,5 @@ pub fn rich_block_quote(
         .line_height(rems(style.size * style.line_height))
         .text_color(text_color.unwrap_or(theme.fg_muted()))
         .italic()
-        .child(StyledText::new(styled_text).with_highlights(highlights))
+        .child(rich_text_run(id, rich_text, palette))
 }

--- a/src/markdown/inline_style.rs
+++ b/src/markdown/inline_style.rs
@@ -1,17 +1,38 @@
 //! Inline text styling for markdown rendering.
 //!
 //! This module provides types for tracking and rendering inline text styles
-//! like bold, italic, and strikethrough within markdown text.
+//! like bold, italic, strikethrough, inline code, and links within markdown
+//! text. Code and links stay *inline* — spans within one text run — rather
+//! than being flushed as separate block elements, so a sentence survives
+//! having a link or a code chip in the middle of it.
 
-use gpui::{FontStyle, FontWeight, HighlightStyle, StrikethroughStyle};
+use gpui::{FontStyle, FontWeight, HighlightStyle, Hsla, SharedString, StrikethroughStyle};
 use std::ops::Range;
 
 /// Inline text style flags that can be combined.
+///
+/// `link` is an index into the owning [`RichText`]'s URL table rather than
+/// the URL itself, which keeps this type `Copy` and keeps span merging
+/// correct: two adjacent links to different URLs have different indices, so
+/// they never merge into one clickable range.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct InlineStyle {
     pub bold: bool,
     pub italic: bool,
     pub strikethrough: bool,
+    pub code: bool,
+    pub link: Option<u32>,
+}
+
+/// Theme-resolved colors for the inline styles that need them. Resolved by
+/// the element (which has the theme) and passed into
+/// [`RichText::to_highlights_with`]; `None` leaves that aspect unstyled.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct InlinePalette {
+    /// Background wash behind inline code spans.
+    pub code_background: Option<Hsla>,
+    /// Text color for link spans (they are also underlined).
+    pub link_color: Option<Hsla>,
 }
 
 impl InlineStyle {
@@ -34,7 +55,16 @@ impl InlineStyle {
         self
     }
 
+    pub fn with_code(mut self) -> Self {
+        self.code = true;
+        self
+    }
+
     pub fn to_highlight_style(self) -> HighlightStyle {
+        self.to_highlight_style_with(&InlinePalette::default())
+    }
+
+    pub fn to_highlight_style_with(self, palette: &InlinePalette) -> HighlightStyle {
         let mut style = HighlightStyle::default();
 
         if self.bold {
@@ -52,11 +82,24 @@ impl InlineStyle {
             });
         }
 
+        if self.code {
+            style.background_color = palette.code_background;
+        }
+
+        if self.link.is_some() {
+            style.color = palette.link_color;
+            style.underline = Some(gpui::UnderlineStyle {
+                thickness: gpui::px(1.0),
+                color: palette.link_color,
+                wavy: false,
+            });
+        }
+
         style
     }
 
     pub fn is_empty(&self) -> bool {
-        !self.bold && !self.italic && !self.strikethrough
+        !self.bold && !self.italic && !self.strikethrough && !self.code && self.link.is_none()
     }
 }
 
@@ -67,15 +110,53 @@ pub struct TextSpan {
     pub style: InlineStyle,
 }
 
-/// Rich text container that holds styled text spans.
+/// Rich text container that holds styled text spans, plus the URL table that
+/// link spans index into.
 #[derive(Clone, Debug, Default)]
 pub struct RichText {
     spans: Vec<TextSpan>,
+    links: Vec<SharedString>,
 }
 
 impl RichText {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Register a link destination, returning the index for
+    /// [`InlineStyle::link`] on the spans that carry its text.
+    pub fn add_link(&mut self, url: impl Into<SharedString>) -> u32 {
+        self.links.push(url.into());
+        (self.links.len() - 1) as u32
+    }
+
+    /// The registered link destinations, in registration order.
+    pub fn links(&self) -> &[SharedString] {
+        &self.links
+    }
+
+    /// Byte ranges of the flattened text that are links, with their
+    /// destinations — the input for an interactive text element's clickable
+    /// ranges. Adjacent spans of the same link merge into one range.
+    pub fn link_ranges(&self) -> Vec<(Range<usize>, SharedString)> {
+        let mut ranges: Vec<(Range<usize>, u32)> = Vec::new();
+        let mut offset = 0;
+        for span in &self.spans {
+            let end = offset + span.text.len();
+            if let Some(link) = span.style.link {
+                match ranges.last_mut() {
+                    Some((range, last)) if *last == link && range.end == offset => {
+                        range.end = end;
+                    }
+                    _ => ranges.push((offset..end, link)),
+                }
+            }
+            offset = end;
+        }
+        ranges
+            .into_iter()
+            .filter_map(|(range, ix)| Some((range, self.links.get(ix as usize)?.clone())))
+            .collect()
     }
 
     pub fn push(&mut self, text: impl Into<String>, style: InlineStyle) {
@@ -104,6 +185,7 @@ impl RichText {
 
     pub fn clear(&mut self) {
         self.spans.clear();
+        self.links.clear();
     }
 
     pub fn to_plain_text(&self) -> String {
@@ -111,6 +193,13 @@ impl RichText {
     }
 
     pub fn to_highlights(&self) -> (String, Vec<(Range<usize>, HighlightStyle)>) {
+        self.to_highlights_with(&InlinePalette::default())
+    }
+
+    pub fn to_highlights_with(
+        &self,
+        palette: &InlinePalette,
+    ) -> (String, Vec<(Range<usize>, HighlightStyle)>) {
         let mut text = String::new();
         let mut highlights = Vec::new();
 
@@ -120,7 +209,7 @@ impl RichText {
             let end = text.len();
 
             if !span.style.is_empty() {
-                highlights.push((start..end, span.style.to_highlight_style()));
+                highlights.push((start..end, span.style.to_highlight_style_with(palette)));
             }
         }
 
@@ -243,5 +332,143 @@ mod tests {
         rt.push_plain("Text");
         rt.push_plain("");
         assert_eq!(rt.spans().len(), 1);
+    }
+
+    #[test]
+    fn test_code_span_styles_without_backticks() {
+        let mut rt = RichText::new();
+        rt.push_plain("run ");
+        rt.push("cargo test", InlineStyle::new().with_code());
+        rt.push_plain(" first");
+
+        let palette = InlinePalette {
+            code_background: Some(gpui::hsla(0., 0., 0.5, 1.)),
+            link_color: None,
+        };
+        let (text, highlights) = rt.to_highlights_with(&palette);
+        assert_eq!(text, "run cargo test first");
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].0, 4..14);
+        assert_eq!(highlights[0].1.background_color, palette.code_background);
+    }
+
+    #[test]
+    fn test_link_spans_stay_inline_and_click_ranges_resolve() {
+        let mut rt = RichText::new();
+        rt.push_plain("see ");
+        let a = rt.add_link("https://a.example");
+        rt.push(
+            "first",
+            InlineStyle {
+                link: Some(a),
+                ..Default::default()
+            },
+        );
+        rt.push_plain(" and ");
+        let b = rt.add_link("https://b.example");
+        rt.push(
+            "second",
+            InlineStyle {
+                link: Some(b),
+                ..Default::default()
+            },
+        );
+
+        // The sentence survives as one text run…
+        let (text, _) = rt.to_highlights();
+        assert_eq!(text, "see first and second");
+
+        // …with two distinct clickable ranges pointing at their own URLs.
+        let ranges = rt.link_ranges();
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].0, 4..9);
+        assert_eq!(ranges[0].1.as_ref(), "https://a.example");
+        assert_eq!(ranges[1].0, 14..20);
+        assert_eq!(ranges[1].1.as_ref(), "https://b.example");
+    }
+
+    #[test]
+    fn test_adjacent_spans_of_different_links_do_not_merge() {
+        let mut rt = RichText::new();
+        let a = rt.add_link("https://a.example");
+        let b = rt.add_link("https://b.example");
+        rt.push(
+            "one",
+            InlineStyle {
+                link: Some(a),
+                ..Default::default()
+            },
+        );
+        rt.push(
+            "two",
+            InlineStyle {
+                link: Some(b),
+                ..Default::default()
+            },
+        );
+        assert_eq!(rt.spans().len(), 2);
+        assert_eq!(rt.link_ranges().len(), 2);
+    }
+
+    #[test]
+    fn test_split_link_spans_merge_into_one_range() {
+        // A link whose text is interrupted by emphasis is still one link.
+        let mut rt = RichText::new();
+        let a = rt.add_link("https://a.example");
+        let plain = InlineStyle {
+            link: Some(a),
+            ..Default::default()
+        };
+        let bold = InlineStyle {
+            link: Some(a),
+            bold: true,
+            ..Default::default()
+        };
+        rt.push("very ", plain);
+        rt.push("bold", bold);
+        rt.push(" link", plain);
+
+        let ranges = rt.link_ranges();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].0, 0..14);
+    }
+
+    #[test]
+    fn test_link_styling_applies_color_and_underline() {
+        let mut rt = RichText::new();
+        let a = rt.add_link("https://a.example");
+        rt.push(
+            "link",
+            InlineStyle {
+                link: Some(a),
+                ..Default::default()
+            },
+        );
+
+        let palette = InlinePalette {
+            code_background: None,
+            link_color: Some(gpui::hsla(0.6, 0.8, 0.5, 1.)),
+        };
+        let (_, highlights) = rt.to_highlights_with(&palette);
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].1.color, palette.link_color);
+        assert!(highlights[0].1.underline.is_some());
+    }
+
+    #[test]
+    fn test_clear_drops_links_too() {
+        let mut rt = RichText::new();
+        let a = rt.add_link("https://a.example");
+        rt.push(
+            "x",
+            InlineStyle {
+                link: Some(a),
+                ..Default::default()
+            },
+        );
+        rt.clear();
+        assert!(rt.is_empty());
+        assert!(rt.links().is_empty());
+        assert!(rt.link_ranges().is_empty());
     }
 }

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -30,8 +30,8 @@ pub use style::*;
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::*, rems, App, Context, Entity, IntoElement, ParentElement, SharedString, Styled,
-    Window,
+    div, prelude::*, rems, App, Context, ElementId, Entity, IntoElement, ParentElement,
+    SharedString, Styled, Window,
 };
 use pulldown_cmark::{Alignment, Event, Tag, TagEnd};
 
@@ -146,10 +146,10 @@ struct MarkdownRenderer {
     in_heading: Option<HeadingLevel>,
     in_code_block: bool,
     in_block_quote: bool,
-    in_link: Option<LinkContext>,
     in_image: Option<ImageContext>,
     list_stack: Vec<ListContext>,
-    link_counter: usize,
+    /// Monotonic id source for elements that need one (interactive text).
+    element_counter: usize,
 
     // Table state
     in_table: bool,
@@ -161,11 +161,6 @@ struct MarkdownRenderer {
     // Rich text tracking
     current_text: RichText,
     active_style: InlineStyle,
-}
-
-#[derive(Clone, Debug)]
-struct LinkContext {
-    url: String,
 }
 
 #[derive(Clone, Debug)]
@@ -188,10 +183,9 @@ impl MarkdownRenderer {
             in_heading: None,
             in_code_block: false,
             in_block_quote: false,
-            in_link: None,
             in_image: None,
             list_stack: Vec::new(),
-            link_counter: 0,
+            element_counter: 0,
             in_table: false,
             table_alignments: Vec::new(),
             table_rows: Vec::new(),
@@ -221,7 +215,15 @@ impl MarkdownRenderer {
             Event::End(tag) => self.handle_end_tag(tag, cx),
             Event::Text(text) => self.handle_text(text),
             Event::Code(code) => self.handle_inline_code(code),
-            Event::SoftBreak => self.current_text.push(" ", self.active_style),
+            // Agent/LLM output often uses single newlines as real breaks;
+            // `soft_break_as_hard_break` opts into honoring them.
+            Event::SoftBreak => {
+                if self.style.soft_break_as_hard_break {
+                    self.current_text.push("\n", self.active_style)
+                } else {
+                    self.current_text.push(" ", self.active_style)
+                }
+            }
             Event::HardBreak => self.current_text.push("\n", self.active_style),
             Event::Rule => self.push_divider(cx),
             Event::TaskListMarker(checked) => self.handle_task_marker(*checked),
@@ -259,9 +261,9 @@ impl MarkdownRenderer {
                 self.active_style.strikethrough = true;
             }
             Tag::Link { dest_url, .. } => {
-                self.in_link = Some(LinkContext {
-                    url: dest_url.to_string(),
-                });
+                // Inline: the link is a styled, clickable range of the
+                // surrounding text run, not its own block element.
+                self.active_style.link = Some(self.current_text.add_link(dest_url.to_string()));
             }
             Tag::Image {
                 dest_url, title, ..
@@ -332,7 +334,7 @@ impl MarkdownRenderer {
                 self.active_style.strikethrough = false;
             }
             TagEnd::Link => {
-                self.flush_link(cx);
+                self.active_style.link = None;
             }
             TagEnd::Image => {
                 self.flush_image(cx);
@@ -374,14 +376,30 @@ impl MarkdownRenderer {
     }
 
     fn handle_inline_code(&mut self, code: &str) {
-        self.current_text.push("`", self.active_style);
-        self.current_text.push(code, self.active_style);
-        self.current_text.push("`", self.active_style);
+        // A styled span (background wash via the palette), not literal
+        // backticks in the text.
+        let mut style = self.active_style;
+        style.code = true;
+        self.current_text.push(code, style);
     }
 
     fn handle_task_marker(&mut self, checked: bool) {
         let marker = if checked { "☑ " } else { "☐ " };
         self.current_text.push(marker, self.active_style);
+    }
+
+    /// Theme-resolved colors for inline code and link spans.
+    fn palette(&self, cx: &App) -> InlinePalette {
+        let theme = cx.theme();
+        InlinePalette {
+            code_background: Some(self.style.inline_code_bg.unwrap_or(theme.surface())),
+            link_color: Some(self.style.link_color.unwrap_or(theme.accent())),
+        }
+    }
+
+    fn next_id(&mut self) -> ElementId {
+        self.element_counter += 1;
+        ElementId::NamedInteger("md-run".into(), self.element_counter as u64)
     }
 
     fn flush_paragraph(&mut self, cx: &App) {
@@ -390,7 +408,8 @@ impl MarkdownRenderer {
         }
 
         let rich_text = std::mem::take(&mut self.current_text);
-        let element = elements::rich_paragraph(&rich_text, &self.style.body, cx);
+        let (id, palette) = (self.next_id(), self.palette(cx));
+        let element = elements::rich_paragraph(id, &rich_text, &self.style.body, &palette, cx);
         self.elements.push(element.into_any_element());
     }
 
@@ -407,9 +426,11 @@ impl MarkdownRenderer {
             elements::HeadingLevel::H4 => &self.style.h4,
             elements::HeadingLevel::H5 => &self.style.h5,
             elements::HeadingLevel::H6 => &self.style.h6,
-        };
+        }
+        .clone();
 
-        let element = elements::rich_heading(&rich_text, heading_style, cx);
+        let (id, palette) = (self.next_id(), self.palette(cx));
+        let element = elements::rich_heading(id, &rich_text, &heading_style, &palette, cx);
         self.elements.push(element.into_any_element());
     }
 
@@ -419,11 +440,14 @@ impl MarkdownRenderer {
         }
 
         let rich_text = std::mem::take(&mut self.current_text);
+        let (id, palette) = (self.next_id(), self.palette(cx));
         let element = elements::rich_block_quote(
+            id,
             &rich_text,
             &self.style.body,
             self.style.block_quote_border,
             self.style.block_quote_text,
+            &palette,
             cx,
         );
         self.elements.push(element.into_any_element());
@@ -469,28 +493,16 @@ impl MarkdownRenderer {
         };
 
         let indent_level = self.list_stack.len().saturating_sub(1);
-        let element =
-            elements::rich_list_item(&rich_text, marker, indent_level, &self.style.body, cx);
-        self.elements.push(element.into_any_element());
-    }
-
-    fn flush_link(&mut self, cx: &App) {
-        let link_ctx = match self.in_link.take() {
-            Some(ctx) => ctx,
-            None => return,
-        };
-
-        if self.current_text.is_empty() {
-            return;
-        }
-
-        let text = self.current_text.to_plain_text();
-        self.current_text.clear();
-
-        let id: SharedString = format!("md-link-{}", self.link_counter).into();
-        self.link_counter += 1;
-
-        let element = elements::link(id, text, link_ctx.url.into(), self.style.link_color, cx);
+        let (id, palette) = (self.next_id(), self.palette(cx));
+        let element = elements::rich_list_item(
+            id,
+            &rich_text,
+            marker,
+            indent_level,
+            &self.style.body,
+            &palette,
+            cx,
+        );
         self.elements.push(element.into_any_element());
     }
 
@@ -557,7 +569,9 @@ impl MarkdownRenderer {
                     .when(row_idx > 0, |el| el.border_t_1().border_color(border_color))
                     .children(row.into_iter().enumerate().map(|(col_idx, cell)| {
                         let alignment = alignments.get(col_idx).copied().unwrap_or(Alignment::None);
-                        let (text, highlights) = cell.to_highlights();
+                        // Styled (code wash, link color) but not clickable —
+                        // cells sit in a custom layout without element ids.
+                        let (text, highlights) = cell.to_highlights_with(&self.palette(cx));
                         let styled_text: SharedString = text.into();
 
                         div()

--- a/src/markdown/style.rs
+++ b/src/markdown/style.rs
@@ -113,6 +113,14 @@ pub struct MarkdownStyle {
     /// Vertical spacing between block elements in rems.
     pub block_spacing: f32,
 
+    // Behavior
+    /// Render soft breaks (single newlines) as hard line breaks.
+    ///
+    /// CommonMark renders a single newline as a space, which is right for
+    /// hand-authored prose but wrong for LLM/agent output, where a single
+    /// newline is almost always an intended break. Off by default.
+    pub soft_break_as_hard_break: bool,
+
     // Colors (None = use theme defaults)
     /// Code block background color.
     pub code_block_bg: Option<Hsla>,
@@ -146,6 +154,8 @@ impl Default for MarkdownStyle {
 
             block_spacing: 0.5,
 
+            soft_break_as_hard_break: false,
+
             code_block_bg: None,
             code_block_border: None,
             inline_code_bg: None,
@@ -172,6 +182,13 @@ impl MarkdownStyle {
     /// Set the block spacing.
     pub fn block_spacing(mut self, spacing: f32) -> Self {
         self.block_spacing = spacing;
+        self
+    }
+
+    /// Render soft breaks (single newlines) as hard line breaks — the right
+    /// setting for LLM/agent-generated markdown.
+    pub fn soft_break_as_hard_break(mut self, enabled: bool) -> Self {
+        self.soft_break_as_hard_break = enabled;
         self
     }
 
@@ -218,6 +235,16 @@ mod tests {
 
         let ratio = h1.size / h2.size;
         assert!((ratio - TYPESCALE_RATIO).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_soft_break_option_defaults_off() {
+        assert!(!MarkdownStyle::default().soft_break_as_hard_break);
+        assert!(
+            MarkdownStyle::new()
+                .soft_break_as_hard_break(true)
+                .soft_break_as_hard_break
+        );
     }
 
     #[test]


### PR DESCRIPTION
Three rendering fixes for markdown, motivated by agent/LLM-authored content (chat replies, generated docs) where the current behavior is visibly wrong:

## Links no longer break their sentence

`TagEnd::Link` used to flush the *entire* accumulated paragraph as one block-level link element: `see [docs](url) for more` rendered as a clickable "see docs" block, then "for more" started a new paragraph. Links are now inline spans — colored and underlined via a new `InlinePalette` — and any rich text run containing links renders as `InteractiveText` with one clickable range per link (still opens in the default browser). A link whose text is interrupted by emphasis merges back into one clickable range; adjacent different links stay distinct ranges.

## Inline code renders as a span, not literal backticks

`` `code` `` used to keep its backticks in the text with no styling. It now renders backtick-free with a background wash (`inline_code_bg`, falling back to `theme.surface()`).

## `soft_break_as_hard_break` (new, default off)

CommonMark joins single newlines with a space — right for hand-authored prose, wrong for model output where a lone newline is nearly always an intended break. `MarkdownStyle::new().soft_break_as_hard_break(true)` opts a surface into honoring them.

## API notes

- `RichText` grows a URL table (`add_link` / `links` / `link_ranges`) so `InlineStyle` stays `Copy` and span-merging stays correct by construction (different links have different indices, so they can never merge).
- `to_highlights()` keeps its exact signature and decoration-only behavior; `to_highlights_with(&InlinePalette)` is the additive, theme-aware variant.
- **Breaking**: the `rich_paragraph` / `rich_heading` / `rich_block_quote` / `rich_list_item` constructors now take an `ElementId` and `&InlinePalette`. Mechanical for direct callers; `MarkdownElement` users are unaffected.
- Table cells get the styled highlights (code wash, link color) but not click handling — they sit in a custom layout without stable element ids. Noted in a comment at the call site.

Verified: 177 lib tests pass (10 new covering link ranges, merging, palette styling, and the soft-break option), `cargo fmt` clean, clippy warning count identical to main (66 pre-existing, none introduced). Built with `--features runtime_shaders` on a machine without the Metal toolchain component.