### PR TITLE
markdown: text selection across the document, with copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ name = "gpuikit"
 path = "src/lib.rs"
 
 [[example]]
+name = "markdown_selection"
+path = "examples/markdown_selection.rs"
+
+[[example]]
 name = "showcase"
 path = "examples/showcase.rs"
 

--- a/examples/markdown_selection.rs
+++ b/examples/markdown_selection.rs
@@ -1,0 +1,94 @@
+//! Markdown text selection.
+//!
+//! Drag across paragraphs, headings, lists and code blocks; double-click a
+//! word; triple-click a block; ⌘C copies the selection.
+//!
+//! The pattern to note: selection state lives on the `Markdown` entity, so
+//! the entity must be *retained* (created once, held by your view). The
+//! `markdown()` convenience creates a fresh entity per call and therefore
+//! cannot hold a selection across frames.
+#![allow(missing_docs)]
+
+use gpui::{
+    actions, div, prelude::*, px, size, App, Application, Bounds, ClipboardItem, Context, Entity,
+    KeyBinding, Window, WindowBounds, WindowOptions,
+};
+use gpuikit::markdown::{Markdown, MarkdownElement, MarkdownStyle};
+use gpuikit::theme::{ActiveTheme, Themeable};
+
+actions!(markdown_selection_example, [CopySelection]);
+
+const SOURCE: &str = "\
+# Selection demo
+
+Drag from this paragraph into the heading above or the list below — the
+selection flows across blocks. A [link](https://example.com) still opens on a
+plain click, and `inline code` selects like any other text.
+
+- First item
+- Second item with **bold** text
+- Third item
+
+```rust
+fn main() {
+    println!(\"code blocks select too\");
+}
+```
+
+> Block quotes as well. Press cmd-c to copy whatever is highlighted.
+";
+
+struct Example {
+    markdown: Entity<Markdown>,
+}
+
+impl Example {
+    fn new(cx: &mut Context<Self>) -> Self {
+        Self {
+            markdown: cx.new(|cx| Markdown::new(SOURCE, cx)),
+        }
+    }
+}
+
+impl Render for Example {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        div()
+            .size_full()
+            .bg(theme.bg())
+            .text_color(theme.fg())
+            .overflow_hidden()
+            .p(px(24.))
+            .on_action(cx.listener(|this, _: &CopySelection, _window, cx| {
+                if let Some(text) = this.markdown.read(cx).selected_text() {
+                    cx.write_to_clipboard(ClipboardItem::new_string(text));
+                }
+            }))
+            .child(
+                MarkdownElement::new(self.markdown.clone())
+                    .style(MarkdownStyle::new().soft_break_as_hard_break(true)),
+            )
+    }
+}
+
+fn main() {
+    let app = Application::with_platform(gpui_platform::current_platform(false))
+        .with_assets(gpuikit::assets());
+    app.run(|cx: &mut App| {
+        gpuikit::theme::init(cx);
+        cx.bind_keys([KeyBinding::new("cmd-c", CopySelection, None)]);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
+                    None,
+                    size(px(560.), px(640.)),
+                    cx,
+                ))),
+                ..Default::default()
+            },
+            |_, cx| cx.new(Example::new),
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}

--- a/src/markdown/elements/code_block.rs
+++ b/src/markdown/elements/code_block.rs
@@ -1,23 +1,30 @@
 //! Code block element for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, rems, App, ParentElement, SharedString, Styled};
+use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, SharedString, Styled};
 
+use super::super::selectable_text::SelectableText;
 use super::super::style::TextStyle;
+use super::paragraph::{selection_styled_text, RunContext};
 
-/// Render a code block element.
+/// Render a code block element. The text inside is a selectable run — code
+/// is the thing people copy most.
 ///
 /// TODO: Replace with gpuikit-editor readonly view for syntax highlighting.
-pub fn code_block(
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn code_block(
+    id: impl Into<ElementId>,
     text: String,
     _language: Option<&str>,
     style: &TextStyle,
     font_family: &SharedString,
     bg: Option<gpui::Hsla>,
     border: Option<gpui::Hsla>,
+    run_cx: RunContext,
     cx: &App,
 ) -> impl IntoElement {
     let theme = cx.theme();
+    let styled = selection_styled_text(text, Vec::new(), &run_cx);
 
     div()
         .px(rems(1.0))
@@ -31,7 +38,12 @@ pub fn code_block(
         .font_family(font_family.clone())
         .text_color(style.color.unwrap_or(theme.fg()))
         .overflow_hidden()
-        .child(text)
+        .child(SelectableText::new(
+            id,
+            styled,
+            run_cx.run,
+            run_cx.selection,
+        ))
 }
 
 /// Render inline code.

--- a/src/markdown/elements/heading.rs
+++ b/src/markdown/elements/heading.rs
@@ -5,7 +5,7 @@ use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, Styled};
 
 use super::super::inline_style::{InlinePalette, RichText};
 use super::super::style::TextStyle;
-use super::paragraph::rich_text_run;
+use super::paragraph::{rich_text_run, RunContext};
 
 /// Heading level (h1-h6).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -48,12 +48,13 @@ pub fn heading(text: impl Into<String>, style: &TextStyle, cx: &App) -> impl Int
 }
 
 /// Render a heading element with rich text (bold, italic, strikethrough,
