### PR TITLE
Build: #129, #128, #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
   `RunRole` saying how the run is announced. A run can no longer be built
   without deciding what it is. It exists to serve the markdown renderer, so
   callers outside this crate are unlikely
+- pulldown-cmark 0.12 → 0.13.4. gpuikit's own rendering is unchanged, but
+  pulldown-cmark types are part of gpuikit's public surface — `MarkdownEvent`
+  hands out a `pulldown_cmark::Event<'static>`, and `CodeBlockKind`,
+  `LinkType`, `Options` and `Parser` are re-exported — so a downstream crate
+  with its own `pulldown-cmark = "0.12"` dependency will end up with two
+  non-unifying copies of `Event` until it bumps too
 
 ### Changed
 
@@ -64,6 +70,29 @@ All notable changes to this project will be documented in this file.
   same entity is rendered more than once in one frame.
   `MarkdownElement::element_id` reads back whichever applies
 - `RunRole`, and `HeadingLevel::level()`
+- Fenced code blocks are syntax highlighted from their info string. The
+  language was parsed and then thrown away; it now reaches the element and is
+  highlighted by the `editor` feature's syntect-backed `SyntaxHighlighter`.
+  **Opt in per app** with `markdown::init_code_highlighting(cx)` after
+  `gpuikit::init` — loading syntect's syntax and theme sets costs tens of
+  milliseconds and a few megabytes, which a document containing no code should
+  not pay. Requires the `editor` feature; without it, without the init call,
+  without an info string, or for a language syntect has no grammar for, blocks
+  render as the plain monospace they did before. Highlights are cached per
+  block on (text, language, theme). The syntect theme follows the block's
+  background — `base16-ocean.dark` on a dark surface, `InspiredGitHub` on a
+  light one — or can be pinned with
+  `markdown::set_code_highlight_theme(cx, CodeHighlightTheme::Pinned(..))`;
+  `markdown::code_highlight_themes(cx)` lists the names it accepts
+- `markdown::normalize_language`, the fence-info-string-to-language-token rule
+  (leading word only, so ` ```rust,ignore ` is `rust`; a small alias table;
+  `text`/`plaintext`/`plain`/`none` mean no language)
+- `SyntaxHighlighter::highlight_block`, which highlights a whole block in one
+  stateless pass and returns `HighlightStyle`s, plus
+  `SyntaxHighlighter::resolve_language` and `SyntaxHighlighter::current_theme`.
+  Unlike `highlight_line`, `highlight_block` keeps its parse state local to the
+  call, so two blocks of one language cannot contaminate each other by both
+  starting at line 0
 
 ## [0.7.0] - 2026-08-15
 
@@ -116,6 +145,31 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Input content text now defaults to the theme foreground color; it previously inherited the window text style, which bottoms out at gpui's default black — invisible on dark themes. An explicit `.text_color()` on the element still wins
+
+## [0.5.0] - 2026-08-11
+
+Recorded retroactively. Both removals below shipped in 0.5.0 but were never
+written down — they rode along in an otherwise unrelated showcase PR
+([#121](https://github.com/iamnbutler/gpuikit/pull/121)), so anyone upgrading
+from 0.4.x met an `unresolved import` with no explanation. See
+[#120](https://github.com/iamnbutler/gpuikit/issues/120).
+
+### Breaking Changes
+
+- **Removed the Skeleton component** (`gpuikit::elements::skeleton`), pending a
+  rewrite that does not lag. Its pulse used `Animation::new(1500ms).repeat()`,
+  and a gpui `AnimationElement` requests another frame for as long as its
+  animation is live — which for a repeating animation is forever. One skeleton
+  therefore pinned its whole window at the display refresh rate, re-laying-out
+  and repainting every other element on it. `Skeleton::animated(false)` was not
+  an escape hatch: the animation was attached unconditionally and the callback
+  simply returned the element unchanged. For a static placeholder in the
+  meantime, a plain `div().bg(cx.theme().surface_secondary())` sized to the
+  content is the direct replacement
+- **Removed the Grain component** (`gpuikit::elements::grain`). It paints one
+  quad per 4px cell inside a `canvas` — on the order of 60k quads for a
+  1200×800 overlay — which is affordable only on a window that never repaints.
+  It comes back as a shader or a tiled texture, not as quads
 
 ## [0.4.0] - 2026-04-05
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ unicode-segmentation = "1.10"
 smol = "2.0"
 
 # Markdown parsing
-pulldown-cmark = { version = "0.12", default-features = false, features = ["simd"] }
+pulldown-cmark = { version = "0.13.4", default-features = false, features = ["simd"] }
 
 # Closes syntax a partially streamed markdown document leaves open, so a
 # half-written `**bold` does not flash as literal asterisks (optional)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ at your option.
 
 ## Components
 
-40+ components including: Accordion, Alert, Avatar, Badge, Breadcrumb, Button, Card, Checkbox, Collapsible, Dialog, Dropdown, Field, Input, Popover, Progress, Radio Group, Scroll Area, Select, Skeleton, Slider, Switch, Tabs, Textarea, Toast, Toggle, Tooltip, and more.
+Nearly 40 components including: Accordion, Alert, Avatar, Badge, Breadcrumb, Button, Card, Checkbox, Collapsible, Dialog, Dropdown, Field, Input, Popover, Progress, Radio Group, Scroll Area, Select, Slider, Switch, Tabs, Textarea, Toast, Toggle, Tooltip, and more.
 
 See [todo.md](todo.md) for the full list and roadmap.

--- a/examples/markdown_selection.rs
+++ b/examples/markdown_selection.rs
@@ -76,6 +76,11 @@ fn main() {
         .with_assets(gpuikit::assets());
     app.run(|cx: &mut App| {
         gpuikit::theme::init(cx);
+        // Syntax highlighting for the ```rust fence above. Opt-in: loading
+        // syntect's syntax and theme sets is not free, so a document with no
+        // code in it should not pay for them. Run with `--features editor`.
+        #[cfg(feature = "editor")]
+        gpuikit::markdown::init_code_highlighting(cx);
         cx.bind_keys([KeyBinding::new("cmd-c", CopySelection, None)]);
         cx.open_window(
             WindowOptions {

--- a/src/editor/syntax_highlighter.rs
+++ b/src/editor/syntax_highlighter.rs
@@ -52,6 +52,114 @@ impl SyntaxHighlighter {
         }
     }
 
+    /// The theme highlighting currently uses.
+    pub fn current_theme(&self) -> String {
+        self.inner.borrow().current_theme.clone()
+    }
+
+    /// Resolve a language token — a code fence's info string, a file
+    /// extension, a syntax name — to the canonical syntax name
+    /// [`highlight_block`](Self::highlight_block) expects, or `None` if
+    /// nothing in the syntax set matches.
+    ///
+    /// `"rs"`, `"rust"` and `"Rust"` all resolve to `"Rust"`. The lowercased
+    /// retry is not redundant: syntect's `find_syntax_by_token` matches
+    /// *names* case-insensitively but *extensions* exactly, so `"JS"` misses
+    /// on both passes without it.
+    pub fn resolve_language(&self, token: &str) -> Option<String> {
+        let token = token.trim();
+        if token.is_empty() {
+            return None;
+        }
+
+        let inner = self.inner.borrow();
+        let lowered = token.to_ascii_lowercase();
+        inner
+            .syntax_set
+            .find_syntax_by_token(token)
+            .or_else(|| inner.syntax_set.find_syntax_by_token(&lowered))
+            .map(|syntax| syntax.name.clone())
+    }
+
+    /// Highlight a whole block of text in one stateless pass.
+    ///
+    /// Unlike [`highlight_line`](Self::highlight_line), this keeps its parse
+    /// and highlight state local to the call, so two blocks of the same
+    /// language cannot contaminate each other (or a live editor) by both
+    /// starting at line 0. Multi-line constructs — a block comment, a raw
+    /// string — carry across lines *within* the block, which is the point.
+    ///
+    /// Returns sorted, disjoint byte ranges over `text`, each on a char
+    /// boundary. Ranges syntect gave no opinion about are simply absent, so
+    /// the caller's own text color shows through. Background colors are
+    /// dropped: they are the syntect theme's block background, which would
+    /// paint over the surface the code block already draws.
+    ///
+    /// `language` must be a canonical syntax name — see
+    /// [`resolve_language`](Self::resolve_language). An unknown one yields no
+    /// highlights rather than an error, so the caller renders plain.
+    pub fn highlight_block(
+        &self,
+        text: &str,
+        language: &str,
+    ) -> Vec<(std::ops::Range<usize>, gpui::HighlightStyle)> {
+        use syntect::util::LinesWithEndings;
+
+        let inner = self.inner.borrow();
+
+        let Some(syntax) = inner.syntax_set.find_syntax_by_name(language) else {
+            return Vec::new();
+        };
+        let Some(theme) = inner
+            .theme_set
+            .themes
+            .get(&inner.current_theme)
+            .or_else(|| inner.theme_set.themes.values().next())
+        else {
+            return Vec::new();
+        };
+
+        let highlighter = Highlighter::new(theme);
+        let mut parse_state = ParseState::new(syntax);
+        let mut highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
+
+        let mut highlights: Vec<(std::ops::Range<usize>, gpui::HighlightStyle)> = Vec::new();
+        let mut offset = 0usize;
+
+        for line in LinesWithEndings::from(text) {
+            // Parse once and highlight from that same op list. `highlight_line`
+            // parses a second time "to update state", which makes every line
+            // look like it occurred twice; doing it once here is what keeps
+            // the cross-line state honest.
+            let ops = parse_state
+                .parse_line(line, &inner.syntax_set)
+                .unwrap_or_default();
+
+            for (style, piece) in
+                HighlightIterator::new(&mut highlight_state, &ops, line, &highlighter)
+            {
+                let start = offset;
+                offset += piece.len();
+                if piece.is_empty() {
+                    continue;
+                }
+
+                let highlight = style_to_highlight(style);
+                match highlights.last_mut() {
+                    // Merge with the immediately preceding span when it is
+                    // contiguous and identical, so the range list stays short
+                    // and trivially sorted and disjoint.
+                    Some((range, previous)) if range.end == start && *previous == highlight => {
+                        range.end = offset;
+                    }
+                    _ => highlights.push((start..offset, highlight)),
+                }
+            }
+        }
+
+        highlights
+    }
+
     pub fn available_themes(&self) -> Vec<String> {
         self.inner
             .borrow()
@@ -514,6 +622,34 @@ fn style_color_to_hsla(color: syntect::highlighting::Color) -> Hsla {
 
 fn style_to_hsla(style: Style) -> Hsla {
     style_color_to_hsla(style.foreground)
+}
+
+/// A syntect span style as a gpui [`HighlightStyle`](gpui::HighlightStyle).
+///
+/// Every field stays `None` unless syntect actually asked for it, so a span
+/// the theme has no opinion about inherits the surrounding text's style.
+/// `background_color` is deliberately never set: syntect puts the theme's own
+/// block background on *every* span, which would paint over the code block's
+/// surface and fight the selection highlight.
+fn style_to_highlight(style: Style) -> gpui::HighlightStyle {
+    use syntect::highlighting::FontStyle as SyntectFontStyle;
+
+    gpui::HighlightStyle {
+        color: Some(style_to_hsla(style)),
+        font_weight: style
+            .font_style
+            .contains(SyntectFontStyle::BOLD)
+            .then_some(FontWeight::BOLD),
+        font_style: style
+            .font_style
+            .contains(SyntectFontStyle::ITALIC)
+            .then_some(FontStyle::Italic),
+        underline: style
+            .font_style
+            .contains(SyntectFontStyle::UNDERLINE)
+            .then(Default::default),
+        ..Default::default()
+    }
 }
 
 fn get_font_style(style: Style) -> (FontWeight, FontStyle) {

--- a/src/markdown/code_highlight.rs
+++ b/src/markdown/code_highlight.rs
@@ -162,6 +162,19 @@ mod editor_bridge {
     /// (text, resolved syntax name, syntect theme) → that block's highlights.
     /// All three matter: the same text under a different theme is a different
     /// answer, which is what makes an app theme toggle re-highlight for free.
+    ///
+    /// **Keying on the whole text means a streaming block never hits.** A fence
+    /// arriving through `Markdown::append` is a different key on every delta,
+    /// so it costs a full syntect pass over the whole block-so-far each time —
+    /// quadratic in the block's final length, on the render path. Worse, those
+    /// prefixes are all distinct entries, so one long streamed block can fill
+    /// [`MAX_CACHED_BLOCKS`] by itself and take every other block's entry with
+    /// it when the cache clears. [`MAX_HIGHLIGHT_BYTES`] bounds the individual
+    /// pass and is deliberately checked before the key is built, so an
+    /// oversized block never lands here at all — but it does not bound the
+    /// repetition. Fixing that means an incremental highlighter or a key that
+    /// is a prefix rather than an identity; neither is worth doing before
+    /// there is a profile that says so.
     type CacheKey = (String, String, String);
 
     type Highlights = Vec<(Range<usize>, HighlightStyle)>;

--- a/src/markdown/code_highlight.rs
+++ b/src/markdown/code_highlight.rs
@@ -1,0 +1,593 @@
+//! Syntax highlighting for fenced code blocks.
+//!
+//! The markdown renderer knows a block's info string; the `editor` feature
+//! knows how to highlight source. This module is the seam between them, and
+//! the only thing [`code_block`](super::elements) has to know about.
+//!
+//! Highlighting is **opt-in per app**: call
+//! [`init_code_highlighting`] once, after `gpuikit::init`. Loading syntect's
+//! default syntax and theme sets costs tens of milliseconds and a few
+//! megabytes, which a document with no code in it should not pay.
+//!
+//! Every step degrades to plain monospace rather than failing: no `editor`
+//! feature, no [`init_code_highlighting`], no info string, an info string
+//! syntect has no grammar for, or a block past
+//! [`MAX_HIGHLIGHT_BYTES`](self) all render exactly what they rendered
+//! before this module existed.
+//!
+//! ```ignore
+//! Application::new().run(|cx| {
+//!     gpuikit::init(cx);
+//!     gpuikit::markdown::init_code_highlighting(cx);
+//! });
+//! ```
+
+use std::ops::Range;
+
+use gpui::{App, HighlightStyle, Hsla};
+
+/// Fence info strings that mean "this is not a language".
+const PLAIN_LANGUAGES: &[&str] = &["text", "plaintext", "plain", "none", "txt"];
+
+/// Fence dialects that name a language syntect knows under another token.
+///
+/// Only aliases that are genuinely the same grammar belong here. `ts` is
+/// absent on purpose: syntect's default set has no TypeScript, and pointing it
+/// at JavaScript would mis-highlight exactly the type syntax that makes it
+/// TypeScript.
+const LANGUAGE_ALIASES: &[(&str, &str)] = &[
+    ("bash", "bash"),
+    ("console", "bash"),
+    ("golang", "go"),
+    ("htm", "html"),
+    ("jsonc", "json"),
+    ("objc", "objective-c"),
+    ("rs", "rust"),
+    ("sh", "bash"),
+    ("shell", "bash"),
+    ("yml", "yaml"),
+    ("zsh", "bash"),
+];
+
+/// Reduce a code fence's info string to a language token, or `None` if it
+/// names no language.
+///
+/// Takes the leading word, so ` ```rust,ignore ` and ` ```rust no_run ` both
+/// arrive as `rust`, then folds case and applies a small alias table
+/// (`golang` → `go`, `yml` → `yaml`, `zsh` → `bash`, …). Returns `None` for an
+/// empty string and for the explicit "no language" spellings (`text`,
+/// `plaintext`, `plain`, `none`, `txt`).
+///
+/// The token still has to survive
+/// [`SyntaxHighlighter::resolve_language`](crate::editor::SyntaxHighlighter::resolve_language);
+/// this only normalizes the *fence* dialect.
+pub fn normalize_language(info: &str) -> Option<String> {
+    let token = info
+        .trim()
+        .split([',', ' ', '\t'])
+        .next()
+        .unwrap_or("")
+        .trim();
+
+    if token.is_empty() {
+        return None;
+    }
+
+    let lowered = token.to_ascii_lowercase();
+    if PLAIN_LANGUAGES.contains(&lowered.as_str()) {
+        return None;
+    }
+
+    Some(
+        LANGUAGE_ALIASES
+            .iter()
+            .find(|(alias, _)| *alias == lowered)
+            .map(|(_, canonical)| (*canonical).to_string())
+            .unwrap_or(lowered),
+    )
+}
+
+#[cfg(feature = "editor")]
+pub use editor_bridge::{
+    code_highlight_themes, init_code_highlighting, set_code_highlight_theme, CodeHighlightTheme,
+    DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME,
+};
+
+/// The highlights for one code block, or an empty vector if anything at all is
+/// missing — see the module docs for the full list of ways this degrades.
+///
+/// `background` is the surface the block is painted on; it decides light or
+/// dark when the theme is [`CodeHighlightTheme::FollowApp`].
+#[cfg(feature = "editor")]
+pub(crate) fn code_highlights(
+    text: &str,
+    language: Option<&str>,
+    background: Hsla,
+    cx: &App,
+) -> Vec<(Range<usize>, HighlightStyle)> {
+    editor_bridge::code_highlights(text, language, background, cx)
+}
+
+/// Without the `editor` feature there is no highlighter to ask, so every code
+/// block renders plain. Same signature as the real one, so `code_block`
+/// contains no `cfg` of its own.
+#[cfg(not(feature = "editor"))]
+pub(crate) fn code_highlights(
+    _text: &str,
+    _language: Option<&str>,
+    _background: Hsla,
+    _cx: &App,
+) -> Vec<(Range<usize>, HighlightStyle)> {
+    Vec::new()
+}
+
+#[cfg(feature = "editor")]
+mod editor_bridge {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::ops::Range;
+    use std::rc::Rc;
+
+    use gpui::{App, Global, HighlightStyle, Hsla};
+
+    use crate::editor::SyntaxHighlighter;
+
+    /// The syntect theme used on a dark surface when following the app.
+    pub const DEFAULT_DARK_THEME: &str = "base16-ocean.dark";
+    /// The syntect theme used on a light surface when following the app.
+    pub const DEFAULT_LIGHT_THEME: &str = "InspiredGitHub";
+
+    /// Past this many bytes a block renders plain. A syntect pass is linear,
+    /// but a megabyte of pasted log in a chat transcript is not worth a frame.
+    const MAX_HIGHLIGHT_BYTES: usize = 256 * 1024;
+
+    /// How many highlighted blocks to remember. Cleared wholesale on
+    /// overflow — an LRU would need a recency list for a cache whose whole
+    /// purpose is to be cheap.
+    const MAX_CACHED_BLOCKS: usize = 256;
+
+    /// Which syntect theme code blocks highlight with.
+    #[derive(Clone, Debug, PartialEq, Eq, Default)]
+    pub enum CodeHighlightTheme {
+        /// Pick [`DEFAULT_DARK_THEME`] or [`DEFAULT_LIGHT_THEME`] from the
+        /// lightness of the surface the block is drawn on, so a light/dark
+        /// toggle needs no extra call.
+        #[default]
+        FollowApp,
+        /// Always this syntect theme, whatever the app is doing. One of
+        /// [`code_highlight_themes`].
+        Pinned(String),
+    }
+
+    /// (text, resolved syntax name, syntect theme) → that block's highlights.
+    /// All three matter: the same text under a different theme is a different
+    /// answer, which is what makes an app theme toggle re-highlight for free.
+    type CacheKey = (String, String, String);
+
+    type Highlights = Vec<(Range<usize>, HighlightStyle)>;
+
+    struct CodeHighlighter {
+        highlighter: RefCell<SyntaxHighlighter>,
+        theme: RefCell<CodeHighlightTheme>,
+        cache: RefCell<HashMap<CacheKey, Rc<Highlights>>>,
+        /// Fence token → syntax name, memoized. Resolution walks syntect's
+        /// whole syntax list, and a document repeats the same few languages.
+        resolved: RefCell<HashMap<String, Option<String>>>,
+    }
+
+    impl CodeHighlighter {
+        fn new() -> Self {
+            Self {
+                highlighter: RefCell::new(SyntaxHighlighter::new()),
+                theme: RefCell::new(CodeHighlightTheme::default()),
+                cache: RefCell::new(HashMap::new()),
+                resolved: RefCell::new(HashMap::new()),
+            }
+        }
+
+        /// The syntect theme name to use for a block on `background`.
+        fn theme_for(&self, background: Hsla) -> String {
+            match &*self.theme.borrow() {
+                CodeHighlightTheme::Pinned(name) => name.clone(),
+                CodeHighlightTheme::FollowApp => if background.l > 0.5 {
+                    DEFAULT_LIGHT_THEME
+                } else {
+                    DEFAULT_DARK_THEME
+                }
+                .to_string(),
+            }
+        }
+
+        fn resolve(&self, token: &str) -> Option<String> {
+            if let Some(hit) = self.resolved.borrow().get(token) {
+                return hit.clone();
+            }
+            let resolved = self.highlighter.borrow().resolve_language(token);
+            self.resolved
+                .borrow_mut()
+                .insert(token.to_string(), resolved.clone());
+            resolved
+        }
+
+        fn highlights(&self, text: &str, token: &str, background: Hsla) -> Rc<Highlights> {
+            let empty = || Rc::new(Vec::new());
+
+            if text.len() > MAX_HIGHLIGHT_BYTES {
+                return empty();
+            }
+            let Some(language) = self.resolve(token) else {
+                return empty();
+            };
+
+            let theme = self.theme_for(background);
+            let key = (text.to_string(), language.clone(), theme.clone());
+            if let Some(hit) = self.cache.borrow().get(&key) {
+                return hit.clone();
+            }
+
+            // `set_theme` is a no-op for a theme syntect does not have, which
+            // leaves whatever was set before — fine, and still consistent with
+            // the cache key, since a miss re-runs this every time.
+            {
+                let mut highlighter = self.highlighter.borrow_mut();
+                if highlighter.current_theme() != theme {
+                    highlighter.set_theme(&theme);
+                }
+            }
+
+            let plain_foreground = self.highlighter.borrow().get_theme_foreground();
+            let highlights: Highlights = self
+                .highlighter
+                .borrow()
+                .highlight_block(text, &language)
+                .into_iter()
+                // A syntect theme's plain foreground is not the app's. Left
+                // in, every unremarkable identifier would be repainted in the
+                // syntect theme's body color — a dark theme's light grey on a
+                // light surface. Dropping those spans lets ordinary code keep
+                // the block's own text color, and only *distinctly* colored
+                // tokens get restyled.
+                .filter(|(_, style)| {
+                    style.font_weight.is_some()
+                        || style.font_style.is_some()
+                        || style.underline.is_some()
+                        || style.color.is_some_and(|color| color != plain_foreground)
+                })
+                .collect();
+
+            let highlights = Rc::new(highlights);
+
+            let mut cache = self.cache.borrow_mut();
+            if cache.len() >= MAX_CACHED_BLOCKS {
+                cache.clear();
+            }
+            cache.insert(key, highlights.clone());
+            highlights
+        }
+
+        fn set_theme(&self, theme: CodeHighlightTheme) {
+            *self.theme.borrow_mut() = theme;
+        }
+
+        fn available_themes(&self) -> Vec<String> {
+            self.highlighter.borrow().available_themes()
+        }
+    }
+
+    struct GlobalCodeHighlighter(Rc<CodeHighlighter>);
+
+    impl Global for GlobalCodeHighlighter {}
+
+    /// Turn on syntax highlighting for markdown code blocks.
+    ///
+    /// Call once during app setup, after `gpuikit::init`. Without it, fenced
+    /// code blocks render as plain monospace — which is the right default,
+    /// since loading syntect's syntax and theme sets is not free and a
+    /// document with no code in it should not pay for them.
+    ///
+    /// Calling it twice replaces the highlighter, discarding the cache.
+    pub fn init_code_highlighting(cx: &mut App) {
+        cx.set_global(GlobalCodeHighlighter(Rc::new(CodeHighlighter::new())));
+    }
+
+    /// Pin code blocks to a specific syntect theme, or put them back on
+    /// [`CodeHighlightTheme::FollowApp`].
+    ///
+    /// Does nothing if [`init_code_highlighting`] has not been called.
+    pub fn set_code_highlight_theme(cx: &mut App, theme: CodeHighlightTheme) {
+        if let Some(global) = cx.try_global::<GlobalCodeHighlighter>() {
+            global.0.set_theme(theme);
+        }
+    }
+
+    /// The syntect theme names [`CodeHighlightTheme::Pinned`] accepts, or an
+    /// empty vector before [`init_code_highlighting`].
+    pub fn code_highlight_themes(cx: &App) -> Vec<String> {
+        cx.try_global::<GlobalCodeHighlighter>()
+            .map(|global| global.0.available_themes())
+            .unwrap_or_default()
+    }
+
+    pub(super) fn code_highlights(
+        text: &str,
+        language: Option<&str>,
+        background: Hsla,
+        cx: &App,
+    ) -> Vec<(Range<usize>, HighlightStyle)> {
+        let Some(language) = language else {
+            return Vec::new();
+        };
+        let Some(global) = cx.try_global::<GlobalCodeHighlighter>() else {
+            return Vec::new();
+        };
+
+        // One `Vec` clone per cached block per frame. If that ever shows up in
+        // a profile, hand back the `Rc` instead of cloning it.
+        (*global.0.highlights(text, language, background)).clone()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn highlighter() -> CodeHighlighter {
+            CodeHighlighter::new()
+        }
+
+        const DARK: Hsla = Hsla {
+            h: 0.0,
+            s: 0.0,
+            l: 0.1,
+            a: 1.0,
+        };
+        const LIGHT: Hsla = Hsla {
+            h: 0.0,
+            s: 0.0,
+            l: 0.95,
+            a: 1.0,
+        };
+
+        /// `StyledText::with_highlights` debug-asserts char boundaries and
+        /// `compute_runs` assumes sorted, non-overlapping ranges. This is the
+        /// guard for both.
+        fn assert_well_formed(text: &str, highlights: &[(Range<usize>, HighlightStyle)]) {
+            let mut previous_end = 0;
+            for (range, _) in highlights {
+                assert!(range.start < range.end, "empty range {range:?}");
+                assert!(
+                    range.start >= previous_end,
+                    "range {range:?} overlaps or precedes {previous_end}"
+                );
+                assert!(range.end <= text.len(), "range {range:?} past end of text");
+                assert!(
+                    text.is_char_boundary(range.start) && text.is_char_boundary(range.end),
+                    "range {range:?} splits a codepoint"
+                );
+                previous_end = range.end;
+            }
+        }
+
+        #[test]
+        fn highlights_are_well_formed() {
+            let highlighter = highlighter();
+            let text = "fn main() {\n    println!(\"hello\");\n}\n";
+            let highlights = highlighter.highlights(text, "rust", DARK);
+
+            assert!(!highlights.is_empty(), "expected rust to highlight");
+            assert_well_formed(text, &highlights);
+        }
+
+        #[test]
+        fn multibyte_highlights_are_well_formed() {
+            let highlighter = highlighter();
+            let text = "fn main() {\n    let grüße = \"héllo 🎉 wörld\";\n}\n";
+            let highlights = highlighter.highlights(text, "rust", DARK);
+
+            assert_well_formed(text, &highlights);
+        }
+
+        /// The reason this path does not reuse `highlight_line`: state has to
+        /// carry across the lines of one block, and only those lines.
+        #[test]
+        fn highlight_block_carries_state_across_lines() {
+            let highlighter = highlighter();
+            let text = "/* opening\n   still a comment\n   closing */\nfn after() {}\n";
+            let highlights = highlighter.highlights(text, "rust", DARK);
+
+            assert_well_formed(text, &highlights);
+
+            let comment_line_two = text.find("still").expect("fixture has the word");
+            let covering = highlights
+                .iter()
+                .find(|(range, _)| range.contains(&comment_line_two));
+            assert!(
+                covering.is_some(),
+                "line 2 of a block comment should still be styled: {highlights:?}"
+            );
+        }
+
+        #[test]
+        fn unknown_language_renders_plain() {
+            let highlighter = highlighter();
+            let highlights = highlighter.highlights("some text", "definitely-not-a-language", DARK);
+
+            assert!(highlights.is_empty());
+        }
+
+        #[test]
+        fn empty_and_newlineless_blocks_are_safe() {
+            let highlighter = highlighter();
+
+            assert!(highlighter.highlights("", "rust", DARK).is_empty());
+
+            let text = "let x = 1;";
+            let highlights = highlighter.highlights(text, "rust", DARK);
+            assert_well_formed(text, &highlights);
+        }
+
+        /// syntect puts its theme's block background on every span, which
+        /// would paint over the code block's own surface.
+        #[test]
+        fn no_span_carries_a_background() {
+            let highlighter = highlighter();
+            let text = "fn main() {\n    let x = 1;\n}\n";
+
+            for (_, style) in highlighter.highlights(text, "rust", DARK).iter() {
+                assert!(style.background_color.is_none(), "{style:?}");
+            }
+        }
+
+        #[test]
+        fn oversized_blocks_render_plain() {
+            let highlighter = highlighter();
+            let text = "// x\n".repeat(MAX_HIGHLIGHT_BYTES / 5 + 1);
+
+            assert!(text.len() > MAX_HIGHLIGHT_BYTES);
+            assert!(highlighter.highlights(&text, "rust", DARK).is_empty());
+        }
+
+        #[test]
+        fn a_repeated_block_is_only_highlighted_once() {
+            let highlighter = highlighter();
+            let text = "fn main() {}\n";
+
+            let first = highlighter.highlights(text, "rust", DARK);
+            assert_eq!(highlighter.cache.borrow().len(), 1);
+
+            let second = highlighter.highlights(text, "rust", DARK);
+            assert_eq!(highlighter.cache.borrow().len(), 1, "expected a cache hit");
+            assert_eq!(*first, *second);
+        }
+
+        #[test]
+        fn theme_follows_the_block_background_unless_pinned() {
+            let highlighter = highlighter();
+
+            assert_eq!(highlighter.theme_for(DARK), DEFAULT_DARK_THEME);
+            assert_eq!(highlighter.theme_for(LIGHT), DEFAULT_LIGHT_THEME);
+
+            highlighter.set_theme(CodeHighlightTheme::Pinned("Solarized (dark)".into()));
+            assert_eq!(highlighter.theme_for(DARK), "Solarized (dark)");
+            assert_eq!(highlighter.theme_for(LIGHT), "Solarized (dark)");
+        }
+
+        /// The theme is part of the cache key, so flipping the app between
+        /// light and dark re-highlights rather than reusing dark-theme colors
+        /// on a light surface.
+        #[test]
+        fn changing_theme_re_highlights() {
+            let highlighter = highlighter();
+            let text = "fn main() {}\n";
+
+            let dark = highlighter.highlights(text, "rust", DARK);
+            let light = highlighter.highlights(text, "rust", LIGHT);
+
+            assert_eq!(highlighter.cache.borrow().len(), 2);
+            assert_ne!(*dark, *light, "expected different colors per theme");
+        }
+
+        /// The wiring, end to end through the gpui global: highlighting is
+        /// opt-in, and every way of not having it renders plain.
+        #[gpui::test]
+        fn highlighting_is_opt_in_per_app(cx: &mut gpui::TestAppContext) {
+            let text = "fn main() {\n    println!(\"hello\");\n}\n";
+
+            cx.update(|cx| {
+                assert!(
+                    super::super::code_highlights(text, Some("rust"), DARK, cx).is_empty(),
+                    "no highlighting before init_code_highlighting"
+                );
+                assert!(code_highlight_themes(cx).is_empty());
+
+                init_code_highlighting(cx);
+
+                assert!(
+                    !super::super::code_highlights(text, Some("rust"), DARK, cx).is_empty(),
+                    "expected highlighting once initialized"
+                );
+                assert!(code_highlight_themes(cx).contains(&DEFAULT_DARK_THEME.to_string()));
+
+                assert!(
+                    super::super::code_highlights(text, None, DARK, cx).is_empty(),
+                    "a bare fence has no language to highlight with"
+                );
+                assert!(
+                    super::super::code_highlights(text, Some("not-a-language"), DARK, cx)
+                        .is_empty(),
+                    "an unknown language renders plain"
+                );
+
+                set_code_highlight_theme(cx, CodeHighlightTheme::Pinned("InspiredGitHub".into()));
+                assert!(!super::super::code_highlights(text, Some("rust"), DARK, cx).is_empty());
+            });
+        }
+
+        #[test]
+        fn common_fence_labels_resolve() {
+            let highlighter = highlighter();
+
+            for token in [
+                "rust", "rs", "python", "js", "JS", "json", "yaml", "yml", "html", "css", "c",
+                "cpp", "go", "golang", "ruby", "bash", "sh", "shell", "zsh", "sql", "xml",
+                "markdown", "java", "php",
+            ] {
+                let normalized = super::super::normalize_language(token)
+                    .unwrap_or_else(|| panic!("{token} should normalize to a language"));
+                assert!(
+                    highlighter.resolve(&normalized).is_some(),
+                    "{token} (normalized to {normalized}) should resolve to a syntax"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leading_word_only() {
+        assert_eq!(normalize_language("rust"), Some("rust".into()));
+        assert_eq!(normalize_language("rust,ignore"), Some("rust".into()));
+        assert_eq!(normalize_language("rust no_run"), Some("rust".into()));
+        assert_eq!(normalize_language("  rust  "), Some("rust".into()));
+        assert_eq!(normalize_language("rust,linenos=1"), Some("rust".into()));
+    }
+
+    #[test]
+    fn case_is_folded() {
+        assert_eq!(normalize_language("Rust"), Some("rust".into()));
+        assert_eq!(normalize_language("JSON"), Some("json".into()));
+    }
+
+    #[test]
+    fn aliases_map_to_one_grammar() {
+        assert_eq!(normalize_language("golang"), Some("go".into()));
+        assert_eq!(normalize_language("yml"), Some("yaml".into()));
+        assert_eq!(normalize_language("jsonc"), Some("json".into()));
+        assert_eq!(normalize_language("objc"), Some("objective-c".into()));
+
+        for shell in ["sh", "bash", "zsh", "shell", "console"] {
+            assert_eq!(normalize_language(shell), Some("bash".into()), "{shell}");
+        }
+    }
+
+    #[test]
+    fn no_language_is_none() {
+        assert_eq!(normalize_language(""), None);
+        assert_eq!(normalize_language("   "), None);
+
+        for plain in ["text", "plaintext", "plain", "none", "txt", "TEXT"] {
+            assert_eq!(normalize_language(plain), None, "{plain}");
+        }
+    }
+
+    /// `ts` deliberately has no alias: syntect's default set has no
+    /// TypeScript, and aliasing it to JavaScript would mis-highlight the type
+    /// syntax. It normalizes fine and then simply fails to resolve.
+    #[test]
+    fn typescript_is_not_aliased_to_javascript() {
+        assert_eq!(normalize_language("ts"), Some("ts".into()));
+    }
+}

--- a/src/markdown/elements/code_block.rs
+++ b/src/markdown/elements/code_block.rs
@@ -3,6 +3,7 @@
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, SharedString, Styled};
 
+use super::super::code_highlight::code_highlights;
 use super::super::selectable_text::{RunRole, SelectableText};
 use super::super::style::TextStyle;
 use super::paragraph::{selection_styled_text, RunContext};
@@ -10,12 +11,16 @@ use super::paragraph::{selection_styled_text, RunContext};
 /// Render a code block element. The text inside is a selectable run — code
 /// is the thing people copy most.
 ///
-/// TODO: Replace with gpuikit-editor readonly view for syntax highlighting.
+/// `language` is the fence's normalized language token. It buys syntax
+/// highlighting only when the `editor` feature is on *and* the app called
+/// [`init_code_highlighting`](super::super::code_highlight); otherwise, and
+/// for a language syntect has no grammar for, the block renders plain
+/// monospace exactly as before.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn code_block(
     id: impl Into<ElementId>,
     text: String,
-    _language: Option<&str>,
+    language: Option<&str>,
     style: &TextStyle,
     font_family: &SharedString,
     bg: Option<gpui::Hsla>,
@@ -24,13 +29,19 @@ pub(crate) fn code_block(
     cx: &App,
 ) -> impl IntoElement {
     let theme = cx.theme();
-    let (styled, plain) = selection_styled_text(text, Vec::new(), &run_cx);
+    // Resolved once, and handed to the highlighter as well as to the div, so
+    // the light/dark decision follows the surface the highlights are painted
+    // on rather than the window at large.
+    let background = bg.unwrap_or(theme.surface());
+
+    let highlights = code_highlights(&text, language, background, cx);
+    let (styled, plain) = selection_styled_text(text, highlights, &run_cx);
 
     div()
         .px(rems(1.0))
         .py(rems(0.75))
         .rounded(rems(0.375))
-        .bg(bg.unwrap_or(theme.surface()))
+        .bg(background)
         .border_1()
         .border_color(border.unwrap_or(theme.border()))
         .text_size(rems(style.size))

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -557,11 +557,20 @@ impl MarkdownRenderer {
             Tag::TableCell => {
                 self.current_text.clear();
             }
+            // Listed rather than folded into a `_ => {}` wildcard on purpose:
+            // an exhaustive match is what turns a pulldown-cmark upgrade into a
+            // compile error instead of silently dropped styling.
+            //
+            // Superscript and Subscript are inert because the options that
+            // produce them are off (see `parser::default_options`) *and*
+            // because `InlineStyle` has nowhere to put them.
             Tag::FootnoteDefinition(_)
             | Tag::MetadataBlock(_)
             | Tag::DefinitionList
             | Tag::DefinitionListTitle
             | Tag::DefinitionListDefinition
+            | Tag::Superscript
+            | Tag::Subscript
             | Tag::HtmlBlock => {}
         }
     }
@@ -632,6 +641,8 @@ impl MarkdownRenderer {
             | TagEnd::DefinitionList
             | TagEnd::DefinitionListTitle
             | TagEnd::DefinitionListDefinition
+            | TagEnd::Superscript
+            | TagEnd::Subscript
             | TagEnd::HtmlBlock => {}
         }
     }

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -18,6 +18,7 @@
 //! )
 //! ```
 
+mod code_highlight;
 mod elements;
 mod inline_style;
 mod parser;
@@ -26,6 +27,12 @@ mod selection;
 mod stitch;
 mod style;
 
+pub use code_highlight::normalize_language;
+#[cfg(feature = "editor")]
+pub use code_highlight::{
+    code_highlight_themes, init_code_highlighting, set_code_highlight_theme, CodeHighlightTheme,
+    DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME,
+};
 pub use elements::*;
 pub use inline_style::*;
 pub use parser::*;
@@ -396,6 +403,9 @@ struct MarkdownRenderer {
     // State tracking
     in_heading: Option<HeadingLevel>,
     in_code_block: bool,
+    /// The language token of the fence currently open, normalized from its
+    /// info string. `None` for an indented block or a bare fence.
+    code_block_language: Option<String>,
     in_block_quote: bool,
     in_image: Option<ImageContext>,
     list_stack: Vec<ListContext>,
@@ -439,6 +449,7 @@ impl MarkdownRenderer {
             elements: Vec::new(),
             in_heading: None,
             in_code_block: false,
+            code_block_language: None,
             in_block_quote: false,
             in_image: None,
             list_stack: Vec::new(),
@@ -510,8 +521,10 @@ impl MarkdownRenderer {
             Tag::BlockQuote(_) => {
                 self.in_block_quote = true;
             }
-            Tag::CodeBlock(_kind) => {
+            Tag::CodeBlock(kind) => {
                 self.in_code_block = true;
+                self.code_block_language =
+                    parser::code_block_language(kind).and_then(code_highlight::normalize_language);
             }
             Tag::List(start) => {
                 self.list_stack.push(ListContext {
@@ -754,6 +767,10 @@ impl MarkdownRenderer {
     }
 
     fn flush_code_block(&mut self, cx: &App) {
+        // Taken before the early return: an empty fence still closes, and its
+        // language must not leak into the next block.
+        let language = self.code_block_language.take();
+
         if self.current_text.is_empty() {
             return;
         }
@@ -765,7 +782,7 @@ impl MarkdownRenderer {
         let element = elements::code_block(
             id,
             text,
-            None,
+            language.as_deref(),
             &self.style.code,
             &self.style.code_font_family,
             self.style.code_block_bg,
@@ -1019,6 +1036,46 @@ mod tests {
 
     fn id_paths(runs: &[RecordedRun]) -> Vec<String> {
         runs.iter().map(|run| run.id_path.clone()).collect()
+    }
+
+    /// The fence's info string used to be dropped at `Tag::CodeBlock` and a
+    /// literal `None` passed on to the element, so fixing the code block
+    /// element alone would have changed nothing.
+    #[gpui::test]
+    fn a_fence_carries_its_language_without_leaking_it(cx: &mut TestAppContext) {
+        use pulldown_cmark::CodeBlockKind;
+
+        cx.update(crate::theme::init);
+        cx.update(|cx| {
+            let mut renderer =
+                MarkdownRenderer::new(MarkdownStyle::default(), MarkdownSelection::new());
+
+            let fence = |info: &'static str| Tag::CodeBlock(CodeBlockKind::Fenced(info.into()));
+
+            renderer.handle_start_tag(&fence("rust,ignore"));
+            assert_eq!(
+                renderer.code_block_language.as_deref(),
+                Some("rust"),
+                "the info string should reach the renderer, normalized"
+            );
+
+            // An empty fence still closes, and must not hand its language to
+            // whatever block comes next.
+            renderer.flush_code_block(cx);
+            assert_eq!(renderer.code_block_language, None);
+
+            for no_language in [
+                fence(""),
+                fence("text"),
+                Tag::CodeBlock(CodeBlockKind::Indented),
+            ] {
+                renderer.handle_start_tag(&no_language);
+                assert_eq!(
+                    renderer.code_block_language, None,
+                    "{no_language:?} names no language"
+                );
+            }
+        });
     }
 
     #[gpui::test]

--- a/src/markdown/parser.rs
+++ b/src/markdown/parser.rs
@@ -6,6 +6,35 @@
 pub use pulldown_cmark::{CodeBlockKind, LinkType, Options, Parser};
 
 /// Default parsing options with GFM support enabled.
+///
+/// This is the *only* option set the renderer uses — [`Markdown::parse`] calls
+/// it rather than assembling the same flags inline, so a change here changes
+/// every document.
+///
+/// The options deliberately left off, and what turning one on would do to
+/// documents that render correctly today:
+///
+/// - `ENABLE_SUBSCRIPT` — takes `~x~` *away from strikethrough* and emits
+///   [`pulldown_cmark::Tag::Subscript`] instead, silently restyling existing
+///   documents. See
+///   `single_tilde_is_strikethrough_not_subscript`.
+/// - `ENABLE_SUPERSCRIPT` — claims `^x^`, which is literal text today.
+/// - Both also need somewhere to land: `InlineStyle` carries no baseline
+///   shift, and neither does `gpui::HighlightStyle`, so enabling them without
+///   that work would parse correctly and render identically to plain text.
+/// - `ENABLE_WIKILINKS` — turns `[[foo|bar]]` into a link. See
+///   `wikilinks_stay_literal_text`.
+/// - `ENABLE_MATH` — claims `$x$` and `$$x$$` as `InlineMath`/`DisplayMath`,
+///   which the renderer drops on the floor.
+/// - `ENABLE_DEFINITION_LIST` — claims `term\n: definition`; the renderer has
+///   no element for it and would swallow the text.
+/// - `ENABLE_SMART_PUNCTUATION` — rewrites quotes and dashes, which is wrong
+///   inside a document quoting code.
+/// - `ENABLE_HEADING_ATTRIBUTES`, `ENABLE_*_METADATA_BLOCKS`,
+///   `ENABLE_OLD_FOOTNOTES` — no renderer support, or superseded by
+///   `ENABLE_GFM`.
+///
+/// [`Markdown::parse`]: super::Markdown
 pub fn default_options() -> Options {
     Options::ENABLE_TABLES
         | Options::ENABLE_FOOTNOTES
@@ -67,5 +96,141 @@ mod tests {
 
         let indented = CodeBlockKind::Indented;
         assert_eq!(code_block_language(&indented), None);
+    }
+
+    // The tests below pin behaviour that a change to `default_options` would
+    // alter silently — nothing else in the crate would fail to compile, and the
+    // documents would just render differently. They are pure parse tests: no
+    // gpui, no window.
+
+    #[test]
+    fn default_options_are_exactly_the_gfm_five() {
+        let options = default_options();
+
+        for on in [
+            Options::ENABLE_TABLES,
+            Options::ENABLE_FOOTNOTES,
+            Options::ENABLE_STRIKETHROUGH,
+            Options::ENABLE_TASKLISTS,
+            Options::ENABLE_GFM,
+        ] {
+            assert!(options.contains(on), "expected {on:?} to be enabled");
+        }
+
+        for off in [
+            Options::ENABLE_SMART_PUNCTUATION,
+            Options::ENABLE_HEADING_ATTRIBUTES,
+            Options::ENABLE_YAML_STYLE_METADATA_BLOCKS,
+            Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS,
+            Options::ENABLE_OLD_FOOTNOTES,
+            Options::ENABLE_MATH,
+            Options::ENABLE_DEFINITION_LIST,
+            Options::ENABLE_SUPERSCRIPT,
+            Options::ENABLE_SUBSCRIPT,
+            Options::ENABLE_WIKILINKS,
+        ] {
+            assert!(!options.contains(off), "expected {off:?} to be disabled");
+        }
+    }
+
+    /// `ENABLE_SUBSCRIPT` is not a free upgrade: pulldown-cmark's own docs say
+    /// that with it on, `~x~` parses as subscript *instead of* strikethrough.
+    /// Turning it on would restyle every document already using single tildes.
+    #[test]
+    fn single_tilde_is_strikethrough_not_subscript() {
+        use pulldown_cmark::{Event, Tag};
+
+        let events: Vec<_> = parse("~struck~").collect();
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::Start(Tag::Strikethrough))),
+            "single tildes should still be strikethrough: {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::Start(Tag::Subscript))),
+            "subscript must stay off: {events:?}"
+        );
+    }
+
+    #[test]
+    fn wikilinks_stay_literal_text() {
+        use pulldown_cmark::{Event, Tag};
+
+        let events: Vec<_> = parse("[[foo|bar]]").collect();
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::Start(Tag::Link { .. }))),
+            "wikilinks must stay off: {events:?}"
+        );
+    }
+
+    /// GFM alerts ride in on the `BlockQuote` tag's payload rather than a tag
+    /// of their own, so the renderer's `Tag::BlockQuote(_)` arm sees them.
+    #[test]
+    fn gfm_alerts_reach_block_quote_kind() {
+        use pulldown_cmark::{BlockQuoteKind, Event, Tag};
+
+        let events: Vec<_> = parse("> [!NOTE]\n> Something worth knowing.").collect();
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::Start(Tag::BlockQuote(Some(BlockQuoteKind::Note))))),
+            "expected a Note alert: {events:?}"
+        );
+    }
+
+    #[test]
+    fn task_list_markers_are_emitted() {
+        use pulldown_cmark::Event;
+
+        let events: Vec<_> = parse("- [x] done\n- [ ] todo").collect();
+        let markers: Vec<bool> = events
+            .iter()
+            .filter_map(|e| match e {
+                Event::TaskListMarker(checked) => Some(*checked),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(markers, vec![true, false]);
+    }
+
+    #[test]
+    fn table_column_alignments_survive() {
+        use pulldown_cmark::{Alignment, Event, Tag};
+
+        let source = "| a | b | c |\n|:--|:-:|--:|\n| 1 | 2 | 3 |";
+        let alignments = parse(source).find_map(|e| match e {
+            Event::Start(Tag::Table(alignments)) => Some(alignments),
+            _ => None,
+        });
+
+        assert_eq!(
+            alignments,
+            Some(vec![Alignment::Left, Alignment::Center, Alignment::Right])
+        );
+    }
+
+    /// The renderer keeps `into_offset_iter` ranges and slices the source with
+    /// them; a range landing mid-codepoint would panic on a non-ASCII document.
+    #[test]
+    fn offset_ranges_land_on_char_boundaries() {
+        let source = "# Überschrift\n\nEin Absatz mit **fettem** Text — und einem Emoji 🎉.\n\n\
+                      - Ein Listenpunkt mit `Code`\n";
+
+        for (event, range) in parse(source).into_offset_iter() {
+            assert!(
+                source.is_char_boundary(range.start) && source.is_char_boundary(range.end),
+                "range {range:?} splits a codepoint for {event:?}"
+            );
+            assert!(range.end <= source.len(), "range {range:?} out of bounds");
+        }
     }
 }

--- a/todo.md
+++ b/todo.md
@@ -31,8 +31,6 @@
 - Scroll Area
 - Select
 - Separator
-- Skeleton
-- Grain
 - Slider
 - Switch
 - Tabs
@@ -42,6 +40,27 @@
 - Toggle Group
 - Tooltip
 - Typography
+
+## Removed — disabled pending performance work
+
+Both were removed in [#121](https://github.com/iamnbutler/gpuikit/pull/121) and
+shipped removed in 0.5.0. They are listed here rather than deleted so that
+whoever revives one does not rebuild the same problem.
+
+- **Skeleton** — the pulse ran through `Animation::new(1500ms).repeat()`. A gpui
+  `AnimationElement` asks for another frame for as long as its animation is
+  live, and `.repeat()` is never done, so a single skeleton pinned its window at
+  the display refresh rate and everything else on that window re-laid-out and
+  repainted at that rate too. (`Skeleton::animated(false)` did not help: the
+  animation was attached unconditionally and the callback merely returned the
+  element unchanged, so the repaint loop ran with the pulse "off".) To bring it
+  back it has to stop requesting frames — drive the pulse off a timer or one
+  shared animation entity — not merely animate more cheaply.
+- **Grain** — paints one quad per 4px cell inside a `canvas`, roughly 60k quads
+  for a 1200×800 area. Tolerable on an idle window; it was what made the
+  skeleton's forced repaint read as "a ton of lag" in the old single-scroll
+  showcase, where several of each were mounted at once. Needs to become a
+  shader or a tiled texture before it comes back.
 
 ## Not Yet Implemented
 


### PR DESCRIPTION
# Markdown: pulldown-cmark 0.13.4, code fence highlighting, and the Skeleton removal on the record

Three related pieces of markdown work, in three commits.

**pulldown-cmark 0.12 → 0.13.4.** 0.13 adds two `Tag`/`TagEnd` variants
(`Superscript`, `Subscript`), and because the renderer matches both types
exhaustively with no wildcard arm, those two variants are the entire compile
break — `Event` gained no variants and every signature this crate calls is
unchanged. Both are added to the existing group of inert arms rather than
replaced with a `_ => {}` wildcard, since the exhaustive match is exactly what
turned this upgrade into a compile error instead of silently dropped styling.
The feature spec is untouched: `features = ["simd"]` is inert here in both
versions, because `simd` expands to `pulldown-cmark-escape?/simd` and that
crate only arrives via the `html` feature, which `default-features = false`
turns off. `default_options()` gains a doc comment recording which 0.13 options
are off and what turning each one on would do to documents that render
correctly today, plus seven pure-parse tests pinning the behaviour an option
change would otherwise alter silently — notably that `~x~` is still
strikethrough, since `ENABLE_SUBSCRIPT` would take it away. Worth flagging for
the release: this is **semver-breaking for downstream consumers** even though
this crate's own rendering does not change, because pulldown-cmark types are
part of the public surface (`MarkdownEvent.event`, the parser re-exports, the
`HeadingLevel` `From` impl). That is recorded in the changelog; the version
bump itself runs through `cargo set-version` in the release workflow, so it is
left to the maintainer.

**Code fences now use their language.** The info string was parsed and then
thrown away. The issue points at `code_block.rs`, but the language was dropped
two frames earlier — `Tag::CodeBlock(_kind)` ignored the kind and
`flush_code_block` passed a literal `None` — so fixing the element alone would
have changed nothing. The renderer now carries the fence's normalized language
down to the element, which asks a new bridge module for that block's highlights
and feeds them into the `selection_styled_text` call that already had an empty
highlight vector in exactly that position. The highlighting comes from the
`editor` feature's syntect-backed `SyntaxHighlighter` via two new methods:
`resolve_language` and `highlight_block`, the latter a stateless single pass
whose parse state stays local to the call — `highlight_line` keys its state on
`(language, line_number)` across the whole instance, so two `rust` blocks both
starting at line 0 would contaminate each other and any live editor. It is
opt-in per app with `markdown::init_code_highlighting(cx)`, because loading
syntect's defaults costs tens of milliseconds and a few megabytes that a
document with no code in it should not pay, and it degrades to the plain
monospace it rendered before at every step: no `editor` feature, no init call,
no info string, no matching syntax, or an oversized block. Two colour
subtractions keep blocks readable — syntect's per-span background would paint
over the block's own surface and fight the selection highlight, and spans that
merely restate the syntect theme's plain foreground are dropped so ordinary
code keeps the app's text colour. Highlights are cached on
(text, language, theme), so a light/dark toggle re-highlights for free.

**Skeleton is documented as removed.** Issue #120 asks to disable the component
until its performance is fixed; in the code that already happened, silently —
`src/elements/skeleton.rs` was deleted in `328ec86`, which folded that step
(and a Grain removal) into an unrelated showcase PR, and shipped in 0.5.0.
There is nothing left in `src/` or `examples/` to disable, so this part is
documentation only: the README no longer advertises Skeleton, `todo.md` moves
both components out of **Implemented** into a **Removed** section, and the
missing `0.5.0` changelog section now records a breaking API removal that
anyone upgrading from 0.4.x previously met as a bare `unresolved import`. The
reason is written down so the next person does not rebuild it: the pulse used
`Animation::new(1500ms).repeat()`, and a gpui `AnimationElement` requests
another frame for as long as its animation is live, so one skeleton pinned its
window at the display refresh rate and forced everything else on it to re-lay-out
and repaint too — with `Skeleton::animated(false)` no escape hatch, since the
animation was attached unconditionally and the callback just returned the
element unchanged. Re-adding a de-animated Skeleton was deliberately not done;
it has been off the public surface since 0.5.0, and reviving a dead element
would reverse a shipped decision and break the API again when it is removed a
second time.

Verification: PASSED — `cargo test --features editor --all-targets` (375 passed, 0 failed), `cargo test --all-targets` (238 passed, 0 failed), `cargo check --all-features --all-targets`, `cargo clippy --all-targets --features editor` (no warnings in any touched file), `cargo fmt --all --check`

Implements #129
Implements #128
Implements #120
