### PR TITLE
Publish 0.8.0: `append`, `stitch` and the background parser exist only on main, and main still calls itself 0.7.0

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -112,6 +112,9 @@ jobs:
 
           echo "Version verified: $ACTUAL"
 
+      # --all-features pulls in `stitch`, and therefore mdstitch, which declares
+      # rust-version 1.95.0 — above this crate's own 1.85 floor. The runner's
+      # `stable` above must stay at or beyond that (it is 1.97 today).
       - name: Run cargo check
         run: cargo check --all-features
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
           - major
         default: patch
       custom_version:
-        description: 'Custom version (overrides version_type if set, e.g., 1.2.3)'
+        description: 'Custom version, e.g. 1.2.3 (overrides version_type; required when Cargo.toml already names the version being released, since version_type counts up FROM Cargo.toml)'
         required: false
         type: string
       dry_run:
@@ -140,7 +140,11 @@ jobs:
         if: ${{ !inputs.dry_run }}
         run: |
           git add Cargo.toml
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          # Cargo.toml may already carry the target version — a release prepared
+          # in a PR makes `cargo set-version` a no-op, and `git commit` with an
+          # empty stage exits 1 and would abort the release before the tag.
+          git diff --cached --quiet || \
+            git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
 
       - name: Create and push tag
         if: ${{ !inputs.dry_run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.8.0] - 2026-08-17
+
+The release that makes streaming markdown depend on a published version rather
+than a git rev. `Markdown::append`, the off-thread parser and the optional
+`stitch` feature have all been on `main` since 0.7.0 with nothing to name them
+by. Also corrects `rust-version`, which claimed 1.75 and has not been true for
+some time.
 
 ### Breaking Changes
 
@@ -163,6 +169,66 @@ All notable changes to this project will be documented in this file.
   against what belongs in its own example binary (interactions and
   integrations), and the build commands
 
+
+- `Markdown::append`, for content that arrives a piece at a time (an LLM reply,
+  a log tail). It extends the source instead of making the caller rebuild and
+  re-set the whole document, and unlike `set_source` it keeps the selection —
+  selection positions are `(run, byte offset)`, so text arriving at the end
+  cannot disturb a selection made earlier
+- Optional `stitch` feature: closes the syntax a partially streamed document
+  leaves open (`**bold` with no closer, `[label](htt`) before parsing, so
+  streaming text does not flicker between literal markers and styled text.
+  Off by default — [mdstitch](https://docs.rs/mdstitch) declares
+  `rust-version = "1.95.0"`, above this crate's 1.85, so turning it on raises
+  the toolchain your build needs. `markdown::preprocessing_available()`
+  reports which build you got, and `Markdown::set_preprocess_partial` turns it
+  off per document
+- `examples/markdown_streaming.rs`, a reply dripping in through `append`
+- Markdown documents and their text runs are now in the accessibility tree.
+  The document is a `Role::Document`; each run is a heading, paragraph, list
+  item, block quote or code node, labelled with its text, and headings report
+  their level
+- `MarkdownElement::id`, to override the element id a document — and therefore
+  all of its runs — is scoped under. The default is derived from the `Markdown`
+  entity, so it is unique and stable across frames already; set it when the
+  same entity is rendered more than once in one frame.
+  `MarkdownElement::element_id` reads back whichever applies
+- `RunRole`, and `HeadingLevel::level()`
+- `element_id`, the rule for minting element ids written down once, with the
+  two helpers that implement it — `element_id::for_entity(name, entity_id)` for
+  an element backed by an entity and `element_id::scoped(&parent_id, part)` for
+  a named part of one — and a note on what does and does not scope an id in
+  gpui (an `Entity<V: Render>` child does, a `RenderOnce` struct does not,
+  `deferred()` neither scopes nor unscopes). A test scans this crate's own
+  source and fails on any element that mints a constant id
+- `Textarea::id`, to override the element id a textarea renders under, and
+  `Textarea::element_id` to read back whichever applies. The default is derived
+  from the `InputState` entity; set it when one state is rendered by more than
+  one textarea in a frame
+- Fenced code blocks are syntax highlighted from their info string. The
+  language was parsed and then thrown away; it now reaches the element and is
+  highlighted by the `editor` feature's syntect-backed `SyntaxHighlighter`.
+  **Opt in per app** with `markdown::init_code_highlighting(cx)` after
+  `gpuikit::init` — loading syntect's syntax and theme sets costs tens of
+  milliseconds and a few megabytes, which a document containing no code should
+  not pay. Requires the `editor` feature; without it, without the init call,
+  without an info string, or for a language syntect has no grammar for, blocks
+  render as the plain monospace they did before. Highlights are cached per
+  block on (text, language, theme). The syntect theme follows the block's
+  background — `base16-ocean.dark` on a dark surface, `InspiredGitHub` on a
+  light one — or can be pinned with
+  `markdown::set_code_highlight_theme(cx, CodeHighlightTheme::Pinned(..))`;
+  `markdown::code_highlight_themes(cx)` lists the names it accepts
+- `markdown::normalize_language`, the fence-info-string-to-language-token rule
+  (leading word only, so ` ```rust,ignore ` is `rust`; a small alias table;
+  `text`/`plaintext`/`plain`/`none` mean no language)
+- `SyntaxHighlighter::highlight_block`, which highlights a whole block in one
+  stateless pass and returns `HighlightStyle`s, plus
+  `SyntaxHighlighter::resolve_language` and `SyntaxHighlighter::current_theme`.
+  Unlike `highlight_line`, `highlight_block` keeps its parse state local to the
+  call, so two blocks of one language cannot contaminate each other by both
+  starting at line 0
+
 ### Changed
 
 - The showcase's Markdown page demonstrates what the renderer can do rather
@@ -186,6 +252,17 @@ All notable changes to this project will be documented in this file.
   which source the current events came from and `is_parsing()` whether one is
   in flight
 - `set_source` with the source the document already has does nothing
+- `rust-version` is `1.85`, correcting a declared `1.75` that was never kept —
+  the crate uses async closures and gpui is edition 2024, both of which need
+  1.85. Nothing about what compiles changes; the manifest now says what was
+  already true. It remains a statement about this crate's own source: cargo does
+  not hold dependencies back to it, and several already declare more
+  (cosmic-text and smol_str 1.89, oo7 1.92 on Linux)
+- The `stitch` feature's toolchain requirement is written down rather than met
+  in a build log: it needs **Rust 1.95**, against this crate's 1.85, because
+  mdstitch declares `rust-version = "1.95.0"`. The README gains a feature table
+  and a minimum-Rust-version section, and the crate docs docs.rs renders list
+  all four features instead of only `editor`
 
 ### Fixed
 
@@ -342,66 +419,6 @@ All notable changes to this project will be documented in this file.
   node in release, so each of these was one `a11y_role` away from a crash. Ids
   are now derived from the entity backing the element, or from the id its
   caller gave it
-
-### Added
-
-- `Markdown::append`, for content that arrives a piece at a time (an LLM reply,
-  a log tail). It extends the source instead of making the caller rebuild and
-  re-set the whole document, and unlike `set_source` it keeps the selection —
-  selection positions are `(run, byte offset)`, so text arriving at the end
-  cannot disturb a selection made earlier
-- Optional `stitch` feature: closes the syntax a partially streamed document
-  leaves open (`**bold` with no closer, `[label](htt`) before parsing, so
-  streaming text does not flicker between literal markers and styled text.
-  Off by default — [mdstitch](https://docs.rs/mdstitch) requires a newer
-  compiler than this crate declares. `markdown::preprocessing_available()`
-  reports which build you got, and `Markdown::set_preprocess_partial` turns it
-  off per document
-- `examples/markdown_streaming.rs`, a reply dripping in through `append`
-- Markdown documents and their text runs are now in the accessibility tree.
-  The document is a `Role::Document`; each run is a heading, paragraph, list
-  item, block quote or code node, labelled with its text, and headings report
-  their level
-- `MarkdownElement::id`, to override the element id a document — and therefore
-  all of its runs — is scoped under. The default is derived from the `Markdown`
-  entity, so it is unique and stable across frames already; set it when the
-  same entity is rendered more than once in one frame.
-  `MarkdownElement::element_id` reads back whichever applies
-- `RunRole`, and `HeadingLevel::level()`
-- `element_id`, the rule for minting element ids written down once, with the
-  two helpers that implement it — `element_id::for_entity(name, entity_id)` for
-  an element backed by an entity and `element_id::scoped(&parent_id, part)` for
-  a named part of one — and a note on what does and does not scope an id in
-  gpui (an `Entity<V: Render>` child does, a `RenderOnce` struct does not,
-  `deferred()` neither scopes nor unscopes). A test scans this crate's own
-  source and fails on any element that mints a constant id
-- `Textarea::id`, to override the element id a textarea renders under, and
-  `Textarea::element_id` to read back whichever applies. The default is derived
-  from the `InputState` entity; set it when one state is rendered by more than
-  one textarea in a frame
-- Fenced code blocks are syntax highlighted from their info string. The
-  language was parsed and then thrown away; it now reaches the element and is
-  highlighted by the `editor` feature's syntect-backed `SyntaxHighlighter`.
-  **Opt in per app** with `markdown::init_code_highlighting(cx)` after
-  `gpuikit::init` — loading syntect's syntax and theme sets costs tens of
-  milliseconds and a few megabytes, which a document containing no code should
-  not pay. Requires the `editor` feature; without it, without the init call,
-  without an info string, or for a language syntect has no grammar for, blocks
-  render as the plain monospace they did before. Highlights are cached per
-  block on (text, language, theme). The syntect theme follows the block's
-  background — `base16-ocean.dark` on a dark surface, `InspiredGitHub` on a
-  light one — or can be pinned with
-  `markdown::set_code_highlight_theme(cx, CodeHighlightTheme::Pinned(..))`;
-  `markdown::code_highlight_themes(cx)` lists the names it accepts
-- `markdown::normalize_language`, the fence-info-string-to-language-token rule
-  (leading word only, so ` ```rust,ignore ` is `rust`; a small alias table;
-  `text`/`plaintext`/`plain`/`none` mean no language)
-- `SyntaxHighlighter::highlight_block`, which highlights a whole block in one
-  stateless pass and returns `HighlightStyle`s, plus
-  `SyntaxHighlighter::resolve_language` and `SyntaxHighlighter::current_theme`.
-  Unlike `highlight_line`, `highlight_block` keeps its parse state local to the
-  call, so two blocks of one language cannot contaminate each other by both
-  starting at line 0
 
 ## [0.7.0] - 2026-08-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpuikit"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Nate Butler <iamnbutler@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,11 @@ description = "A UI toolkit for GPUI applications"
 readme = "README.md"
 keywords = ["gpui", "ui", "components", "toolkit", "gui"]
 categories = ["gui", "graphics"]
-rust-version = "1.75"
+# This crate's own floor, not a promise about the whole dependency tree: it uses
+# async closures (stable in 1.85), and gpui is edition 2024, which needs the same
+# 1.85. The declared 1.75 was never true. Dependencies declare their own, higher
+# numbers and cargo does not hold them back — see README's "Minimum Rust version".
+rust-version = "1.85"
 
 [lib]
 name = "gpuikit"
@@ -87,7 +91,9 @@ schema = ["dep:schemars"]
 runtime_shaders = ["gpui_platform/runtime_shaders"]
 # Close unterminated markdown syntax before parsing, so a streaming document
 # does not flicker between literal markers and styled text. Off by default:
-# mdstitch declares rust-version 1.95, above this crate's declared floor.
+# mdstitch declares rust-version 1.95.0, above this crate's own 1.85 floor, so
+# enabling it raises the toolchain a consumer needs. Keep the README's feature
+# table in step with these numbers.
 stitch = ["dep:mdstitch"]
 
 # Lints

--- a/README.md
+++ b/README.md
@@ -10,15 +10,43 @@ A UI toolkit for GPUI applications.
 
 ```toml
 [dependencies]
-gpuikit = "0.7"
+gpuikit = "0.8"
 
 # OR to enable the text editor component:
-# gpuikit = { version = "0.7", features = ["editor"] }
+# gpuikit = { version = "0.8", features = ["editor"] }
 
 # OR, for streaming markdown, to close the syntax a half-written document
 # leaves open before parsing it (needs Rust 1.95+):
-# gpuikit = { version = "0.7", features = ["stitch"] }
+# gpuikit = { version = "0.8", features = ["stitch"] }
 ```
+
+## Features
+
+All features are off by default.
+
+| Feature | Needs Rust | What it adds |
+| --- | --- | --- |
+| `editor` | 1.85 | The `Editor` component, and the syntect-backed syntax highlighting that markdown code fences use once an app calls `markdown::init_code_highlighting`. Pulls in `syntect` |
+| `stitch` | **1.95** | Closes the syntax a partially streamed markdown document leaves open (`**bold`, `[label](htt`) before parsing, so streaming text does not flicker between literal markers and styled text. Pulls in [mdstitch](https://docs.rs/mdstitch), which declares `rust-version = "1.95.0"`. `markdown::preprocessing_available()` reports which build you got |
+| `runtime_shaders` | 1.85 | Compiles Metal shaders at runtime instead of at build time, so a macOS build needs no Xcode Metal toolchain |
+| `schema` | 1.85 | Adds the `schemars` dependency. Nothing in the crate derives `JsonSchema` yet, so today this only affects your dependency graph |
+
+### Minimum Rust version
+
+gpuikit declares `rust-version = "1.85"`. That is a statement about **this
+crate's own source** — it uses async closures, and gpui is edition 2024, which
+needs the same 1.85 — and not a guarantee about a whole build. The crate is
+edition 2021, so cargo's v2 feature resolver does not hold dependencies back to
+gpuikit's floor, and several of them already declare more (cosmic-text and
+smol_str 1.89, image and time 1.88, oo7 1.92 on the Linux secret-service path).
+On a toolchain near 1.85 you will most likely meet a dependency's floor before
+you meet gpuikit's. A recent stable is the practical answer.
+
+`stitch` is the one feature that raises the floor of gpuikit itself, to **1.95**.
+Leaving it off costs you only the partial-syntax closing: `Markdown::append` and
+the background parser are unconditional, so streaming still works — a
+half-written `**bold` just flashes as literal asterisks until its closer
+arrives.
 
 ## Control sizes
 

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -835,7 +835,7 @@ impl Showcase {
         let text_field_disabled = cx.new(|cx| InputState::new_singleline(cx));
         let text_field_read_only = cx.new(|cx| {
             let mut state = InputState::new_singleline(cx);
-            state.set_content("gpuikit-0.7.0", cx);
+            state.set_content("gpuikit-0.8.0", cx);
             state
         });
         // One of each stateful control per rung. Built here rather than in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,33 @@
 //!
 //! # Feature Flags
 //!
-//! - `editor` - Enables the editor component with syntax highlighting support
+//! All features are off by default.
+//!
+//! - `editor` — the editor component, and the syntect-backed syntax
+//!   highlighting markdown code fences use once an app calls
+//!   `markdown::init_code_highlighting` (itself gated on this feature)
+//! - `stitch` — closes the syntax a partially streamed markdown document leaves
+//!   open (`**bold`, `[label](htt`) before parsing, so streaming text does not
+//!   flicker between literal markers and styled text. Pulls in
+//!   [mdstitch](https://docs.rs/mdstitch), which **requires Rust 1.95**;
+//!   [`markdown::preprocessing_available`] reports which build you got
+//! - `runtime_shaders` — compiles Metal shaders at runtime rather than at build
+//!   time, so a macOS build needs no Xcode Metal toolchain
+//! - `schema` — adds the `schemars` dependency. Nothing here derives
+//!   `JsonSchema` yet, so today this only affects your dependency graph
+//!
+//! # Minimum Rust version
+//!
+//! This crate declares `rust-version = "1.85"`, which is a statement about its
+//! own source — async closures, and gpui's edition 2024 — rather than a
+//! guarantee about a whole build. gpuikit is edition 2021, so cargo's v2
+//! feature resolver does not hold dependencies back to that floor, and several
+//! already declare more (cosmic-text and smol_str 1.89, oo7 1.92 on Linux); on
+//! a toolchain near 1.85 you will most likely meet one of theirs first. A
+//! recent stable is the practical answer.
+//!
+//! The `stitch` feature raises gpuikit's own floor to **1.95**. It is the only
+//! one that does.
 
 use gpui::App;
 use rust_embed::RustEmbed;


### PR DESCRIPTION
# Cut gpuikit 0.8.0

`main` carries `Markdown::append`, the off-thread parser and the optional
`stitch` feature, but still calls itself `0.7.0`, so consumers have no released
version to name and are pinned to a git rev. This prepares the release:
`version = "0.8.0"`, and `rust-version` corrected from a never-kept `1.75` to
the actual `1.85` — the crate uses async closures (`cx.spawn(async move |…|`)
and gpui is edition 2024, both of which need 1.85. The `[Unreleased]` changelog
section becomes `[0.8.0] - 2026-08-17` with a lead paragraph, following how
0.5.0 and 0.7.0 were written; the build batches had left **two** separate
`### Added` sections inside `[Unreleased]`, and they are merged back into house
order (Breaking Changes / Added / Changed / Fixed). Bullet count went 84 → 86,
exactly the two new *Changed* entries, so the merge dropped nothing.

The `stitch` feature's toolchain requirement is now written down instead of
turning up in someone's build log: it needs **Rust 1.95**, against this crate's
1.85, because mdstitch declares `rust-version = "1.95.0"` (confirmed from the
registry copy of its manifest, not from the existing comment). That goes in a
new README `## Features` table covering all four features — `editor`, `stitch`,
`runtime_shaders` and the honestly-described inert `schema` — and in the
`# Feature Flags` rustdoc in `src/lib.rs`, which had listed only `editor` and is
what docs.rs renders with `all-features = true`. Both also gain a minimum Rust
version section saying out loud that `rust-version` is a promise about *this
crate*, not about a whole build: gpuikit is edition 2021, so the v2 resolver
does not hold dependencies back to 1.85, and several already declare more
(cosmic-text and smol_str 1.89, image/time/psm 1.88, oo7 1.92 on the Linux
secret-service path). Raising the declared floor to chase those numbers was
deliberately not done — it is a separate decision and those numbers move.

Two workflow fixes come with it. `release.yml`'s *Commit version bump* step ran
a bare `git commit`, which exits 1 when nothing is staged; now that `Cargo.toml`
carries 0.8.0 ahead of the run, `cargo set-version 0.8.0` is a no-op and that
step would have aborted the release before the tag, so it is now
`git diff --cached --quiet || git commit`. The `custom_version` input
description now says it is required when `Cargo.toml` already names the version,
because `version_type` counts up *from* `Cargo.toml` — choosing `minor` after
this change would release 0.9.0, not 0.8.0. **Whoever publishes should run the
Release workflow with `custom_version: 0.8.0`.** `release-deploy.yml` gets a
comment only, noting that its `cargo check --all-features` gate pulls `stitch`
and so needs the runner's `stable` to stay ≥ 1.95 (it is 1.97 today). One stale
`"gpuikit-0.7.0"` placeholder string in the showcase's read-only field demo was
bumped too.

Verification: PASSED — `cargo fmt --check`, `cargo check --all-features --all-targets` (exit 0, only the pre-existing `unused_mut` warning at `src/input/bindings.rs:461`), `cargo test --all-features --lib -j 1` (**510 passed, 0 failed**), and `cargo doc --no-deps --all-features` (exit 0; 7 warnings, all pre-existing and none in `src/lib.rs`). Clippy was not re-run — the spec recorded it green and this change touches no executable code beyond one string literal.

Implements #150