-/// inline code, and clickable links).
-pub fn rich_heading(
+/// inline code, clickable links, and selection).
+pub(crate) fn rich_heading(
     id: impl Into<ElementId>,
     rich_text: &RichText,
     style: &TextStyle,
     palette: &InlinePalette,
+    run_cx: RunContext,
     cx: &App,
 ) -> impl IntoElement {
     let theme = cx.theme();
@@ -66,5 +67,5 @@ pub fn rich_heading(
         .font_weight(style.weight)
         .text_color(text_color)
         .mt(rems(style.margin_top))
-        .child(rich_text_run(id, rich_text, palette))
+        .child(rich_text_run(id, rich_text, palette, run_cx))
 }

--- a/src/markdown/elements/list.rs
+++ b/src/markdown/elements/list.rs
@@ -5,7 +5,7 @@ use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, Styled};
 
 use super::super::inline_style::{InlinePalette, RichText};
 use super::super::style::TextStyle;
-use super::paragraph::rich_text_run;
+use super::paragraph::{rich_text_run, RunContext};
 
 /// Render a list item element with plain text.
 pub fn list_item(
@@ -33,14 +33,16 @@ pub fn list_item(
 }
 
 /// Render a list item element with rich text (bold, italic, strikethrough,
-/// inline code, and clickable links).
-pub fn rich_list_item(
+/// inline code, clickable links, and selection).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn rich_list_item(
     id: impl Into<ElementId>,
     rich_text: &RichText,
     marker: String,
     indent_level: usize,
     style: &TextStyle,
     palette: &InlinePalette,
+    run_cx: RunContext,
     cx: &App,
 ) -> impl IntoElement {
     let indent = rems(indent_level as f32 * 1.5);
@@ -56,7 +58,11 @@ pub fn rich_list_item(
         .line_height(rems(style.size * style.line_height))
         .text_color(text_color)
         .child(div().flex_none().child(marker))
-        .child(div().flex_1().child(rich_text_run(id, rich_text, palette)))
+        .child(
+            div()
+                .flex_1()
+                .child(rich_text_run(id, rich_text, palette, run_cx)),
+        )
 }
 
 /// Get the marker for an unordered list item.

--- a/src/markdown/elements/paragraph.rs
+++ b/src/markdown/elements/paragraph.rs
@@ -2,11 +2,13 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::*, rems, App, ElementId, InteractiveText, ParentElement, SharedString, Styled,
-    StyledText,
+    combine_highlights, div, prelude::*, rems, App, ElementId, HighlightStyle, Hsla, ParentElement,
+    SharedString, Styled, StyledText,
 };
 
 use super::super::inline_style::{InlinePalette, RichText};
+use super::super::selectable_text::SelectableText;
+use super::super::selection::MarkdownSelection;
 use super::super::style::TextStyle;
 
 /// Render a paragraph element with plain text.
@@ -23,24 +25,34 @@ pub fn paragraph(text: impl Into<String>, style: &TextStyle, cx: &App) -> impl I
         .child(text)
 }
 
-/// One rich text run: a `StyledText` carrying the span highlights, wrapped in
-/// `InteractiveText` when any span is a link so the link ranges are clickable
-/// (opening in the default browser) without breaking the text into blocks.
+/// Everything a text run needs to take part in document-wide selection:
+/// the shared state, this run's document-order index, and the highlight
+/// color a selected range paints with.
+pub(crate) struct RunContext {
+    pub selection: MarkdownSelection,
+    pub run: usize,
+    pub selection_background: Hsla,
+}
+
+/// One rich text run: a `StyledText` carrying the span highlights (plus the
+/// selected range as a background highlight), wrapped in [`SelectableText`]
+/// so it drags as part of the document and its link ranges open on click.
 pub(crate) fn rich_text_run(
     id: impl Into<ElementId>,
     rich_text: &RichText,
     palette: &InlinePalette,
+    run_cx: RunContext,
 ) -> gpui::AnyElement {
     let (text, highlights) = rich_text.to_highlights_with(palette);
-    let styled: SharedString = text.into();
-    let styled = StyledText::new(styled).with_highlights(highlights);
-
     let links = rich_text.link_ranges();
+    let styled = selection_styled_text(text, highlights, &run_cx);
+
+    let element = SelectableText::new(id, styled, run_cx.run, run_cx.selection);
     if links.is_empty() {
-        return styled.into_any_element();
+        return element.into_any_element();
     }
     let (ranges, urls): (Vec<_>, Vec<_>) = links.into_iter().unzip();
-    InteractiveText::new(id, styled)
+    element
         .on_click(ranges, move |range_ix, _window, cx| {
             if let Some(url) = urls.get(range_ix) {
                 cx.open_url(url);
@@ -49,13 +61,39 @@ pub(crate) fn rich_text_run(
         .into_any_element()
 }
 
+/// A `StyledText` with the run's selected range merged in as one more
+/// background highlight — which is all "rendering the selection" is.
+pub(crate) fn selection_styled_text(
+    text: String,
+    highlights: Vec<(std::ops::Range<usize>, HighlightStyle)>,
+    run_cx: &RunContext,
+) -> StyledText {
+    let highlights = match run_cx.selection.range_in_run(run_cx.run, text.len()) {
+        Some(range) => combine_highlights(
+            highlights,
+            [(
+                range,
+                HighlightStyle {
+                    background_color: Some(run_cx.selection_background),
+                    ..Default::default()
+                },
+            )],
+        )
+        .collect(),
+        None => highlights,
+    };
+    let text: SharedString = text.into();
+    StyledText::new(text).with_highlights(highlights)
+}
+
 /// Render a paragraph element with rich text (bold, italic, strikethrough,
-/// inline code, and clickable links).
-pub fn rich_paragraph(
+/// inline code, clickable links, and selection).
+pub(crate) fn rich_paragraph(
     id: impl Into<ElementId>,
     rich_text: &RichText,
     style: &TextStyle,
     palette: &InlinePalette,
+    run_cx: RunContext,
     cx: &App,
 ) -> impl IntoElement {
     let theme = cx.theme();
@@ -66,5 +104,5 @@ pub fn rich_paragraph(
         .text_size(rems(style.size))
         .line_height(rems(style.size * style.line_height))
         .text_color(text_color)
-        .child(rich_text_run(id, rich_text, palette))
+        .child(rich_text_run(id, rich_text, palette, run_cx))
 }

--- a/src/markdown/elements/quote.rs
+++ b/src/markdown/elements/quote.rs
@@ -5,7 +5,7 @@ use gpui::{div, prelude::*, px, rems, App, ElementId, ParentElement, Styled};
 
 use super::super::inline_style::{InlinePalette, RichText};
 use super::super::style::TextStyle;
-use super::paragraph::rich_text_run;
+use super::paragraph::{rich_text_run, RunContext};
 
 /// Render a block quote element with plain text.
 pub fn block_quote(
@@ -31,14 +31,16 @@ pub fn block_quote(
 }
 
 /// Render a block quote element with rich text (bold, italic, strikethrough,
-/// inline code, and clickable links).
-pub fn rich_block_quote(
+/// inline code, clickable links, and selection).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn rich_block_quote(
     id: impl Into<ElementId>,
     rich_text: &RichText,
     style: &TextStyle,
     border_color: Option<gpui::Hsla>,
     text_color: Option<gpui::Hsla>,
     palette: &InlinePalette,
+    run_cx: RunContext,
     cx: &App,
 ) -> impl IntoElement {
     let theme = cx.theme();
@@ -52,5 +54,5 @@ pub fn rich_block_quote(
         .line_height(rems(style.size * style.line_height))
         .text_color(text_color.unwrap_or(theme.fg_muted()))
         .italic()
-        .child(rich_text_run(id, rich_text, palette))
+        .child(rich_text_run(id, rich_text, palette, run_cx))
 }

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -21,11 +21,15 @@
 mod elements;
 mod inline_style;
 mod parser;
+mod selectable_text;
+mod selection;
 mod style;
 
 pub use elements::*;
 pub use inline_style::*;
 pub use parser::*;
+pub use selectable_text::SelectableText;
+pub use selection::{MarkdownSelection, SelectionPosition};
 pub use style::*;
 
 use crate::theme::{ActiveTheme, Themeable};
@@ -41,6 +45,8 @@ use pulldown_cmark::{Alignment, Event, Tag, TagEnd};
 pub struct Markdown {
     source: SharedString,
     events: Vec<MarkdownEvent>,
+    /// Document-wide text selection, shared with every rendered run.
+    selection: MarkdownSelection,
 }
 
 /// Parsed markdown event with source range information.
@@ -55,7 +61,11 @@ impl Markdown {
     pub fn new(source: impl Into<SharedString>, _cx: &mut Context<Self>) -> Self {
         let source: SharedString = source.into();
         let events = Self::parse(&source);
-        Self { source, events }
+        Self {
+            source,
+            events,
+            selection: MarkdownSelection::new(),
+        }
     }
 
     /// Get the source text.
@@ -63,11 +73,25 @@ impl Markdown {
         &self.source
     }
 
-    /// Update the markdown content.
+    /// Update the markdown content. Drops any selection — its offsets
+    /// belong to the old text.
     pub fn set_source(&mut self, source: impl Into<SharedString>, cx: &mut Context<Self>) {
         self.source = source.into();
         self.events = Self::parse(&self.source);
+        self.selection.clear();
         cx.notify();
+    }
+
+    /// The document's selection handle — for clearing it from outside (e.g.
+    /// when another document in the same view starts a selection).
+    pub fn selection(&self) -> MarkdownSelection {
+        self.selection.clone()
+    }
+
+    /// The currently selected text, if any — what ⌘C should copy. Routing
+    /// the copy binding is the embedding app's job; this is the value.
+    pub fn selected_text(&self) -> Option<String> {
+        self.selection.selected_text()
     }
 
     fn parse(source: &str) -> Vec<MarkdownEvent> {
@@ -130,9 +154,14 @@ impl RenderOnce for MarkdownElement {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let markdown = self.markdown.read(cx);
         let events = markdown.events.clone();
+        let selection = markdown.selection.clone();
         let style = self.style.clone();
 
-        let renderer = MarkdownRenderer::new(style);
+        // New frame: the previous frame's run layouts are about to be
+        // dropped and must not be hit-tested.
+        selection.begin_frame();
+
+        let renderer = MarkdownRenderer::new(style, selection);
         renderer.render_events(&events, cx)
     }
 }
@@ -150,6 +179,10 @@ struct MarkdownRenderer {
     list_stack: Vec<ListContext>,
     /// Monotonic id source for elements that need one (interactive text).
     element_counter: usize,
+    /// Document-order index for selectable text runs.
+    run_counter: usize,
+    /// Shared selection state, handed to every run.
+    selection: MarkdownSelection,
 
     // Table state
     in_table: bool,
@@ -176,9 +209,10 @@ struct ListContext {
 }
 
 impl MarkdownRenderer {
-    fn new(style: MarkdownStyle) -> Self {
+    fn new(style: MarkdownStyle, selection: MarkdownSelection) -> Self {
         Self {
             style,
+            selection,
             elements: Vec::new(),
             in_heading: None,
             in_code_block: false,
@@ -186,6 +220,7 @@ impl MarkdownRenderer {
             in_image: None,
             list_stack: Vec::new(),
             element_counter: 0,
+            run_counter: 0,
             in_table: false,
             table_alignments: Vec::new(),
             table_rows: Vec::new(),
@@ -402,6 +437,24 @@ impl MarkdownRenderer {
         ElementId::NamedInteger("md-run".into(), self.element_counter as u64)
     }
 
+    /// Selection context for the next text run, in document order. The
+    /// counter here must tick once per selectable run and nowhere else —
+    /// it is the identity the per-frame registry and the highlights agree
+    /// on.
+    fn next_run_cx(&mut self, cx: &App) -> elements::RunContext {
+        let run = self.run_counter;
+        self.run_counter += 1;
+        let theme = cx.theme();
+        elements::RunContext {
+            selection: self.selection.clone(),
+            run,
+            selection_background: self
+                .style
+                .selection_background
+                .unwrap_or_else(|| theme.accent().opacity(0.25)),
+        }
+    }
+
     fn flush_paragraph(&mut self, cx: &App) {
         if self.current_text.is_empty() {
             return;
@@ -409,7 +462,9 @@ impl MarkdownRenderer {
 
         let rich_text = std::mem::take(&mut self.current_text);
         let (id, palette) = (self.next_id(), self.palette(cx));
-        let element = elements::rich_paragraph(id, &rich_text, &self.style.body, &palette, cx);
+        let run_cx = self.next_run_cx(cx);
+        let element =
+            elements::rich_paragraph(id, &rich_text, &self.style.body, &palette, run_cx, cx);
         self.elements.push(element.into_any_element());
     }
 
@@ -430,7 +485,8 @@ impl MarkdownRenderer {
         .clone();
 
         let (id, palette) = (self.next_id(), self.palette(cx));
-        let element = elements::rich_heading(id, &rich_text, &heading_style, &palette, cx);
+        let run_cx = self.next_run_cx(cx);
+        let element = elements::rich_heading(id, &rich_text, &heading_style, &palette, run_cx, cx);
         self.elements.push(element.into_any_element());
     }
 
@@ -441,6 +497,7 @@ impl MarkdownRenderer {
 
         let rich_text = std::mem::take(&mut self.current_text);
         let (id, palette) = (self.next_id(), self.palette(cx));
+        let run_cx = self.next_run_cx(cx);
         let element = elements::rich_block_quote(
             id,
             &rich_text,
@@ -448,6 +505,7 @@ impl MarkdownRenderer {
             self.style.block_quote_border,
             self.style.block_quote_text,
             &palette,
+            run_cx,
             cx,
         );
         self.elements.push(element.into_any_element());
@@ -461,13 +519,16 @@ impl MarkdownRenderer {
         let text = self.current_text.to_plain_text();
         self.current_text.clear();
 
+        let (id, run_cx) = (self.next_id(), self.next_run_cx(cx));
         let element = elements::code_block(
+            id,
             text,
             None,
             &self.style.code,
             &self.style.code_font_family,
             self.style.code_block_bg,
             self.style.code_block_border,
+            run_cx,
             cx,
         );
         self.elements.push(element.into_any_element());
@@ -494,6 +555,7 @@ impl MarkdownRenderer {
 
         let indent_level = self.list_stack.len().saturating_sub(1);
         let (id, palette) = (self.next_id(), self.palette(cx));
+        let run_cx = self.next_run_cx(cx);
         let element = elements::rich_list_item(
             id,
             &rich_text,
@@ -501,6 +563,7 @@ impl MarkdownRenderer {
             indent_level,
             &self.style.body,
             &palette,
+            run_cx,
             cx,
         );
         self.elements.push(element.into_any_element());

--- a/src/markdown/selectable_text.rs
+++ b/src/markdown/selectable_text.rs
@@ -1,0 +1,273 @@
+//! A text run that participates in document-wide selection.
+//!
+//! Wraps [`StyledText`], modeled on gpui's `InteractiveText`, and adds the
+//! two behaviours markdown needs from every run:
+//!
+//! - **Selection**: mouse down anchors a drag; while dragging, the anchor
+//!   run's element registers window-wide move/up handlers and hit-tests the
+//!   pointer against the *whole document's* registered runs (via the shared
+//!   [`MarkdownSelection`]), so a drag flows across paragraphs, headings and
+//!   code blocks. Double-click selects a word, triple-click the run.
+//! - **Link clicks**: clickable ranges still open on click — but only when
+//!   the mouse didn't move between down and up. A drag that starts on a link
+//!   selects; a click on one follows it.
+//!
+//! Rendering the selection is not this element's job: the renderer injects
+//! the selected range as one more background highlight before construction,
+//! so painting stays plain `StyledText`.
+
+use std::mem;
+use std::ops::Range;
+use std::rc::Rc;
+
+use gpui::{
+    App, Bounds, CursorStyle, DispatchPhase, Element, ElementId, GlobalElementId, Hitbox,
+    HitboxBehavior, IntoElement, LayoutId, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
+    SharedString, StyledText, TextLayout, Window,
+};
+
+use super::selection::{word_range_at, MarkdownSelection, SelectionPosition};
+
+/// One run's layout and text, registered into the document's selection state
+/// for the current frame.
+pub(crate) struct RegisteredRun {
+    pub layout: TextLayout,
+    pub text: SharedString,
+}
+
+impl RegisteredRun {
+    /// A registry entry with no layout behind it — selection-state tests
+    /// exercise text assembly, which never touches the layout.
+    #[cfg(test)]
+    pub(crate) fn for_test(text: &str) -> Self {
+        Self {
+            layout: TextLayout::default(),
+            text: SharedString::from(text.to_string()),
+        }
+    }
+}
+
+type ClickListener = Rc<dyn Fn(usize, &mut Window, &mut App)>;
+
+/// A selectable (and optionally link-bearing) text run.
+pub struct SelectableText {
+    element_id: ElementId,
+    text: StyledText,
+    /// This run's index in document order — its identity in the selection.
+    run: usize,
+    selection: MarkdownSelection,
+    clickable_ranges: Vec<Range<usize>>,
+    click_listener: Option<ClickListener>,
+}
+
+impl SelectableText {
+    pub fn new(
+        id: impl Into<ElementId>,
+        text: StyledText,
+        run: usize,
+        selection: MarkdownSelection,
+    ) -> Self {
+        Self {
+            element_id: id.into(),
+            text,
+            run,
+            selection,
+            clickable_ranges: Vec::new(),
+            click_listener: None,
+        }
+    }
+
+    /// `listener` is called with the index of the clicked range — same
+    /// contract as `InteractiveText::on_click`, except a click is only a
+    /// click when the pointer didn't drag between down and up.
+    pub fn on_click(
+        mut self,
+        ranges: Vec<Range<usize>>,
+        listener: impl Fn(usize, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.clickable_ranges = ranges;
+        self.click_listener = Some(Rc::new(listener));
+        self
+    }
+}
+
+impl IntoElement for SelectableText {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for SelectableText {
+    type RequestLayoutState = ();
+    type PrepaintState = Hitbox;
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.element_id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        inspector_id: Option<&gpui::InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        self.text.request_layout(None, inspector_id, window, cx)
+    }
+
+    fn prepaint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&gpui::InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        state: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Hitbox {
+        self.text
+            .prepaint(None, inspector_id, bounds, state, window, cx);
+        window.insert_hitbox(bounds, HitboxBehavior::Normal)
+    }
+
+    fn paint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        inspector_id: Option<&gpui::InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        hitbox: &mut Hitbox,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let text_layout = self.text.layout().clone();
+        let selection = self.selection.clone();
+        let run = self.run;
+
+        // This frame's registry entry — hit-testing and copy read from it.
+        selection.register_run(
+            run,
+            RegisteredRun {
+                layout: text_layout.clone(),
+                text: SharedString::from(text_layout.text()),
+            },
+        );
+
+        // Cursor: ibeam over text; pointing hand over a link.
+        let over_link = text_layout
+            .index_for_position(window.mouse_position())
+            .is_ok_and(|ix| {
+                self.clickable_ranges
+                    .iter()
+                    .any(|range| range.contains(&ix))
+            });
+        window.set_cursor_style(
+            if over_link {
+                CursorStyle::PointingHand
+            } else {
+                CursorStyle::IBeam
+            },
+            hitbox,
+        );
+
+        // Mouse down in this run: anchor a drag (single click), select a
+        // word (double), or the whole run (triple). Also the place a click
+        // anywhere *outside* the document clears its selection.
+        {
+            let selection = selection.clone();
+            let text_layout = text_layout.clone();
+            let hitbox = hitbox.clone();
+            window.on_mouse_event(move |event: &MouseDownEvent, phase, window, _cx| {
+                if phase != DispatchPhase::Bubble {
+                    return;
+                }
+                if hitbox.is_hovered(window) {
+                    let offset = match text_layout.index_for_position(event.position) {
+                        Ok(offset) => offset,
+                        Err(nearest) => nearest,
+                    };
+                    match event.click_count {
+                        1 => selection.begin_drag(SelectionPosition { run, offset }),
+                        2 => {
+                            if let Some(text) = selection.run_text(run) {
+                                selection.select_in_run(run, word_range_at(&text, offset));
+                            }
+                        }
+                        _ => {
+                            let len = selection.run_text(run).map_or(0, |text| text.len());
+                            selection.select_in_run(run, 0..len);
+                        }
+                    }
+                    window.refresh();
+                } else if run == 0
+                    && !selection.is_empty()
+                    && !selection.point_in_any_run(event.position)
+                {
+                    // Run 0 speaks for the document: a press outside every
+                    // run drops the selection. (Guarded to one run so the
+                    // clear doesn't run once per block.)
+                    selection.clear();
+                    window.refresh();
+                }
+            });
+        }
+
+        // While a drag that started in this run is live, this element owns
+        // the document-wide move/up handlers. Deliberately not hitbox-gated:
+        // the pointer outruns the run immediately, and crossing into another
+        // block is the point.
+        if selection.drag_anchor_run() == Some(run) {
+            {
+                let selection = selection.clone();
+                window.on_mouse_event(move |event: &MouseMoveEvent, phase, window, _cx| {
+                    if phase != DispatchPhase::Bubble || !selection.is_dragging() {
+                        return;
+                    }
+                    if let Some(position) = selection.position_for_point(event.position) {
+                        selection.update_head(position);
+                        window.refresh();
+                    }
+                });
+            }
+            {
+                let selection = selection.clone();
+                let text_layout = text_layout.clone();
+                let hitbox = hitbox.clone();
+                let clickable_ranges = mem::take(&mut self.clickable_ranges);
+                let click_listener = self.click_listener.clone();
+                window.on_mouse_event(move |event: &MouseUpEvent, phase, window, cx| {
+                    if phase != DispatchPhase::Bubble || !selection.is_dragging() {
+                        return;
+                    }
+                    let was_click = selection.range().is_none();
+                    selection.end_drag();
+                    // A press-and-release with no movement on a link opens
+                    // it; with movement, the selection wins and the link
+                    // stays put.
+                    if was_click && hitbox.is_hovered(window) {
+                        if let (Some(listener), Ok(ix)) = (
+                            click_listener.as_ref(),
+                            text_layout.index_for_position(event.position),
+                        ) {
+                            if let Some(range_ix) = clickable_ranges
+                                .iter()
+                                .position(|range| range.contains(&ix))
+                            {
+                                listener(range_ix, window, cx);
+                            }
+                        }
+                    }
+                    window.refresh();
+                });
+            }
+        }
+
+        self.text
+            .paint(None, inspector_id, bounds, &mut (), &mut (), window, cx);
+    }
+}

--- a/src/markdown/selection.rs
+++ b/src/markdown/selection.rs
@@ -1,0 +1,398 @@
+//! Text selection across a markdown document.
+//!
+//! A markdown document renders as many text runs (paragraphs, headings,
+//! quotes, list items, code blocks), each its own element with its own
+//! layout. Selection has to read as one document anyway: the user drags from
+//! a heading into the paragraph below it and expects both to highlight, and
+//! ⌘C to yield both. This module holds the document-wide state that makes
+//! that work.
+//!
+//! The state lives behind an `Rc<RefCell<…>>` handle ([`MarkdownSelection`])
+//! owned by the [`Markdown`](super::Markdown) entity and cloned into every
+//! run element. Two kinds of data live in it:
+//!
+//! - The **selection** itself: an anchor and head, each a `(run, byte offset)`
+//!   position. Persistent across frames.
+//! - A per-frame **registry** of run layouts and texts, repopulated on every
+//!   paint. Mouse handlers hit-test against it (position → run + byte), and
+//!   `selected_text` reads run texts out of it. It is a view of the last
+//!   painted frame, never authoritative state.
+//!
+//! Selection is per-document, but coherence across documents mostly falls
+//! out: a mouse press inside one document lands outside every run of its
+//! siblings, which clears them (see the run-0 handler in
+//! [`SelectableText`](super::selectable_text::SelectableText)). An embedding
+//! app only needs [`MarkdownSelection::clear`] for programmatic cases.
+
+use std::cell::RefCell;
+use std::ops::Range;
+use std::rc::Rc;
+
+use gpui::{Bounds, Pixels, Point, SharedString};
+
+use super::selectable_text::RegisteredRun;
+
+/// A position in the document: which run, and a byte offset into its text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SelectionPosition {
+    pub run: usize,
+    pub offset: usize,
+}
+
+#[derive(Default)]
+pub(crate) struct SelectionState {
+    /// Selection endpoints in document order — `anchor` is where the drag
+    /// started, `head` where it currently is. Either order.
+    anchor: Option<SelectionPosition>,
+    head: Option<SelectionPosition>,
+    /// A drag is in progress (mouse down, not yet up).
+    dragging: bool,
+    /// Per-frame registry, indexed by run. Rebuilt every paint; `None` slots
+    /// are runs that did not paint this frame.
+    runs: Vec<Option<RegisteredRun>>,
+}
+
+/// Shared handle to a document's selection state. Cheap to clone; every run
+/// element of one document holds the same handle.
+#[derive(Clone, Default)]
+pub struct MarkdownSelection(Rc<RefCell<SelectionState>>);
+
+impl MarkdownSelection {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start a new frame: forget the previous frame's run registry (layouts
+    /// from a dropped frame must not be hit-tested). Called from the
+    /// markdown element's render, before any run paints.
+    pub(crate) fn begin_frame(&self) {
+        self.0.borrow_mut().runs.clear();
+    }
+
+    /// Record a run's layout and text for this frame.
+    pub(crate) fn register_run(&self, run: usize, entry: RegisteredRun) {
+        let mut state = self.0.borrow_mut();
+        if state.runs.len() <= run {
+            state.runs.resize_with(run + 1, || None);
+        }
+        state.runs[run] = Some(entry);
+    }
+
+    // --- drag lifecycle (mouse handlers) ---
+
+    pub(crate) fn begin_drag(&self, position: SelectionPosition) {
+        let mut state = self.0.borrow_mut();
+        state.anchor = Some(position);
+        state.head = Some(position);
+        state.dragging = true;
+    }
+
+    pub(crate) fn update_head(&self, position: SelectionPosition) {
+        let mut state = self.0.borrow_mut();
+        if state.dragging {
+            state.head = Some(position);
+        }
+    }
+
+    pub(crate) fn end_drag(&self) {
+        let mut state = self.0.borrow_mut();
+        state.dragging = false;
+        // A drag that never moved is a click, not a selection.
+        if state.anchor == state.head {
+            state.anchor = None;
+            state.head = None;
+        }
+    }
+
+    pub(crate) fn is_dragging(&self) -> bool {
+        self.0.borrow().dragging
+    }
+
+    /// The run the current drag started in, if a drag is in progress. That
+    /// run's element owns the document-wide mouse handlers for the drag.
+    pub(crate) fn drag_anchor_run(&self) -> Option<usize> {
+        let state = self.0.borrow();
+        state.dragging.then_some(state.anchor?.run)
+    }
+
+    /// Select `range` within one run (double-click word, triple-click run).
+    pub(crate) fn select_in_run(&self, run: usize, range: Range<usize>) {
+        let mut state = self.0.borrow_mut();
+        state.anchor = Some(SelectionPosition {
+            run,
+            offset: range.start,
+        });
+        state.head = Some(SelectionPosition {
+            run,
+            offset: range.end,
+        });
+        state.dragging = false;
+    }
+
+    /// Drop the selection entirely.
+    pub fn clear(&self) {
+        let mut state = self.0.borrow_mut();
+        state.anchor = None;
+        state.head = None;
+        state.dragging = false;
+    }
+
+    /// Whether a non-empty selection exists.
+    pub fn is_empty(&self) -> bool {
+        let state = self.0.borrow();
+        match (state.anchor, state.head) {
+            (Some(anchor), Some(head)) => anchor == head,
+            _ => true,
+        }
+    }
+
+    /// The selection's endpoints in document order, if non-empty.
+    pub fn range(&self) -> Option<(SelectionPosition, SelectionPosition)> {
+        let state = self.0.borrow();
+        let (anchor, head) = (state.anchor?, state.head?);
+        if anchor == head {
+            return None;
+        }
+        Some((anchor.min(head), anchor.max(head)))
+    }
+
+    /// The selected byte range within run `run` of length `len`, if any —
+    /// what the renderer highlights.
+    pub(crate) fn range_in_run(&self, run: usize, len: usize) -> Option<Range<usize>> {
+        let (start, end) = self.range()?;
+        if run < start.run || run > end.run {
+            return None;
+        }
+        let from = if run == start.run { start.offset } else { 0 };
+        let to = if run == end.run { end.offset } else { len };
+        let (from, to) = (from.min(len), to.min(len));
+        (from < to).then_some(from..to)
+    }
+
+    /// The selected text, assembled across runs in document order, runs
+    /// joined with newlines. `None` when nothing is selected.
+    pub fn selected_text(&self) -> Option<String> {
+        let (start, end) = self.range()?;
+        let state = self.0.borrow();
+        let mut parts = Vec::new();
+        for run in start.run..=end.run {
+            let Some(Some(entry)) = state.runs.get(run) else {
+                continue;
+            };
+            let text: &str = &entry.text;
+            let from = if run == start.run { start.offset } else { 0 };
+            let to = if run == end.run {
+                end.offset
+            } else {
+                text.len()
+            };
+            let (from, to) = (
+                clamp_to_char_boundary(text, from.min(text.len())),
+                clamp_to_char_boundary(text, to.min(text.len())),
+            );
+            if from < to {
+                parts.push(text[from..to].to_string());
+            }
+        }
+        (!parts.is_empty()).then(|| parts.join("\n"))
+    }
+
+    // --- hit testing against the last painted frame ---
+
+    /// The document position for a window-space point: the run whose bounds
+    /// contain (or are vertically nearest to) the point, and the nearest
+    /// byte offset within it. `None` when no runs painted.
+    pub(crate) fn position_for_point(&self, point: Point<Pixels>) -> Option<SelectionPosition> {
+        let state = self.0.borrow();
+        let mut best: Option<(Pixels, SelectionPosition)> = None;
+        for (run, entry) in state.runs.iter().enumerate() {
+            let Some(entry) = entry else { continue };
+            let offset = match entry.layout.index_for_position(point) {
+                Ok(offset) => {
+                    // Inside this run — exact hit, no contest.
+                    return Some(SelectionPosition { run, offset });
+                }
+                Err(nearest) => nearest,
+            };
+            let distance = vertical_distance(entry.layout.bounds(), point);
+            let position = SelectionPosition { run, offset };
+            if best.map_or(true, |(best_distance, _)| distance < best_distance) {
+                best = Some((distance, position));
+            }
+        }
+        best.map(|(_, position)| position)
+    }
+
+    /// Whether the point falls within any registered run's bounds — used to
+    /// tell "clicked elsewhere in this document" from "clicked outside it".
+    pub(crate) fn point_in_any_run(&self, point: Point<Pixels>) -> bool {
+        self.0.borrow().runs.iter().flatten().any(|entry| {
+            let bounds = entry.layout.bounds();
+            bounds.contains(&point)
+        })
+    }
+
+    /// The registered text of run `run`, if it painted this frame.
+    pub(crate) fn run_text(&self, run: usize) -> Option<SharedString> {
+        self.0
+            .borrow()
+            .runs
+            .get(run)?
+            .as_ref()
+            .map(|entry| entry.text.clone())
+    }
+}
+
+/// Vertical distance from `point` to `bounds` (zero when inside the band) —
+/// the tie-breaker for points between blocks, where every run reports a
+/// nearest index and the closest band should win.
+fn vertical_distance(bounds: Bounds<Pixels>, point: Point<Pixels>) -> Pixels {
+    if point.y < bounds.top() {
+        bounds.top() - point.y
+    } else if point.y > bounds.bottom() {
+        point.y - bounds.bottom()
+    } else {
+        Pixels::ZERO
+    }
+}
+
+/// Round `ix` down to a char boundary so slicing can't panic mid-codepoint
+/// (offsets come from layout hit-tests, which are glyph-aligned, but clamp
+/// defensively — a stale offset against updated text must not crash).
+fn clamp_to_char_boundary(text: &str, mut ix: usize) -> usize {
+    while ix > 0 && !text.is_char_boundary(ix) {
+        ix -= 1;
+    }
+    ix
+}
+
+/// The word range around byte `ix` in `text` — double-click selection.
+/// Falls back to the whole text when `ix` lands outside any word.
+pub(crate) fn word_range_at(text: &str, ix: usize) -> Range<usize> {
+    use unicode_segmentation::UnicodeSegmentation;
+    let ix = clamp_to_char_boundary(text, ix.min(text.len()));
+    for (start, word) in text.split_word_bound_indices() {
+        let end = start + word.len();
+        if ix >= start && ix < end {
+            return start..end;
+        }
+    }
+    0..text.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pos(run: usize, offset: usize) -> SelectionPosition {
+        SelectionPosition { run, offset }
+    }
+
+    #[test]
+    fn a_drag_that_never_moved_is_not_a_selection() {
+        let selection = MarkdownSelection::new();
+        selection.begin_drag(pos(0, 4));
+        selection.end_drag();
+        assert!(selection.is_empty());
+        assert!(selection.range().is_none());
+    }
+
+    #[test]
+    fn range_normalizes_backwards_drags() {
+        let selection = MarkdownSelection::new();
+        selection.begin_drag(pos(2, 10));
+        selection.update_head(pos(0, 3));
+        selection.end_drag();
+        let (start, end) = selection.range().unwrap();
+        assert_eq!(start, pos(0, 3));
+        assert_eq!(end, pos(2, 10));
+    }
+
+    #[test]
+    fn range_in_run_covers_middle_runs_fully_and_ends_partially() {
+        let selection = MarkdownSelection::new();
+        selection.begin_drag(pos(0, 3));
+        selection.update_head(pos(2, 5));
+        selection.end_drag();
+
+        assert_eq!(selection.range_in_run(0, 10), Some(3..10));
+        assert_eq!(selection.range_in_run(1, 7), Some(0..7));
+        assert_eq!(selection.range_in_run(2, 10), Some(0..5));
+        assert_eq!(selection.range_in_run(3, 10), None);
+    }
+
+    #[test]
+    fn range_in_run_clamps_to_run_length() {
+        // A head offset past the run's end (text shrank under a live
+        // selection) must clamp, not panic or produce an inverted range.
+        let selection = MarkdownSelection::new();
+        selection.begin_drag(pos(0, 8));
+        selection.update_head(pos(0, 20));
+        selection.end_drag();
+        assert_eq!(selection.range_in_run(0, 10), Some(8..10));
+        assert_eq!(selection.range_in_run(0, 4), None);
+    }
+
+    #[test]
+    fn selected_text_joins_runs_in_document_order() {
+        let selection = MarkdownSelection::new();
+        selection.register_run(0, RegisteredRun::for_test("alpha beta"));
+        selection.register_run(1, RegisteredRun::for_test("gamma"));
+        selection.register_run(2, RegisteredRun::for_test("delta epsilon"));
+
+        selection.begin_drag(pos(0, 6));
+        selection.update_head(pos(2, 5));
+        selection.end_drag();
+
+        assert_eq!(
+            selection.selected_text().as_deref(),
+            Some("beta\ngamma\ndelta")
+        );
+    }
+
+    #[test]
+    fn selected_text_survives_a_run_that_did_not_paint() {
+        let selection = MarkdownSelection::new();
+        selection.register_run(0, RegisteredRun::for_test("first"));
+        selection.register_run(2, RegisteredRun::for_test("third"));
+
+        selection.begin_drag(pos(0, 0));
+        selection.update_head(pos(2, 5));
+        selection.end_drag();
+
+        assert_eq!(selection.selected_text().as_deref(), Some("first\nthird"));
+    }
+
+    #[test]
+    fn selected_text_clamps_offsets_to_char_boundaries() {
+        let selection = MarkdownSelection::new();
+        selection.register_run(0, RegisteredRun::for_test("héllo"));
+        // "é" is two bytes (1..3); an offset of 2 splits it.
+        selection.begin_drag(pos(0, 2));
+        selection.update_head(pos(0, 5));
+        selection.end_drag();
+        assert_eq!(selection.selected_text().as_deref(), Some("éll"));
+    }
+
+    #[test]
+    fn double_click_word_ranges() {
+        assert_eq!(word_range_at("alpha beta", 1), 0..5);
+        assert_eq!(word_range_at("alpha beta", 7), 6..10);
+        // On the space between words: the space is its own "word bound".
+        assert_eq!(word_range_at("alpha beta", 5), 5..6);
+        // Unicode word.
+        assert_eq!(word_range_at("héllo wörld", 2), 0..6);
+    }
+
+    #[test]
+    fn clearing_forgets_everything() {
+        let selection = MarkdownSelection::new();
+        selection.begin_drag(pos(0, 0));
+        selection.update_head(pos(1, 4));
+        selection.end_drag();
+        assert!(!selection.is_empty());
+        selection.clear();
+        assert!(selection.is_empty());
+        assert!(selection.selected_text().is_none());
+    }
+}

--- a/src/markdown/style.rs
+++ b/src/markdown/style.rs
@@ -136,6 +136,8 @@ pub struct MarkdownStyle {
     pub rule_color: Option<Hsla>,
     /// Link text color.
     pub link_color: Option<Hsla>,
+    /// Background for selected text (default: theme accent at 25%).
+    pub selection_background: Option<Hsla>,
 }
 
 impl Default for MarkdownStyle {
@@ -163,6 +165,7 @@ impl Default for MarkdownStyle {
             block_quote_text: None,
             rule_color: None,
             link_color: None,
+            selection_background: None,
         }
     }
 }
@@ -216,6 +219,12 @@ impl MarkdownStyle {
     /// Set the link color.
     pub fn link_color(mut self, color: Hsla) -> Self {
         self.link_color = Some(color);
+        self
+    }
+
+    /// Set the background color for selected text.
+    pub fn selection_background(mut self, color: Hsla) -> Self {
+        self.selection_background = Some(color);
         self
     }
 }


### PR DESCRIPTION
Text selection for markdown — drag across paragraphs, headings, quotes, list items, and code blocks as one document; double-click selects a word, triple-click a block; the selected text is exposed for ⌘C.

## Architecture

Markdown renders as many independent text runs, but selection must read as one document. Three pieces make that work:

**`MarkdownSelection`** — shared state on the `Markdown` entity: anchor/head positions as `(run, byte offset)`, plus a per-frame registry of run layouts and texts. Mouse handlers hit-test against the registry (position → run + offset), and `selected_text()` assembles the copy value from it. The registry is a view of the last painted frame, rebuilt on every render — never authoritative state.

**`SelectableText`** — a text-run element modeled directly on gpui's `InteractiveText`. Mouse down anchors a drag; while one is live, the anchor run's element owns window-wide move/up handlers (deliberately not hitbox-gated — the pointer outruns the run immediately) and hit-tests against *every* registered run: an exact hit inside a run wins, otherwise the vertically nearest run's nearest offset, which is what makes dragging through the gaps between blocks feel continuous. **Link semantics**: clickable ranges still open on click, but only a true click — any movement between down and up means the selection wins and the link stays put.

**Rendering** — the selected range is merged into the run's highlights as one more background highlight via `gpui::combine_highlights` before `StyledText` construction. No custom quad painting; painting stays plain `StyledText`. Color from `MarkdownStyle::selection_background` (default: theme accent at 25%).

## API

- `Markdown::selected_text() -> Option<String>` — the copy value (runs joined with newlines; offsets clamped to char boundaries so a stale position against updated text can't panic). Routing ⌘C is the embedding app's job; `examples/markdown_selection.rs` shows the complete wiring.
- `Markdown::selection() -> MarkdownSelection` — the handle, for programmatic `clear()`.
- `set_source` clears the selection (its offsets belong to the old text).
- Selection requires the **retained-entity** form (`Markdown::new` held by your view) — the `markdown()` per-call convenience creates a fresh entity per frame and can't hold one. Documented on the example.
- Cross-document coherence mostly falls out: a press inside one document lands outside every run of its siblings, which clears them. Apps only need `clear()` for programmatic cases.

## Deliberately not covered

- **Table cells** — custom layout without stable element ids, same reason they aren't clickable.
- **Auto-scroll** when a drag leaves the viewport (awkward inside a virtualized list; separable).
- **Shift-click** extension and cross-*document* selection.

## API note

The `rich_paragraph` / `rich_heading` / `rich_block_quote` / `rich_list_item` / `code_block` constructors move to `pub(crate)`: they now carry per-run selection context whose run-index contract is internal, and `MarkdownElement` is the public API. (#122 had already broken their signatures.)

## Verified

186 lib tests pass (9 new: drag normalization, per-run range math including clamping under shrinking text, multi-run text assembly, char-boundary safety, unicode word ranges). `cargo fmt` clean; clippy warning count identical to main (66 pre-existing). The new example builds and runs without panic — construction, frame lifecycle, registration, and highlight paths exercised live; interactive drag/copy behavior needs hands on a mouse, which this machine's harness can't fake.