### PR TITLE
Wasm support: embed assets on wasm, guard hostile std APIs, document web

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,14 @@ gpui_util = { package = "gpui-util-gpui-unofficial", version = "1.14.2", optiona
 # Schema generation (optional)
 schemars = { version = "0.8", optional = true }
 
+# rust-embed's default debug behavior reads assets from disk at runtime, and
+# the browser has no disk — a debug wasm build would fail to load every icon
+# and font. `debug-embed` compiles the assets in for every profile; gating it
+# to wasm keeps native debug builds' fast from-disk iteration. Consumers get
+# this via feature unification without knowing the trick exists.
+[target.'cfg(target_family = "wasm")'.dependencies]
+rust-embed = { version = "8.2.0", features = ["debug-embed"] }
+
 [dev-dependencies]
 gpui = { package = "gpui-unofficial", version = "1.14.2", features = ["test-support"] }
 tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,32 @@ follow-up parse. The `stitch` feature additionally closes unterminated syntax
 document flickering between literal markers and styled text. See
 `examples/markdown_streaming.rs`.
 
+## Web (wasm)
+
+gpuikit runs in the browser on gpui's web platform
+(`gpui-web-gpui-unofficial`, WebGPU via wgpu) — live demo at
+<https://nate.rip/gpuikit-demo/>, built from
+[iamnbutler/gpuikit-demo](https://github.com/iamnbutler/gpuikit-demo), which
+is also the reference for the build setup (trunk, nightly + `build-std`, wasm
+atomics, COOP/COEP headers).
+
+Two things to know beyond that recipe:
+
+- **Boot with `run_embedded`, not `run`.** The browser owns the event loop,
+  so `Platform::run` returns immediately and plain `Application::run` drops
+  the app right after launch — a blank page with no error. Keep the handle
+  alive: `std::mem::forget(app.run_embedded(boot))`. (Upstream:
+  [gpui-unofficial#297](https://github.com/iamnbutler/gpui-unofficial/issues/297).)
+- **Assets embed automatically.** On wasm targets this crate turns on
+  rust-embed's `debug-embed`, so debug builds don't try to read icons and
+  fonts from a disk that isn't there.
+
+A few APIs are native-only by design — `gpuikit::fs`, keymap-from-file, the
+editor's theme-from-file — and say so in their docs;
+`src/wasm_compat_guard.rs` keeps that list honest and keeps wasm-hostile std
+APIs (`std::time::Instant`, `std::fs`, `std::thread::spawn`) out of runtime
+code everywhere else.
+
 ## Testing
 
 ```sh

--- a/src/editor/syntax_highlighter.rs
+++ b/src/editor/syntax_highlighter.rs
@@ -606,8 +606,12 @@ impl SyntaxHighlighter {
             .unwrap_or_else(|| gpui::rgba(0x3e4451aa).into())
     }
 
-    // Load custom themes from a directory
-    // Example: highlighter.load_theme_from_file("./themes/my-theme.tmTheme")
+    /// Loads a custom `.tmTheme` from disk, e.g.
+    /// `highlighter.load_theme_from_file("./themes/my-theme.tmTheme")`.
+    ///
+    /// **Native-only**: reads via `std::fs`, which fails at runtime on
+    /// `wasm32-unknown-unknown`. `src/wasm_compat_guard.rs` tracks this
+    /// exemption.
     #[allow(dead_code)]
     pub fn load_theme_from_file(&mut self, path: &str) -> Result<(), String> {
         use std::fs::File;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,3 +1,12 @@
+//! In-memory file editing backed by the local filesystem.
+//!
+//! **Native-only.** This module exists to read and write the local disk via
+//! `std::fs`, so while it *compiles* for `wasm32-unknown-unknown`, every disk
+//! operation fails at runtime in the browser — there is no filesystem there.
+//! A wasm consumer should bundle content as assets (see [`crate::assets`])
+//! instead of reaching for this module. `src/wasm_compat_guard.rs` tracks
+//! this exemption.
+
 use anyhow::{anyhow, Result};
 use gpui::Context;
 use gpui::TaskExt as _;

--- a/src/input/bindings.rs
+++ b/src/input/bindings.rs
@@ -458,6 +458,8 @@ impl InputBindings {
 
     /// Collects all `Some` bindings into a `Vec<KeyBinding>`.
     pub fn into_bindings(self) -> Vec<KeyBinding> {
+        // The `mut` is only exercised by the macOS-only pushes below.
+        #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
         let mut bindings: Vec<Option<KeyBinding>> = vec![
             self.backspace,
             self.delete,

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -2,6 +2,11 @@
 //!
 //! This module provides JSON-based keymap configuration support, allowing
 //! keybindings to be loaded from external files rather than hardcoded.
+//!
+//! **Loading from a path is native-only.** The from-file APIs use `std::fs`,
+//! which compiles for `wasm32-unknown-unknown` but fails at runtime in the
+//! browser. On wasm, build a [`Keymap`] from a JSON string or in code
+//! instead. `src/wasm_compat_guard.rs` tracks this exemption.
 
 use anyhow::{anyhow, Context as _, Result};
 use serde::{Deserialize, Serialize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,17 @@ mod build_profile_guard;
 #[cfg(test)]
 mod undying_thread_guard;
 
+/// Tests for the rule that runtime code stays runnable on
+/// `wasm32-unknown-unknown` — no `std::time::Instant`/`SystemTime`,
+/// `std::fs`, or `std::thread::spawn` outside an explicit allowlist of
+/// native-only APIs and test-only code. These compile for wasm and then
+/// panic or error in the browser, which no local `cargo test` would catch.
+///
+/// No runtime code, and nothing outside a test build. See its own docs, and
+/// <https://github.com/iamnbutler/gpuikit-demo> for gpuikit running on wasm.
+#[cfg(test)]
+mod wasm_compat_guard;
+
 /// Embedded assets for gpuikit (icons, fonts, etc.)
 #[derive(RustEmbed)]
 #[folder = "assets"]

--- a/src/wasm_compat_guard.rs
+++ b/src/wasm_compat_guard.rs
@@ -1,0 +1,256 @@
+//! Tests for the rule that runtime code stays compilable *and runnable* on
+//! `wasm32-unknown-unknown`.
+//!
+//! gpuikit runs in the browser on gpui's web platform (see the demo at
+//! <https://github.com/iamnbutler/gpuikit-demo>, live at
+//! <https://nate.rip/gpuikit-demo/>). The failure mode this guards against is
+//! quiet: several std APIs *compile* for wasm and then fail at runtime —
+//! `std::time::Instant::now()` panics outright, and `std::fs` returns errors
+//! on a filesystem that does not exist. The first symptom is a crashed or
+//! broken page in a browser, on a target no local `cargo test` exercises.
+//!
+//! The real check would be `cargo check --target wasm32-unknown-unknown` in
+//! CI, but that build needs nightly, `build-std`, and the wasm-atomics
+//! rustflags (see the demo repo's `.cargo/config.toml`) — a heavier lift than
+//! this repository's CI carries today. Until it does, this scan is the guard:
+//! it forbids the APIs by name in source, with an explicit per-file allowlist
+//! for the uses that are legitimate.
+//!
+//! Two kinds of use are allowed, and each allowlist entry says which it is:
+//!
+//! - **Native-only APIs by design.** `fs::File`, keymap-loading, and the
+//!   editor's theme-from-file all exist to read the local disk; their docs say
+//!   they are native-only. A wasm consumer simply doesn't call them.
+//! - **Test-only code.** Guard modules and `#[cfg(test)]` blocks never reach
+//!   a wasm binary.
+//!
+//! Every entry is also asserted to still be true — a file that stops using
+//! the API fails the scan until its entry is deleted, so the allowlist cannot
+//! go stale, and a *new* use anywhere fails until someone consciously adds an
+//! entry (or, better, reaches for a wasm-safe alternative: `web-time` for
+//! clocks, gpui's asset system for bundled files).
+//!
+//! Like the other guards, this lives in the lib rather than `tests/` because
+//! `cargo test --lib` is the command that works everywhere. Each scan asserts
+//! it actually looked at something before its "found nothing" is trusted.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// This module names every forbidden string in its own literals, so it would
+/// flag itself. It is the one file the scan skips outright, and the scan
+/// asserts the count so the exemption cannot silently widen.
+const SELF: &str = "wasm_compat_guard.rs";
+
+/// A std API that misbehaves on `wasm32-unknown-unknown`, the files allowed
+/// to use it, and why each is allowed.
+struct ForbiddenApi {
+    /// Substring that marks a use. Matched against comment-stripped source,
+    /// so prose mentions don't count; string literals do, which is why
+    /// [`SELF`] is skipped by name.
+    needle: &'static str,
+    /// Only flag lines that also contain one of these (empty = flag any
+    /// occurrence). This is how `std::time::Duration` — fine on wasm — stays
+    /// allowed while `Instant` and `SystemTime` from the same import line are
+    /// not.
+    line_must_also_contain: &'static [&'static str],
+    /// What happens on wasm, shown in the failure message.
+    why: &'static str,
+    /// (path relative to `src/`, justification) — every entry is asserted to
+    /// still match, so deleting the last use of an API also means deleting
+    /// its entry here.
+    allowed: &'static [(&'static str, &'static str)],
+}
+
+const FORBIDDEN: &[ForbiddenApi] = &[
+    ForbiddenApi {
+        needle: "std::time",
+        line_must_also_contain: &["Instant", "SystemTime"],
+        why: "`std::time::Instant::now()` and `SystemTime::now()` panic on \
+              wasm32-unknown-unknown. Use the `web-time` crate (already a dependency), \
+              which re-exports the std types on native targets and browser-backed ones \
+              on wasm — see `input/state.rs` for the pattern.",
+        allowed: &[],
+    },
+    ForbiddenApi {
+        needle: "std::fs",
+        line_must_also_contain: &[],
+        why: "there is no filesystem on wasm32-unknown-unknown; `std::fs` compiles and then \
+              errors at runtime. Bundle files with the asset system, or document the API as \
+              native-only and add it to this allowlist.",
+        allowed: &[
+            ("fs.rs", "the file-editing module exists to read/write the local disk; native-only by design and documented as such"),
+            ("keymap/mod.rs", "loads keymap JSON from user-supplied paths; native-only by design and documented as such"),
+            ("editor/syntax_highlighter.rs", "`load_theme_from_file` reads a .tmTheme from disk; native-only by design and documented as such"),
+            ("a11y.rs", "test-only: golden-file assertions inside `#[cfg(test)] mod tests`"),
+            ("element_id.rs", "test-only: source scan inside `#[cfg(test)] mod tests`"),
+            ("elements.rs", "test-only: coverage scans inside `#[cfg(test)]` modules"),
+            ("build_profile_guard.rs", "test-only guard module"),
+            ("release_input_validation.rs", "test-only guard module"),
+            ("release_version_guard.rs", "test-only guard module"),
+            ("undying_thread_guard.rs", "test-only guard module"),
+        ],
+    },
+    ForbiddenApi {
+        needle: "std::thread::spawn",
+        line_must_also_contain: &[],
+        why: "spawning OS threads traps on wasm32-unknown-unknown (gpui's web platform runs \
+              background work on web workers instead). Use gpui's BackgroundExecutor.",
+        allowed: &[(
+            "utils/element_manager.rs",
+            "test-only: a thread-safety test inside `#[cfg(test)] mod tests`",
+        )],
+    },
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// `source` with `//` line comments and `/* … */` blocks removed. String
+/// literals are left alone — this is a scan for imports and calls, not a
+/// parser, and the one file whose literals would trip it is skipped by name.
+fn code_only(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut chars = source.chars().peekable();
+    let mut in_block = false;
+
+    while let Some(c) = chars.next() {
+        if in_block {
+            if c == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                in_block = false;
+            }
+            continue;
+        }
+        if c == '/' {
+            match chars.peek() {
+                Some('/') => {
+                    for c in chars.by_ref() {
+                        if c == '\n' {
+                            out.push('\n');
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                Some('*') => {
+                    chars.next();
+                    in_block = true;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        out.push(c);
+    }
+
+    out
+}
+
+fn rust_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("source directory is readable") {
+            let path = entry.expect("directory entry is readable").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort();
+    files
+}
+
+/// True if `code` uses the API: contains `needle` on a line that also
+/// mentions one of `line_must_also_contain` (or on any line when that list is
+/// empty).
+fn uses_api(code: &str, api: &ForbiddenApi) -> bool {
+    code.lines().any(|line| {
+        line.contains(api.needle)
+            && (api.line_must_also_contain.is_empty()
+                || api
+                    .line_must_also_contain
+                    .iter()
+                    .any(|extra| line.contains(extra)))
+    })
+}
+
+#[test]
+fn wasm_hostile_apis_appear_only_where_allowed() {
+    let src = repo_root().join("src");
+    let files = rust_files(&src);
+    assert!(
+        files.len() > 20,
+        "walked src/ and found {} Rust files — the walker is broken",
+        files.len(),
+    );
+
+    let mut scanned = 0usize;
+    let mut matched: Vec<(usize, String)> = Vec::new();
+
+    for file in &files {
+        if file.file_name().is_some_and(|name| name == SELF) {
+            continue;
+        }
+        scanned += 1;
+
+        let relative = file
+            .strip_prefix(&src)
+            .expect("file is under src/")
+            .to_str()
+            .expect("source paths are UTF-8")
+            .to_string();
+        let code = code_only(&std::fs::read_to_string(file).expect("source file is readable"));
+
+        for (index, api) in FORBIDDEN.iter().enumerate() {
+            if !uses_api(&code, api) {
+                continue;
+            }
+            let allowed = api.allowed.iter().any(|(path, _)| *path == relative);
+            assert!(
+                allowed,
+                "{relative} uses `{}`{}, which is not on the allowlist: {} \
+                 If this use is genuinely native-only or test-only, add an entry to \
+                 `FORBIDDEN` in {SELF} saying which; otherwise use the wasm-safe \
+                 alternative the message names.",
+                api.needle,
+                if api.line_must_also_contain.is_empty() {
+                    String::new()
+                } else {
+                    format!(" (with {:?})", api.line_must_also_contain)
+                },
+                api.why,
+            );
+            matched.push((index, relative.clone()));
+        }
+    }
+
+    assert_eq!(
+        scanned,
+        files.len() - 1,
+        "exactly one file — `{SELF}`, which names the forbidden strings in its own \
+         literals — is exempt from this scan. {} were skipped.",
+        files.len() - scanned,
+    );
+
+    // Every allowlist entry must still be earning its place. A stale entry is
+    // how "being ported on a parallel branch" quietly becomes "allowed
+    // forever".
+    let matched: BTreeSet<(usize, String)> = matched.into_iter().collect();
+    for (index, api) in FORBIDDEN.iter().enumerate() {
+        for (path, justification) in api.allowed {
+            assert!(
+                matched.contains(&(index, (*path).to_string())),
+                "src/{path} no longer uses `{}` — delete its allowlist entry from {SELF} \
+                 (it was allowed because: {justification}).",
+                api.needle,
+            );
+        }
+    }
+}


### PR DESCRIPTION
Mainlines the wasm findings from the web demo ([gpuikit-demo](https://github.com/iamnbutler/gpuikit-demo), live at https://nate.rip/gpuikit-demo/).

## What

- **Assets embed automatically on wasm.** A `[target.'cfg(target_family = "wasm")'.dependencies]` entry turns on rust-embed's `debug-embed`, so debug wasm builds stop trying to read icons/fonts from a disk that doesn't exist. Consumers get it via feature unification; native debug builds keep from-disk iteration.
- **`src/wasm_compat_guard.rs`** — a guard test (in the `undying_thread_guard` idiom) forbidding std APIs that compile for `wasm32-unknown-unknown` and then fail in the browser: `std::time::Instant`/`SystemTime` (panic), `std::fs` (errors), `std::thread::spawn` (traps). A per-file allowlist distinguishes native-only-by-design APIs (`fs`, keymap-from-file, editor theme-from-file — each now documented as such) from test-only code, and every entry is asserted to still match, so a fixed file fails the suite until its entry is deleted. With #210 merged, the clock rule has no exemptions; the guard keeps it that way.
- **README "Web (wasm)" section** — live demo, the `run_embedded` boot requirement (iamnbutler/gpui-unofficial#297), and the asset story.
- **`input/bindings.rs`** — quiets an `unused_mut` that only fires off-macOS, where the cfg-gated pushes vanish.

## Verification

- `cargo test --lib`: 565 passed (includes the new guard).
- `cargo check --target wasm32-unknown-unknown` against this branch (via the demo's nightly/build-std toolchain config): clean — the `unused_mut` is gone; only the toolchain's own unstable-atomics note remains.
- `cargo check --features editor`: clean (the doc edit in `syntax_highlighter.rs` isn't covered by `--lib`).
- Guard negative-tested: injecting `std::time::Instant::now()` into `date.rs` fails with a message naming the file, the rule, and the `web-time` fix; reverting goes green.

The real end-state check would be a wasm `cargo check` in CI, but that needs nightly + `build-std` + the atomics rustflags — the guard's module docs call that out as the follow-up.
