### PR TITLE
Context menu: attach to an element, not to a view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Breaking Changes
+
+- Context Menu was rewritten. It is now an element you attach to a trigger you
+  have already built — `context_menu(id, my_element).menu(|menu, window, cx| …)`
+  — rather than an `Entity<ContextMenuState>` the view has to own and render.
+  `ContextMenuState`, `ContextMenu::trigger` and `menu_separator` are gone;
+  `menu_item` takes only a label, and entries are assembled with
+  `menu.item(…).separator().header(…)` instead of a `Vec<MenuEntry>`
+
+### Added
+
+- Context Menu: gpui action support (`menu_item("Rename").action(Box::new(Rename))`),
+  which dispatches to whatever was focused before the menu opened and reads the
+  item's keyboard shortcut from the keymap instead of hardcoding it
+- Context Menu: section headers, checkmark items (`toggled`), keyboard
+  navigation that skips separators and disabled items, hover and keyboard focus
+  kept in sync, scroll-into-view in long menus, focus restored on dismiss, and
+  edge-aware positioning
+- `examples/context_menu.rs`, demonstrating both closure- and action-driven items
+
 ## [0.6.0] - 2026-08-14
 
 ### Breaking Changes

--- a/examples/context_menu.rs
+++ b/examples/context_menu.rs
@@ -1,0 +1,229 @@
+#![allow(missing_docs)]
+//! Context menu demo.
+//!
+//! Right-click a row to act on it. Shows the two ways an item does its work:
+//!
+//! - `on_click`, a closure — used here for the per-row pin/delete actions,
+//!   which reach back into the view through its entity handle.
+//! - `action`, a gpui action — used for "Duplicate". Its shortcut is read from
+//!   the keymap rather than written into the menu, and it dispatches to
+//!   whatever had focus before the menu opened, so the same handler serves the
+//!   menu and the keyboard.
+//!
+//! Run with: cargo run --example context_menu
+
+use gpui::{
+    actions, div, prelude::*, px, size, App, Application, Bounds, Context, FocusHandle, Focusable,
+    IntoElement, KeyBinding, ParentElement, Render, SharedString, Styled, Window, WindowBounds,
+    WindowOptions,
+};
+use gpuikit::elements::context_menu::{context_menu, menu_item};
+use gpuikit::layout::v_stack;
+use gpuikit::theme::{ActiveTheme, Themeable};
+use gpuikit::DefaultIcons;
+
+actions!(context_menu_example, [Duplicate]);
+
+struct Row {
+    name: SharedString,
+    pinned: bool,
+}
+
+struct Demo {
+    focus_handle: FocusHandle,
+    rows: Vec<Row>,
+    selected: usize,
+    status: SharedString,
+}
+
+impl Demo {
+    fn new(cx: &mut Context<Self>) -> Self {
+        Self {
+            focus_handle: cx.focus_handle(),
+            rows: vec![
+                Row {
+                    name: "Untitled draft".into(),
+                    pinned: false,
+                },
+                Row {
+                    name: "Quarterly plan".into(),
+                    pinned: true,
+                },
+                Row {
+                    name: "Release notes".into(),
+                    pinned: false,
+                },
+            ],
+            selected: 0,
+            status: "Right-click a row.".into(),
+        }
+    }
+
+    /// Handles the action whether it arrives from the menu or from ⌘D.
+    ///
+    /// The menu dispatches to the focus that was in place before it opened, so
+    /// this fires either way without the menu having to know it exists.
+    fn duplicate(&mut self, _: &Duplicate, _window: &mut Window, cx: &mut Context<Self>) {
+        let Some(row) = self.rows.get(self.selected) else {
+            return;
+        };
+        let copy = format!("{} copy", row.name);
+        self.status = format!("Duplicated “{}”", row.name).into();
+        self.rows.insert(
+            self.selected + 1,
+            Row {
+                name: copy.into(),
+                pinned: false,
+            },
+        );
+        cx.notify();
+    }
+
+    fn render_row(&self, index: usize, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let row = &self.rows[index];
+        let selected = self.selected == index;
+        let name = row.name.clone();
+        let pinned = row.pinned;
+        let this = cx.entity();
+        let last_row = self.rows.len() == 1;
+
+        // The trigger is an ordinary element built from view state; the menu
+        // wraps what the view already renders rather than replacing it.
+        let trigger = div()
+            .id(("row", index))
+            .flex()
+            .items_center()
+            .gap_2()
+            .w(px(320.))
+            .px_3()
+            .py_2()
+            .rounded_md()
+            .text_sm()
+            .when(selected, |this| this.bg(theme.surface_secondary()))
+            .hover(|style| style.bg(theme.surface_secondary()))
+            .on_click(cx.listener(move |this, _, _window, cx| {
+                this.selected = index;
+                cx.notify();
+            }))
+            .when(pinned, |this| {
+                this.child(
+                    DefaultIcons::star()
+                        .size(px(12.))
+                        .text_color(theme.fg_muted()),
+                )
+            })
+            .child(name.clone());
+
+        context_menu(("row-menu", index), trigger).menu(move |menu, _window, _cx| {
+            let name = name.clone();
+            menu.header(name.clone())
+                .item(
+                    menu_item("Duplicate")
+                        .icon(DefaultIcons::copy)
+                        // No .kbd() — the shortcut comes from the keymap.
+                        .action(Box::new(Duplicate)),
+                )
+                .item(menu_item("Pinned").toggled(pinned).on_click({
+                    let this = this.clone();
+                    move |_window, cx| {
+                        this.update(cx, |demo: &mut Demo, cx| {
+                            demo.rows[index].pinned = !demo.rows[index].pinned;
+                            demo.status = if demo.rows[index].pinned {
+                                format!("Pinned “{}”", demo.rows[index].name).into()
+                            } else {
+                                format!("Unpinned “{}”", demo.rows[index].name).into()
+                            };
+                            cx.notify();
+                        });
+                    }
+                }))
+                .separator()
+                .item(
+                    menu_item("Delete")
+                        .icon(DefaultIcons::trash)
+                        .destructive()
+                        // The last row cannot go: a disabled item explains why
+                        // the command exists but is unavailable, where hiding
+                        // it would just look like a missing feature.
+                        .disabled(last_row)
+                        .on_click({
+                            let this = this.clone();
+                            move |_window, cx| {
+                                this.update(cx, |demo: &mut Demo, cx| {
+                                    let removed = demo.rows.remove(index);
+                                    demo.selected = demo.selected.min(demo.rows.len() - 1);
+                                    demo.status = format!("Deleted “{}”", removed.name).into();
+                                    cx.notify();
+                                });
+                            }
+                        }),
+                )
+        })
+    }
+}
+
+impl Focusable for Demo {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for Demo {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let rows = (0..self.rows.len())
+            .map(|index| self.render_row(index, cx).into_any_element())
+            .collect::<Vec<_>>();
+        let theme = cx.theme();
+
+        div()
+            .track_focus(&self.focus_handle)
+            // Scopes ⌘D to this view, and is what lets the menu find the
+            // binding to display next to "Duplicate".
+            .key_context("Demo")
+            .on_action(cx.listener(Self::duplicate))
+            .size_full()
+            .bg(theme.bg())
+            .text_color(theme.fg())
+            .flex()
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap_6()
+            .child(
+                v_stack()
+                    .gap_1()
+                    .items_center()
+                    .child(div().text_lg().child("Context Menu"))
+                    .child(div().text_sm().text_color(theme.fg_muted()).child(
+                        "Right-click a row. Arrow keys move, Enter chooses, Escape closes.",
+                    )),
+            )
+            .child(v_stack().gap_1().children(rows))
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(theme.fg_muted())
+                    .child(self.status.clone()),
+            )
+    }
+}
+
+fn main() {
+    Application::with_platform(gpui_platform::current_platform(false))
+        .with_assets(gpuikit::assets())
+        .run(|cx: &mut App| {
+            gpuikit::init(cx);
+            cx.bind_keys([KeyBinding::new("cmd-d", Duplicate, Some("Demo"))]);
+
+            let bounds = Bounds::centered(None, size(px(560.), px(420.)), cx);
+            cx.open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    ..Default::default()
+                },
+                |_window, cx| cx.new(Demo::new),
+            )
+            .unwrap();
+        });
+}

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -21,7 +21,7 @@ use gpuikit::{
         card::card,
         checkbox::{checkbox, Checkbox},
         collapsible::{collapsible, Collapsible},
-        context_menu::{context_menu, menu_item, menu_separator, ContextMenuState},
+        context_menu::{context_menu, menu_item},
         dialog::{dialog, DialogState},
         dropdown::{dropdown, DropdownState},
         field::{field, LabelPosition},
@@ -176,7 +176,8 @@ struct Showcase {
     textarea_example: Entity<InputState>,
     popover_example: Entity<PopoverState>,
     dialog_example: Entity<DialogState>,
-    context_menu_example: Entity<ContextMenuState>,
+    context_menu_pinned: bool,
+    context_menu_status: SharedString,
 }
 
 impl Showcase {
@@ -419,35 +420,6 @@ impl Showcase {
             )
         });
 
