### PR TITLE
Input: use web-time so undo grouping doesn't panic on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ log = "0.4"
 # Input module dependencies
 unicode-bidi = "0.3"
 unicode-segmentation = "1.10"
+# `std::time::Instant::now()` panics on wasm32-unknown-unknown; web-time
+# re-exports the std types unchanged on native targets.
+web-time = "1"
 # No async runtime here on purpose. `smol::Timer` is `async_io::Timer`, and
 # constructing one spawns the process-global `async-io` OS thread, whose
 # `main_loop` has no exit path — it was still in the reactor at process exit

--- a/src/input/state.rs
+++ b/src/input/state.rs
@@ -1,6 +1,9 @@
 use std::ops::Range;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+// std's Instant::now() panics on wasm32-unknown-unknown; web-time re-exports
+// std::time::Instant on native targets.
+use web_time::Instant;
 
 use gpui::{
     point, px, App, AppContext, Bounds, ClipboardItem, Context, Entity, EventEmitter, FocusHandle,


### PR DESCRIPTION
## Problem

`std::time::Instant::now()` panics on `wasm32-unknown-unknown`. `InputState::push_undo_patch` calls it to timestamp history entries for undo grouping, so typing a single character into any gpuikit text input crashed the whole app when compiled for the web (gpui-unofficial's web platform).

## Fix

Depend on [`web-time`](https://crates.io/crates/web-time) (v1) and import `Instant` from it in `src/input/state.rs`. On native targets web-time re-exports the std types unchanged, so this is zero behavior change on desktop; on wasm it backs `Instant` with `performance.now()`.

Audited the rest of `src/`: `state.rs` was the only runtime `Instant` user, nothing uses `SystemTime`, and the remaining `std::time` imports are `Duration`-only (pure arithmetic, safe on wasm).

## Verification

- `cargo check --target wasm32-unknown-unknown` passes, run through the gpuikit-wasm-example harness (nightly + build-std, wasm atomics) with its path dependency pointed at this branch.
- `cargo test` natively: 564 unit tests + 2 doctests, 0 failures.