-        let context_menu_example = cx.new(|_cx| {
-            ContextMenuState::new(
-                context_menu("showcase-context-menu")
-                    .trigger(|_window, cx| {
-                        let theme = cx.theme();
-                        div()
-                            .px_4()
-                            .py_3()
-                            .rounded_md()
-                            .border_1()
-                            .border_color(theme.border())
-                            .bg(theme.surface())
-                            .text_sm()
-                            .text_color(theme.fg_muted())
-                            .child("Right-click here")
-                            .into_any_element()
-                    })
-                    .menu(|_window, _cx| {
-                        vec![
-                            menu_item("cut", "Cut").kbd("Cmd+X").into(),
-                            menu_item("copy", "Copy").kbd("Cmd+C").into(),
-                            menu_item("paste", "Paste").kbd("Cmd+V").into(),
-                            menu_separator().into(),
-                            menu_item("delete", "Delete").destructive().into(),
-                        ]
-                    }),
-            )
-        });
-
         Self {
             focus_handle: cx.focus_handle(),
             active_page: Rc::new(RefCell::new(SharedString::from("button"))),
@@ -476,7 +448,8 @@ impl Showcase {
             textarea_example,
             popover_example,
             dialog_example,
-            context_menu_example,
+            context_menu_pinned: true,
+            context_menu_status: "No action chosen yet.".into(),
         }
     }
 
@@ -1640,8 +1613,25 @@ impl Showcase {
 
     fn render_context_menu_page(&self, cx: &Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
+        let this = cx.entity();
+        let pinned = self.context_menu_pinned;
+
+        // The trigger is an ordinary element. The menu attaches to what the
+        // view already renders instead of taking over how it is built.
+        let target = div()
+            .px_8()
+            .py_6()
+            .rounded_md()
+            .border_1()
+            .border_color(theme.border())
+            .bg(theme.surface())
+            .text_sm()
+            .text_color(theme.fg_muted())
+            .child("Right-click here");
+
         v_stack()
             .gap_4()
+            .items_start()
             .child(
                 div()
                     .text_lg()
@@ -1649,7 +1639,68 @@ impl Showcase {
                     .text_color(theme.fg_muted())
                     .child("Context Menu"),
             )
-            .child(self.context_menu_example.clone())
+            .child(
+                context_menu("showcase-context-menu", target).menu(move |menu, _window, _cx| {
+                    let choose = |label: &'static str| {
+                        let this = this.clone();
+                        move |_window: &mut Window, cx: &mut App| {
+                            this.update(cx, |showcase: &mut Showcase, cx| {
+                                showcase.context_menu_status = format!("Chose “{label}”").into();
+                                cx.notify();
+                            });
+                        }
+                    };
+
+                    menu.header("Edit")
+                        .item(
+                            menu_item("Cut")
+                                .icon(DefaultIcons::scissors)
+                                .kbd("⌘X")
+                                .on_click(choose("Cut")),
+                        )
+                        .item(
+                            menu_item("Copy")
+                                .icon(DefaultIcons::copy)
+                                .kbd("⌘C")
+                                .on_click(choose("Copy")),
+                        )
+                        .item(
+                            menu_item("Paste")
+                                .icon(DefaultIcons::clipboard)
+                                .kbd("⌘V")
+                                // Nothing to paste: shown, but not choosable.
+                                .disabled(true),
+                        )
+                        .separator()
+                        .item(menu_item("Pinned").toggled(pinned).on_click({
+                            let this = this.clone();
+                            move |_window, cx| {
+                                this.update(cx, |showcase: &mut Showcase, cx| {
+                                    showcase.context_menu_pinned = !showcase.context_menu_pinned;
+                                    showcase.context_menu_status = if showcase.context_menu_pinned {
+                                        "Pinned".into()
+                                    } else {
+                                        "Unpinned".into()
+                                    };
+                                    cx.notify();
+                                });
+                            }
+                        }))
+                        .separator()
+                        .item(
+                            menu_item("Delete")
+                                .icon(DefaultIcons::trash)
+                                .destructive()
+                                .on_click(choose("Delete")),
+                        )
+                }),
+            )
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(theme.fg_muted())
+                    .child(self.context_menu_status.clone()),
+            )
     }
 
     fn render_toast_page(

--- a/src/elements/context_menu.rs
+++ b/src/elements/context_menu.rs
@@ -1,482 +1,1024 @@
 //! Context Menu
 //!
-//! A right-click triggered menu for displaying contextual actions.
+//! A menu of actions, opened by right-clicking the element it is attached to.
 //!
-//! # Example
+//! The menu attaches to an element you have already built, so it composes with
+//! whatever a view renders — a list row, a card, a piece of text — without
+//! restructuring that view:
 //!
 //! ```ignore
-//! use gpuikit::elements::context_menu::{context_menu, menu_item, menu_separator};
+//! use gpuikit::elements::context_menu::{context_menu, menu_item};
 //!
-//! let context_menu_state = cx.new(|_cx| {
-//!     ContextMenuState::new(
-//!         context_menu("file-actions")
-//!             .trigger(|_window, _cx| div().p_4().child("Right-click me").into_any_element())
-//!             .menu(|_window, _cx| {
-//!                 vec![
-//!                     menu_item("copy", "Copy").kbd("Cmd+C").into(),
-//!                     menu_item("paste", "Paste").kbd("Cmd+V").into(),
-//!                     menu_separator().into(),
-//!                     menu_item("delete", "Delete").destructive().into(),
-//!                 ]
-//!             })
-//!     )
-//! });
+//! context_menu("row", self.render_row(ix, cx)).menu(move |menu, _window, _cx| {
+//!     menu.item(menu_item("Copy").kbd("⌘C").on_click(|_window, _cx| { /* … */ }))
+//!         .item(menu_item("Rename").action(Box::new(Rename)))
+//!         .separator()
+//!         .item(menu_item("Delete").destructive().disabled(!can_delete))
+//! })
 //! ```
+//!
+//! Entries are built once, when the menu opens, so they see the state at the
+//! moment of the click. Give each menu a stable, unique id — the open/closed
+//! state is keyed on it, so rows in a list need the row index in their id.
+//!
+//! An item can carry a closure ([`MenuItem::on_click`]), a gpui action
+//! ([`MenuItem::action`]), or both. An action is the better default where one
+//! exists: it dispatches to whatever had focus before the menu opened, and its
+//! keyboard shortcut is read from the keymap rather than hardcoded.
 
-use crate::elements::kbd::{kbd, KbdSize};
-use crate::theme::{ActiveTheme, Themeable};
-use gpui::{
-    anchored, deferred, div, point, prelude::*, px, Anchor, AnyElement, App, Context, DismissEvent,
-    ElementId, Entity, EventEmitter, FocusHandle, Focusable, IntoElement, MouseButton,
-    ParentElement, Point, Render, SharedString, Styled, Svg, Window,
-};
 use std::rc::Rc;
 
-/// A menu entry - either an item or a separator.
-pub enum MenuEntry {
-    Item(MenuItem),
-    Separator,
-}
+use gpui::{
+    anchored, deferred, div, prelude::*, px, Action, AnyElement, App, Context, ElementId, Entity,
+    FocusHandle, IntoElement, KeyDownEvent, MouseButton, MouseDownEvent, ParentElement, Pixels,
+    Point, ScrollHandle, SharedString, Styled, Svg, Window,
+};
 
-impl From<MenuItem> for MenuEntry {
-    fn from(item: MenuItem) -> Self {
-        MenuEntry::Item(item)
-    }
-}
+use crate::elements::kbd::{kbd, KbdSize};
+use crate::icons::Icons;
+use crate::theme::{ActiveTheme, Themeable};
 
-impl From<MenuSeparator> for MenuEntry {
-    fn from(_: MenuSeparator) -> Self {
-        MenuEntry::Separator
-    }
-}
-
-/// Icon factory type for menu items.
+/// Builds the leading icon of a menu item.
 pub type IconFactory = Rc<dyn Fn() -> Svg>;
 
-/// A menu item with label, optional icon, optional keyboard shortcut.
+type ClickHandler = Rc<dyn Fn(&mut Window, &mut App)>;
+type MenuBuilder = Rc<dyn Fn(MenuItems, &mut Window, &mut App) -> MenuItems>;
+
+/// A single action in a context menu.
 pub struct MenuItem {
-    id: ElementId,
     label: SharedString,
     icon: Option<IconFactory>,
     kbd: Option<SharedString>,
+    action: Option<Box<dyn Action>>,
+    on_click: Option<ClickHandler>,
     disabled: bool,
     destructive: bool,
-    on_click: Option<Rc<dyn Fn(&mut Window, &mut App)>>,
+    toggled: Option<bool>,
 }
 
-/// Creates a new menu item.
-pub fn menu_item(id: impl Into<ElementId>, label: impl Into<SharedString>) -> MenuItem {
-    MenuItem::new(id, label)
+/// Creates a menu item with the given label.
+pub fn menu_item(label: impl Into<SharedString>) -> MenuItem {
+    MenuItem::new(label)
 }
-
-/// Creates a menu separator.
-pub fn menu_separator() -> MenuSeparator {
-    MenuSeparator
-}
-
-/// A separator entry in the menu.
-pub struct MenuSeparator;
 
 impl MenuItem {
-    pub fn new(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Self {
+    /// Creates a menu item with the given label.
+    pub fn new(label: impl Into<SharedString>) -> Self {
         Self {
-            id: id.into(),
             label: label.into(),
             icon: None,
             kbd: None,
+            action: None,
+            on_click: None,
             disabled: false,
             destructive: false,
-            on_click: None,
+            toggled: None,
         }
     }
 
-    /// Set an icon for this menu item using a factory function.
-    pub fn icon(mut self, icon_factory: impl Fn() -> Svg + 'static) -> Self {
-        self.icon = Some(Rc::new(icon_factory));
+    /// Sets a leading icon.
+    pub fn icon(mut self, icon: impl Fn() -> Svg + 'static) -> Self {
+        self.icon = Some(Rc::new(icon));
         self
     }
 
-    /// Set a keyboard shortcut display for this menu item.
+    /// Sets the keyboard shortcut shown after the label.
+    ///
+    /// Only needed for items with no [`action`](Self::action) — an item that
+    /// has one takes its shortcut from the keymap.
     pub fn kbd(mut self, shortcut: impl Into<SharedString>) -> Self {
         self.kbd = Some(shortcut.into());
         self
     }
 
-    /// Mark this item as disabled.
+    /// Dispatches the given action when this item is chosen.
+    ///
+    /// The action goes to whatever was focused before the menu opened, so it
+    /// lands on the view the menu was opened over rather than on the menu. The
+    /// item's keyboard shortcut is taken from the action's highest-precedence
+    /// binding unless [`kbd`](Self::kbd) overrides it.
+    pub fn action(mut self, action: Box<dyn Action>) -> Self {
+        self.action = Some(action);
+        self
+    }
+
+    /// Runs the given callback when this item is chosen.
+    ///
+    /// Runs after the menu has closed and focus has been restored, so a handler
+    /// is free to open a dialog or move focus itself.
+    pub fn on_click(mut self, handler: impl Fn(&mut Window, &mut App) + 'static) -> Self {
+        self.on_click = Some(Rc::new(handler));
+        self
+    }
+
+    /// Greys the item out and stops it from being chosen or focused.
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
     }
 
-    /// Mark this item as destructive (will display in danger color).
+    /// Renders the item in the theme's danger color.
     pub fn destructive(mut self) -> Self {
         self.destructive = true;
         self
     }
 
-    /// Set a click handler for this menu item.
-    pub fn on_click(mut self, handler: impl Fn(&mut Window, &mut App) + 'static) -> Self {
-        self.on_click = Some(Rc::new(handler));
+    /// Renders the item with a checkmark when `toggled` is true.
+    ///
+    /// Items that show a toggle reserve room for the checkmark either way, so
+    /// a group of them stays aligned as the state changes.
+    pub fn toggled(mut self, toggled: bool) -> Self {
+        self.toggled = Some(toggled);
         self
     }
 }
 
-/// The popup menu that displays context menu items.
-pub struct ContextMenuPopup {
+/// One entry in a context menu.
+///
+/// Built through [`MenuItems`] rather than directly.
+#[non_exhaustive]
+pub enum MenuEntry {
+    /// An action.
+    Item(MenuItem),
+    /// A horizontal rule between groups of items.
+    Separator,
+    /// A label introducing the group of items below it.
+    Header(SharedString),
+}
+
+/// The entries of a context menu.
+///
+/// Handed to the [`ContextMenu::menu`] callback to be filled in.
+#[derive(Default)]
+pub struct MenuItems {
     entries: Vec<MenuEntry>,
-    focus_handle: FocusHandle,
-    focused_index: Option<usize>,
 }
 
-impl EventEmitter<DismissEvent> for ContextMenuPopup {}
-
-impl Focusable for ContextMenuPopup {
-    fn focus_handle(&self, _cx: &App) -> FocusHandle {
-        self.focus_handle.clone()
-    }
-}
-
-impl ContextMenuPopup {
-    pub fn build(entries: Vec<MenuEntry>, window: &mut Window, cx: &mut App) -> Entity<Self> {
-        cx.new(|cx| {
-            let focus_handle = cx.focus_handle();
-            window.focus(&focus_handle, cx);
-            Self {
-                entries,
-                focus_handle,
-                focused_index: None,
-            }
-        })
+impl MenuItems {
+    /// Creates an empty set of entries.
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    fn dismiss(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        cx.emit(DismissEvent);
+    /// Appends an item.
+    pub fn item(mut self, item: MenuItem) -> Self {
+        self.entries.push(MenuEntry::Item(item));
+        self
     }
 
-    fn select_item(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(MenuEntry::Item(item)) = self.entries.get(index) {
-            if !item.disabled {
-                if let Some(on_click) = &item.on_click {
-                    let on_click = on_click.clone();
-                    on_click(window, cx);
-                }
-                cx.emit(DismissEvent);
-            }
+    /// Appends several items.
+    pub fn items(mut self, items: impl IntoIterator<Item = MenuItem>) -> Self {
+        self.entries.extend(items.into_iter().map(MenuEntry::Item));
+        self
+    }
+
+    /// Appends a separator.
+    ///
+    /// Separators that would land at the start of the menu or next to another
+    /// separator are dropped, so a menu assembled from optional groups does not
+    /// need to track which of them ended up present.
+    pub fn separator(mut self) -> Self {
+        if matches!(
+            self.entries.last(),
+            None | Some(MenuEntry::Separator) | Some(MenuEntry::Header(_))
+        ) {
+            return self;
         }
+        self.entries.push(MenuEntry::Separator);
+        self
     }
 
-    fn focusable_item_count(&self) -> usize {
-        self.entries
-            .iter()
-            .filter(|e| matches!(e, MenuEntry::Item(item) if !item.disabled))
-            .count()
+    /// Appends a section header.
+    pub fn header(mut self, label: impl Into<SharedString>) -> Self {
+        self.entries.push(MenuEntry::Header(label.into()));
+        self
     }
 
-    fn index_to_focusable(&self, index: usize) -> Option<usize> {
-        let mut focusable_count = 0;
-        for (i, entry) in self.entries.iter().enumerate() {
-            if let MenuEntry::Item(item) = entry {
-                if !item.disabled {
-                    if focusable_count == index {
-                        return Some(i);
-                    }
-                    focusable_count += 1;
-                }
-            }
-        }
-        None
-    }
-
-    fn focusable_to_index(&self, entry_index: usize) -> Option<usize> {
-        let mut focusable_count = 0;
-        for (i, entry) in self.entries.iter().enumerate() {
-            if let MenuEntry::Item(item) = entry {
-                if !item.disabled {
-                    if i == entry_index {
-                        return Some(focusable_count);
-                    }
-                    focusable_count += 1;
-                }
-            }
-        }
-        None
-    }
-
-    fn move_focus(&mut self, delta: i32, cx: &mut Context<Self>) {
-        let count = self.focusable_item_count();
-        if count == 0 {
-            return;
-        }
-
-        let current = self
-            .focused_index
-            .and_then(|i| self.focusable_to_index(i))
-            .unwrap_or(if delta > 0 { count - 1 } else { 0 });
-
-        let new_focusable = if delta > 0 {
-            (current + 1) % count
+    /// Applies `f` only when `condition` holds.
+    pub fn when(self, condition: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if condition {
+            f(self)
         } else {
-            (current + count - 1) % count
-        };
-
-        self.focused_index = self.index_to_focusable(new_focusable);
-        cx.notify();
-    }
-}
-
-impl Render for ContextMenuPopup {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let focus_handle = self.focus_handle.clone();
-        let theme = cx.theme();
-
-        div()
-            .id("context-menu-popup")
-            .track_focus(&focus_handle)
-            .on_mouse_down_out(cx.listener(|this, _, window, cx| {
-                this.dismiss(window, cx);
-            }))
-            .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, window, cx| {
-                match event.keystroke.key.as_str() {
-                    "escape" => this.dismiss(window, cx),
-                    "up" => this.move_focus(-1, cx),
-                    "down" => this.move_focus(1, cx),
-                    "enter" | " " => {
-                        if let Some(index) = this.focused_index {
-                            this.select_item(index, window, cx);
-                        }
-                    }
-                    _ => {}
-                }
-            }))
-            .min_w(px(160.))
-            .max_h(px(400.))
-            .overflow_y_scroll()
-            .on_scroll_wheel(|_, _, cx| {
-                cx.stop_propagation();
-            })
-            .bg(theme.surface())
-            .border_1()
-            .border_color(theme.border())
-            .rounded_md()
-            .shadow_lg()
-            .py_1()
-            .flex()
-            .flex_col()
-            .children(self.entries.iter().enumerate().map(|(index, entry)| {
-                match entry {
-                    MenuEntry::Separator => div()
-                        .my_1()
-                        .h(px(1.))
-                        .bg(theme.border_subtle())
-                        .into_any_element(),
-                    MenuEntry::Item(item) => {
-                        let is_focused = self.focused_index == Some(index);
-                        let theme = cx.theme();
-                        let id = item.id.clone();
-                        let disabled = item.disabled;
-                        let destructive = item.destructive;
-
-                        let text_color = if disabled {
-                            theme.fg_disabled()
-                        } else if destructive {
-                            theme.danger()
-                        } else {
-                            theme.fg()
-                        };
-
-                        let mut row = div()
-                            .id(id)
-                            .px_3()
-                            .py_1()
-                            .mx_1()
-                            .rounded_sm()
-                            .text_xs()
-                            .flex()
-                            .items_center()
-                            .gap_3()
-                            .text_color(text_color);
-
-                        if disabled {
-                            row = row.cursor_not_allowed();
-                        } else {
-                            row = row
-                                .cursor_pointer()
-                                .when(is_focused, |this| this.bg(theme.surface_secondary()))
-                                .hover(|style| style.bg(theme.surface_secondary()))
-                                .on_click(cx.listener(move |this, _, window, cx| {
-                                    this.select_item(index, window, cx);
-                                }));
-                        }
-
-                        // Icon (if any)
-                        let icon_element = item.icon.as_ref().map(|factory| {
-                            factory()
-                                .size(px(14.))
-                                .text_color(if disabled {
-                                    theme.fg_disabled()
-                                } else {
-                                    theme.fg_muted()
-                                })
-                                .flex_shrink_0()
-                        });
-
-                        // Label
-                        let label_element = div().flex_1().child(item.label.clone());
-
-                        // Keyboard shortcut (if any)
-                        let kbd_element = item
-                            .kbd
-                            .clone()
-                            .map(|shortcut| kbd(shortcut).size(KbdSize::Small));
-
-                        row = row.when_some(icon_element, |this, icon| this.child(icon));
-                        row = row.child(label_element);
-                        row = row.when_some(kbd_element, |this, kbd| this.child(kbd));
-
-                        row.into_any_element()
-                    }
-                }
-            }))
-    }
-}
-
-type MenuBuilder = Rc<dyn Fn(&mut Window, &mut App) -> Vec<MenuEntry>>;
-type TriggerRender = Rc<dyn Fn(&mut Window, &mut App) -> AnyElement>;
-
-/// Builder for creating a context menu component.
-pub struct ContextMenu {
-    id: ElementId,
-    trigger_render: Option<TriggerRender>,
-    menu_builder: Option<MenuBuilder>,
-}
-
-/// Creates a new context menu builder.
-pub fn context_menu(id: impl Into<ElementId>) -> ContextMenu {
-    ContextMenu::new(id)
-}
-
-impl ContextMenu {
-    pub fn new(id: impl Into<ElementId>) -> Self {
-        Self {
-            id: id.into(),
-            trigger_render: None,
-            menu_builder: None,
+            self
         }
     }
 
-    /// Set the trigger element via a render callback that responds to right-click.
-    pub fn trigger(
-        mut self,
-        render: impl Fn(&mut Window, &mut App) -> AnyElement + 'static,
-    ) -> Self {
-        self.trigger_render = Some(Rc::new(render));
-        self
+    /// Whether no entries have been added.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
     }
 
-    /// Set the menu builder function that creates menu entries.
-    pub fn menu(
-        mut self,
-        builder: impl Fn(&mut Window, &mut App) -> Vec<MenuEntry> + 'static,
-    ) -> Self {
-        self.menu_builder = Some(Rc::new(builder));
-        self
+    /// Drops trailing separators and headers, which are what a conditionally
+    /// built menu leaves behind when its last group turns out to be empty. A
+    /// menu that reduces to nothing this way does not open at all.
+    fn finish(mut self) -> Vec<MenuEntry> {
+        while matches!(
+            self.entries.last(),
+            Some(MenuEntry::Separator) | Some(MenuEntry::Header(_))
+        ) {
+            self.entries.pop();
+        }
+        self.entries
     }
 }
 
-/// Stateful context menu component that manages the popup.
-pub struct ContextMenuState {
-    id: ElementId,
-    trigger_render: Option<TriggerRender>,
-    menu_builder: Option<MenuBuilder>,
-    popup: Option<Entity<ContextMenuPopup>>,
-    cursor_position: Point<gpui::Pixels>,
+/// Indices of the entries that can be focused: items that are not disabled.
+/// Separators and headers are skipped over by keyboard navigation.
+fn selectable_indices(entries: &[MenuEntry]) -> Vec<usize> {
+    entries
+        .iter()
+        .enumerate()
+        .filter_map(|(ix, entry)| match entry {
+            MenuEntry::Item(item) if !item.disabled => Some(ix),
+            _ => None,
+        })
+        .collect()
 }
 
-impl ContextMenuState {
-    pub fn new(context_menu: ContextMenu) -> Self {
+/// The entry `delta` steps from `current`, wrapping at both ends.
+///
+/// With nothing focused yet, arrowing down enters the menu at the top and
+/// arrowing up enters it at the bottom.
+fn next_focus(selectable: &[usize], current: Option<usize>, delta: isize) -> Option<usize> {
+    if selectable.is_empty() {
+        return None;
+    }
+    match current.and_then(|ix| selectable.iter().position(|&s| s == ix)) {
+        Some(pos) => {
+            let moved = (pos as isize + delta).rem_euclid(selectable.len() as isize);
+            selectable.get(moved as usize).copied()
+        }
+        None if delta >= 0 => selectable.first().copied(),
+        None => selectable.last().copied(),
+    }
+}
+
+/// An open menu: where it sits, what is in it, and what is focused.
+struct OpenMenu {
+    position: Point<Pixels>,
+    entries: Vec<MenuEntry>,
+    focused: Option<usize>,
+    restore_focus: Option<FocusHandle>,
+    scroll: ScrollHandle,
+}
+
+/// The open/closed state of one context menu, held across frames.
+struct MenuState {
+    focus_handle: FocusHandle,
+    open: Option<OpenMenu>,
+}
+
+impl MenuState {
+    fn new(cx: &mut Context<Self>) -> Self {
         Self {
-            id: context_menu.id,
-            trigger_render: context_menu.trigger_render,
-            menu_builder: context_menu.menu_builder,
-            popup: None,
-            cursor_position: point(px(0.), px(0.)),
+            focus_handle: cx.focus_handle(),
+            open: None,
         }
     }
 
-    /// Check if the context menu is currently open.
-    pub fn is_open(&self) -> bool {
-        self.popup.is_some()
-    }
-
-    /// Close the context menu.
-    pub fn close(&mut self, cx: &mut Context<Self>) {
-        self.popup = None;
-        cx.notify();
-    }
-
-    fn open_menu(
+    fn open(
         &mut self,
-        position: Point<gpui::Pixels>,
+        position: Point<Pixels>,
+        entries: Vec<MenuEntry>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(builder) = &self.menu_builder {
-            let entries = builder(window, cx);
-            self.cursor_position = position;
+        if entries.is_empty() {
+            return;
+        }
 
-            let popup = ContextMenuPopup::build(entries, window, cx);
+        let restore_focus = window.focused(cx);
+        self.open = Some(OpenMenu {
+            position,
+            entries,
+            focused: None,
+            restore_focus,
+            scroll: ScrollHandle::new(),
+        });
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+    }
 
-            cx.subscribe_in(
-                &popup,
-                window,
-                |this, _, _event: &DismissEvent, _window, cx| {
-                    this.popup = None;
-                    cx.notify();
-                },
-            )
-            .detach();
+    fn close(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(open) = self.open.take() else {
+            return;
+        };
+        if let Some(handle) = open.restore_focus {
+            window.focus(&handle, cx);
+        }
+        cx.notify();
+    }
 
-            self.popup = Some(popup);
-            cx.notify();
+    /// Moves focus by `delta` selectable entries, wrapping at both ends.
+    fn move_focus(&mut self, delta: isize, cx: &mut Context<Self>) {
+        let Some(open) = self.open.as_mut() else {
+            return;
+        };
+        let Some(next) = next_focus(&selectable_indices(&open.entries), open.focused, delta) else {
+            return;
+        };
+
+        open.focused = Some(next);
+        open.scroll.scroll_to_item(next);
+        cx.notify();
+    }
+
+    /// Focuses the first (`delta >= 0`) or last selectable entry.
+    fn focus_edge(&mut self, delta: isize, cx: &mut Context<Self>) {
+        if let Some(open) = self.open.as_mut() {
+            open.focused = None;
+        }
+        self.move_focus(delta, cx);
+    }
+
+    /// Follows the pointer, so the mouse and the keyboard never disagree about
+    /// which entry is about to be chosen.
+    fn focus_from_hover(&mut self, index: usize, cx: &mut Context<Self>) {
+        let Some(open) = self.open.as_mut() else {
+            return;
+        };
+        if open.focused == Some(index) {
+            return;
+        }
+        open.focused = Some(index);
+        cx.notify();
+    }
+
+    fn activate(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(open) = self.open.as_ref() else {
+            return;
+        };
+        let Some(MenuEntry::Item(item)) = open.entries.get(index) else {
+            return;
+        };
+        if item.disabled {
+            return;
+        }
+
+        let on_click = item.on_click.clone();
+        let action = item.action.as_ref().map(|action| action.boxed_clone());
+        let restore_focus = open.restore_focus.clone();
+
+        // Close first: the handler may want to move focus or open something of
+        // its own, and the action has to reach the view the menu covered rather
+        // than the menu itself.
+        self.close(window, cx);
+
+        if let Some(on_click) = on_click {
+            on_click(window, cx);
+        }
+        if let Some(action) = action {
+            match restore_focus {
+                Some(handle) => handle.dispatch_action(action.as_ref(), window, cx),
+                None => window.dispatch_action(action, cx),
+            }
         }
     }
 }
 
-impl Render for ContextMenuState {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let cursor_pos = self.cursor_position;
+/// What one entry looks like this frame, lifted out of the state entity so the
+/// borrow ends before the elements are built.
+enum Row {
+    Item {
+        index: usize,
+        label: SharedString,
+        icon: Option<IconFactory>,
+        kbd: Option<SharedString>,
+        disabled: bool,
+        destructive: bool,
+        toggled: Option<bool>,
+        focused: bool,
+    },
+    Separator,
+    Header(SharedString),
+}
 
-        let trigger_element = if let Some(ref render) = self.trigger_render {
-            Some(render(window, cx))
-        } else {
-            None
+/// The shortcut to show for an item: its explicit one, else its action's
+/// highest-precedence binding. An action with no binding shows nothing.
+fn shortcut_for(item: &MenuItem, window: &Window) -> Option<SharedString> {
+    if let Some(shortcut) = item.kbd.clone() {
+        return Some(shortcut);
+    }
+    let action = item.action.as_ref()?;
+    let binding = window.highest_precedence_binding_for_action(action.as_ref())?;
+    let text = binding
+        .keystrokes()
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(" ");
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.into())
+    }
+}
+
+fn rows_for(open: &OpenMenu, window: &Window) -> Vec<Row> {
+    open.entries
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| match entry {
+            MenuEntry::Separator => Row::Separator,
+            MenuEntry::Header(label) => Row::Header(label.clone()),
+            MenuEntry::Item(item) => Row::Item {
+                index,
+                label: item.label.clone(),
+                icon: item.icon.clone(),
+                kbd: shortcut_for(item, window),
+                disabled: item.disabled,
+                destructive: item.destructive,
+                toggled: item.toggled,
+                focused: open.focused == Some(index),
+            },
+        })
+        .collect()
+}
+
+/// A context menu attached to a trigger element.
+///
+/// Created with [`context_menu`].
+#[derive(IntoElement)]
+pub struct ContextMenu {
+    id: ElementId,
+    trigger: AnyElement,
+    builder: Option<MenuBuilder>,
+    min_width: Pixels,
+    max_height: Pixels,
+}
+
+/// Attaches a context menu to `trigger`.
+///
+/// The id must be stable across frames and unique among its siblings — the
+/// menu's open state is keyed on it.
+pub fn context_menu(id: impl Into<ElementId>, trigger: impl IntoElement) -> ContextMenu {
+    ContextMenu {
+        id: id.into(),
+        trigger: trigger.into_any_element(),
+        builder: None,
+        min_width: px(180.),
+        max_height: px(420.),
+    }
+}
+
+impl ContextMenu {
+    /// Sets the callback that fills in the menu's entries.
+    ///
+    /// Called each time the menu opens, so the entries reflect the state at the
+    /// moment of the click. A menu that comes back empty does not open.
+    pub fn menu(
+        mut self,
+        builder: impl Fn(MenuItems, &mut Window, &mut App) -> MenuItems + 'static,
+    ) -> Self {
+        self.builder = Some(Rc::new(builder));
+        self
+    }
+
+    /// Sets the menu's minimum width. Defaults to 180px.
+    pub fn min_width(mut self, width: Pixels) -> Self {
+        self.min_width = width;
+        self
+    }
+
+    /// Sets the height past which the menu scrolls. Defaults to 420px.
+    pub fn max_height(mut self, height: Pixels) -> Self {
+        self.max_height = height;
+        self
+    }
+}
+
+impl RenderOnce for ContextMenu {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let state = window.use_keyed_state(self.id.clone(), cx, |_window, cx| MenuState::new(cx));
+
+        let ContextMenu {
+            trigger,
+            builder,
+            min_width,
+            max_height,
+            ..
+        } = self;
+
+        // Everything the popup needs, taken by value so the borrow of the state
+        // entity ends here rather than running through element construction.
+        let open = {
+            let menu = state.read(cx);
+            menu.open.as_ref().map(|open| {
+                (
+                    open.position,
+                    rows_for(open, window),
+                    open.scroll.clone(),
+                    menu.focus_handle.clone(),
+                )
+            })
         };
 
+        let trigger = div()
+            .when_some(builder, |el, builder| {
+                let state = state.clone();
+                el.on_mouse_down(
+                    MouseButton::Right,
+                    move |event: &MouseDownEvent, window, cx| {
+                        window.prevent_default();
+                        let entries = builder(MenuItems::new(), window, cx).finish();
+                        let position = event.position;
+                        state.update(cx, |menu, cx| menu.open(position, entries, window, cx));
+                        cx.stop_propagation();
+                    },
+                )
+            })
+            .child(trigger);
+
         div()
-            .id(self.id.clone())
-            .relative()
-            .child(
-                div()
-                    .on_mouse_down(
-                        MouseButton::Right,
-                        cx.listener(move |this, event: &gpui::MouseDownEvent, window, cx| {
-                            window.prevent_default();
-                            this.open_menu(event.position, window, cx);
-                            cx.stop_propagation();
-                        }),
-                    )
-                    .when_some(trigger_element, |el, trigger| el.child(trigger)),
-            )
-            .when_some(self.popup.clone(), move |this, popup| {
-                this.child(
+            .child(trigger)
+            .when_some(open, |el, (position, rows, scroll, focus_handle)| {
+                el.child(
                     deferred(
                         anchored()
-                            .anchor(Anchor::TopLeft)
-                            .position(cursor_pos)
-                            .child(div().occlude().child(popup)),
+                            .position(position)
+                            // Keep the whole menu on screen near a window edge.
+                            .snap_to_window_with_margin(px(8.))
+                            .child(div().occlude().child(menu_popup(
+                                rows,
+                                scroll,
+                                focus_handle,
+                                state,
+                                min_width,
+                                max_height,
+                                cx,
+                            ))),
                     )
                     .with_priority(1),
                 )
             })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn menu_popup(
+    rows: Vec<Row>,
+    scroll: ScrollHandle,
+    focus_handle: FocusHandle,
+    state: Entity<MenuState>,
+    min_width: Pixels,
+    max_height: Pixels,
+    cx: &App,
+) -> impl IntoElement {
+    let theme = cx.theme();
+
+    div()
+        .id("gpuikit-context-menu")
+        .track_focus(&focus_handle)
+        .on_mouse_down_out({
+            let state = state.clone();
+            move |_, window, cx| {
+                state.update(cx, |menu, cx| menu.close(window, cx));
+            }
+        })
+        .on_key_down({
+            let state = state.clone();
+            move |event: &KeyDownEvent, window, cx| {
+                let handled = match event.keystroke.key.as_str() {
+                    "escape" => {
+                        state.update(cx, |menu, cx| menu.close(window, cx));
+                        true
+                    }
+                    "up" => {
+                        state.update(cx, |menu, cx| menu.move_focus(-1, cx));
+                        true
+                    }
+                    "down" => {
+                        state.update(cx, |menu, cx| menu.move_focus(1, cx));
+                        true
+                    }
+                    "home" => {
+                        state.update(cx, |menu, cx| menu.focus_edge(1, cx));
+                        true
+                    }
+                    "end" => {
+                        state.update(cx, |menu, cx| menu.focus_edge(-1, cx));
+                        true
+                    }
+                    "enter" | "space" => state.update(cx, |menu, cx| {
+                        let focused = menu.open.as_ref().and_then(|open| open.focused);
+                        match focused {
+                            Some(index) => {
+                                menu.activate(index, window, cx);
+                                true
+                            }
+                            None => false,
+                        }
+                    }),
+                    _ => false,
+                };
+                if handled {
+                    cx.stop_propagation();
+                }
+            }
+        })
+        .min_w(min_width)
+        .max_h(max_height)
+        .overflow_y_scroll()
+        .track_scroll(&scroll)
+        .on_scroll_wheel(|_, _, cx| {
+            cx.stop_propagation();
+        })
+        .bg(theme.surface())
+        .border_1()
+        .border_color(theme.border())
+        .rounded_md()
+        .shadow_lg()
+        .py_1()
+        .flex()
+        .flex_col()
+        .children(
+            rows.into_iter()
+                .map(|row| menu_row(row, state.clone(), cx).into_any_element()),
+        )
+}
+
+fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement {
+    let theme = cx.theme();
+
+    match row {
+        Row::Separator => div()
+            .my_1()
+            .h(px(1.))
+            .bg(theme.border_subtle())
+            .into_any_element(),
+        Row::Header(label) => div()
+            .px_3()
+            .pt_2()
+            .pb_1()
+            .text_xs()
+            .text_color(theme.fg_muted())
+            .child(label)
+            .into_any_element(),
+        Row::Item {
+            index,
+            label,
+            icon,
+            kbd: shortcut,
+            disabled,
+            destructive,
+            toggled,
+            focused,
+        } => {
+            let text_color = if disabled {
+                theme.fg_disabled()
+            } else if destructive {
+                theme.danger()
+            } else {
+                theme.fg()
+            };
+            let icon_color = if disabled {
+                theme.fg_disabled()
+            } else if destructive {
+                theme.danger()
+            } else {
+                theme.fg_muted()
+            };
+
+            let mut row = div()
+                .id(("gpuikit-context-menu-item", index))
+                .px_3()
+                .py_1()
+                .mx_1()
+                .rounded_sm()
+                .text_xs()
+                .flex()
+                .items_center()
+                .gap_2()
+                .text_color(text_color);
+
+            if disabled {
+                row = row.cursor_not_allowed();
+            } else {
+                row = row
+                    .cursor_pointer()
+                    .when(focused, |this| this.bg(theme.surface_secondary()))
+                    .on_mouse_move({
+                        let state = state.clone();
+                        move |_, _window, cx| {
+                            state.update(cx, |menu, cx| menu.focus_from_hover(index, cx));
+                        }
+                    })
+                    .on_click({
+                        let state = state.clone();
+                        move |_, window, cx| {
+                            state.update(cx, |menu, cx| menu.activate(index, window, cx));
+                        }
+                    });
+            }
+
+            // Items that can toggle keep the checkmark's width whether or not
+            // they are on, so a group of them stays aligned.
+            if let Some(toggled) = toggled {
+                row = row.child(div().w(px(14.)).flex_shrink_0().when(toggled, |this| {
+                    this.child(Icons::check().size(px(14.)).text_color(icon_color))
+                }));
+            }
+
+            let row = row
+                .when_some(icon, |this, icon| {
+                    this.child(icon().size(px(14.)).text_color(icon_color).flex_shrink_0())
+                })
+                .child(div().flex_1().child(label))
+                .when_some(shortcut, |this, shortcut| {
+                    this.child(kbd(shortcut).size(KbdSize::Small))
+                });
+
+            // Lets a test find where a row was actually laid out, so clicking
+            // one does not mean hardcoding the menu's metrics.
+            #[cfg(test)]
+            let row = row.debug_selector(|| format!("gpuikit-context-menu-item-{index}"));
+
+            row.into_any_element()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{point, Modifiers, MouseUpEvent, Render, TestAppContext, VisualTestContext};
+    use std::cell::RefCell;
+
+    fn labels(entries: &[MenuEntry]) -> Vec<&str> {
+        entries
+            .iter()
+            .map(|entry| match entry {
+                MenuEntry::Item(item) => item.label.as_ref(),
+                MenuEntry::Separator => "---",
+                MenuEntry::Header(label) => label.as_ref(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn separators_never_lead_or_double_up() {
+        let entries = MenuItems::new()
+            .separator()
+            .item(menu_item("Copy"))
+            .separator()
+            .separator()
+            .item(menu_item("Delete"))
+            .finish();
+
+        assert_eq!(labels(&entries), vec!["Copy", "---", "Delete"]);
+    }
+
+    #[test]
+    fn trailing_separators_are_dropped() {
+        // The shape a conditionally-built menu takes when its last group is empty.
+        let entries = MenuItems::new()
+            .item(menu_item("Copy"))
+            .separator()
+            .when(false, |menu| menu.item(menu_item("Delete")))
+            .finish();
+
+        assert_eq!(labels(&entries), vec!["Copy"]);
+    }
+
+    #[test]
+    fn an_empty_trailing_section_leaves_nothing_behind() {
+        let entries = MenuItems::new()
+            .item(menu_item("Copy"))
+            .separator()
+            .header("Danger")
+            .when(false, |menu| menu.item(menu_item("Delete")))
+            .finish();
+
+        assert_eq!(labels(&entries), vec!["Copy"]);
+    }
+
+    #[test]
+    fn a_menu_that_reduces_to_nothing_is_empty() {
+        let entries = MenuItems::new()
+            .header("Danger")
+            .when(false, |menu| menu.item(menu_item("Delete")))
+            .finish();
+
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn a_separator_after_a_header_is_dropped() {
+        let entries = MenuItems::new()
+            .item(menu_item("Copy"))
+            .separator()
+            .header("Danger")
+            .separator()
+            .item(menu_item("Delete"))
+            .finish();
+
+        assert_eq!(labels(&entries), vec!["Copy", "---", "Danger", "Delete"]);
+    }
+
+    #[test]
+    fn keyboard_navigation_skips_headers_separators_and_disabled_items() {
+        let entries = MenuItems::new()
+            .header("Group")
+            .item(menu_item("Copy"))
+            .item(menu_item("Paste").disabled(true))
+            .separator()
+            .item(menu_item("Delete"))
+            .finish();
+
+        // Header at 0, Copy at 1, disabled Paste at 2, separator at 3, Delete at 4.
+        assert_eq!(selectable_indices(&entries), vec![1, 4]);
+    }
+
+    #[test]
+    fn arrowing_into_a_fresh_menu_enters_from_the_end_it_moves_from() {
+        let selectable = vec![1, 4];
+
+        assert_eq!(next_focus(&selectable, None, 1), Some(1));
+        assert_eq!(next_focus(&selectable, None, -1), Some(4));
+    }
+
+    #[test]
+    fn focus_wraps_at_both_ends() {
+        let selectable = vec![1, 4];
+
+        assert_eq!(next_focus(&selectable, Some(1), 1), Some(4));
+        assert_eq!(next_focus(&selectable, Some(4), 1), Some(1));
+        assert_eq!(next_focus(&selectable, Some(1), -1), Some(4));
+    }
+
+    #[test]
+    fn a_menu_with_nothing_selectable_never_focuses() {
+        let entries = MenuItems::new()
+            .header("Group")
+            .item(menu_item("Copy").disabled(true))
+            .finish();
+        let selectable = selectable_indices(&entries);
+
+        assert!(selectable.is_empty());
+        assert_eq!(next_focus(&selectable, None, 1), None);
+        assert_eq!(next_focus(&selectable, None, -1), None);
+    }
+
+    #[test]
+    fn focus_survives_an_entry_that_is_no_longer_selectable() {
+        // Focus is held as an entry index; a menu rebuilt with that entry
+        // disabled must not strand the keyboard on it.
+        let selectable = vec![0, 2];
+
+        assert_eq!(next_focus(&selectable, Some(1), 1), Some(0));
+    }
+
+    /// Records which items were chosen, so a test can assert on what the menu
+    /// actually did rather than on its internal state.
+    #[derive(Clone, Default)]
+    struct Chosen(Rc<RefCell<Vec<String>>>);
+
+    impl Chosen {
+        fn record(&self, label: &'static str) -> impl Fn(&mut Window, &mut App) + use<> {
+            let chosen = self.0.clone();
+            move |_window, _cx| chosen.borrow_mut().push(label.to_string())
+        }
+
+        fn get(&self) -> Vec<String> {
+            self.0.borrow().clone()
+        }
+    }
+
+    struct TestView {
+        chosen: Chosen,
+    }
+
+    impl Render for TestView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let chosen = self.chosen.clone();
+
+            context_menu("test-menu", div().w(px(400.)).h(px(300.))).menu(
+                move |menu, _window, _cx| {
+                    menu.item(menu_item("Copy").on_click(chosen.record("Copy")))
+                        // Both skipped by the keyboard, for different reasons.
+                        .item(
+                            menu_item("Paste")
+                                .disabled(true)
+                                .on_click(chosen.record("Paste")),
+                        )
+                        .separator()
+                        .item(menu_item("Delete").on_click(chosen.record("Delete")))
+                },
+            )
+        }
+    }
+
+    fn open_menu(cx: &mut TestAppContext) -> (Chosen, &mut VisualTestContext) {
+        // Only the theme, not the whole of `gpuikit::init`: the rest binds keys
+        // (escape opens dialogs) that these tests would then be testing too.
+        cx.update(crate::theme::init);
+
+        let chosen = Chosen::default();
+        let (_view, cx) = cx.add_window_view({
+            let chosen = chosen.clone();
+            move |_window, _cx| TestView { chosen }
+        });
+
+        right_click(cx, point(px(50.), px(50.)));
+        (chosen, cx)
+    }
+
+    fn right_click(cx: &mut VisualTestContext, position: Point<Pixels>) {
+        cx.simulate_event(MouseDownEvent {
+            position,
+            modifiers: Modifiers::default(),
+            button: MouseButton::Right,
+            click_count: 1,
+            first_mouse: false,
+        });
+        cx.simulate_event(MouseUpEvent {
+            position,
+            modifiers: Modifiers::default(),
+            button: MouseButton::Right,
+            click_count: 1,
+        });
+    }
+
+    #[gpui::test]
+    fn right_click_opens_the_menu_and_enter_chooses(cx: &mut TestAppContext) {
+        let (chosen, cx) = open_menu(cx);
+
+        cx.simulate_keystrokes("down enter");
+
+        assert_eq!(chosen.get(), vec!["Copy".to_string()]);
+    }
+
+    #[gpui::test]
+    fn arrowing_past_a_disabled_item_lands_on_the_next_enabled_one(cx: &mut TestAppContext) {
+        let (chosen, cx) = open_menu(cx);
+
+        // Down twice: Copy, then past disabled Paste and the separator.
+        cx.simulate_keystrokes("down down enter");
+
+        assert_eq!(chosen.get(), vec!["Delete".to_string()]);
+    }
+
+    #[gpui::test]
+    fn escape_closes_the_menu_without_choosing(cx: &mut TestAppContext) {
+        let (chosen, cx) = open_menu(cx);
+
+        cx.simulate_keystrokes("down escape");
+        // Would choose Copy if the menu were still open and still focused.
+        cx.simulate_keystrokes("down enter");
+
+        assert!(chosen.get().is_empty(), "{:?}", chosen.get());
+    }
+
+    #[gpui::test]
+    fn clicking_away_closes_the_menu(cx: &mut TestAppContext) {
+        let (chosen, cx) = open_menu(cx);
+
+        cx.simulate_click(point(px(900.), px(700.)), Modifiers::default());
+        cx.simulate_keystrokes("down enter");
+
+        assert!(chosen.get().is_empty(), "{:?}", chosen.get());
+    }
+
+    #[gpui::test]
+    fn clicking_an_item_chooses_it(cx: &mut TestAppContext) {
+        let (chosen, cx) = open_menu(cx);
+
+        // Covers what the keyboard tests cannot: that the popup receives mouse
+        // events at all, over whatever it was opened on top of.
+        // 0 Copy, 1 Paste, 2 the separator, 3 Delete.
+        let bounds = cx
+            .debug_bounds("gpuikit-context-menu-item-3")
+            .expect("the Delete row should have been laid out");
+        cx.simulate_click(bounds.center(), Modifiers::default());
+
+        assert_eq!(chosen.get(), vec!["Delete".to_string()]);
+    }
+
+    #[gpui::test]
+    fn clicking_a_disabled_item_does_nothing(cx: &mut TestAppContext) {
+        let (chosen, cx) = open_menu(cx);
+
+        let bounds = cx
+            .debug_bounds("gpuikit-context-menu-item-1")
+            .expect("the Paste row should have been laid out");
+        cx.simulate_click(bounds.center(), Modifiers::default());
+
+        assert!(chosen.get().is_empty(), "{:?}", chosen.get());
+        // Still open: a dead click inside the menu must not dismiss it.
+        cx.simulate_keystrokes("down enter");
+        assert_eq!(chosen.get(), vec!["Copy".to_string()]);
+    }
+
+    #[gpui::test]
+    fn right_clicking_again_moves_the_open_menu(cx: &mut TestAppContext) {
+        // The popup's outside-press handler and the trigger's press handler both
+        // see this click. Capture runs before bubble, so it closes and reopens
+        // rather than closing what it just opened.
+        let (chosen, cx) = open_menu(cx);
+
+        right_click(cx, point(px(120.), px(90.)));
+        cx.simulate_keystrokes("down enter");
+
+        assert_eq!(chosen.get(), vec!["Copy".to_string()]);
     }
 }


### PR DESCRIPTION
Rewrites the Context Menu component. Closes #79 (properly), and supersedes #107.

## Why

The component that landed in #86 requires the view to own an `Entity<ContextMenuState>` and render *that* in place of its own content, with the trigger produced by a `Fn(&mut Window, &mut App) -> AnyElement` callback. That callback is `'static` and never sees the view's context, so there is no way to put a menu on anything drawn from view state — a list row, a card, a message. It worked for the static trigger in the showcase and not much else.

## What changed

The menu now wraps a trigger the caller has already built:

```rust
context_menu(("row", ix), self.render_row(ix, cx))
    .menu(move |menu, _window, _cx| {
        menu.header(name)
            .item(menu_item("Duplicate").action(Box::new(Duplicate)))
            .item(menu_item("Pinned").toggled(pinned).on_click(…))
            .separator()
            .item(menu_item("Delete").destructive().disabled(last_row).on_click(…))
    })
```

Open state lives in element state keyed on the id (`window.use_keyed_state`), so nothing is hoisted into the view. Entries are built at right-click, so they see the state at the moment of the click.

**Actions.** An item can carry a gpui action rather than a closure. It dispatches to whatever had focus before the menu opened, so one handler serves both the menu and the keybinding, and the shortcut shown beside the label is read from the keymap — no more hardcoded `"Cmd+C"` that goes stale when the binding moves.

Also added: section headers, checkmark items, keyboard navigation that skips separators and disabled items and wraps at both ends, hover and keyboard focus kept in sync, scroll-into-view in long menus, focus restored to the previous holder on dismiss, edge-aware positioning, and separators that drop themselves when a conditionally built group turns out to be empty.

## On #107

It re-adds a component that is already on main (#86 landed it) and does not fix the problem above — it keeps the entity-and-trigger-callback shape and swaps per-item `on_click` for a single `on_action(id)` dispatcher, which is less flexible. Nothing here is taken from it. Recommend closing it.

## Verification

Driven through gpui's test harness rather than by hand, since the interaction is the risky part: right-click opens the menu, arrows skip separators and disabled items, enter chooses, clicking a row chooses, clicking a disabled row does nothing *and* leaves the menu open, escape and clicking away dismiss, and right-clicking again moves the menu rather than closing what it just opened. That last one is the case where the popup's outside-press handler and the trigger's press handler both see the same click; capture runs before bubble, so it closes and reopens in the right order.

194 lib tests pass, `cargo fmt` clean, clippy unchanged from main. `cargo run --example context_menu --features runtime_shaders` for a hands-on look — worth a minute with a mouse before merging, since feel is the one thing the tests cannot judge.

## Breaking

`ContextMenuState`, `ContextMenu::trigger` and `menu_separator` are gone; `menu_item` takes only a label; entries are assembled with `menu.item(…).separator()` instead of a `Vec<MenuEntry>`. The showcase is updated. Nothing else in the repo used the old API, and the tasks app pins an older rev.