### PR TITLE
InputState: don't emit TextChanged for programmatic self-writes (#224)

### DIFF
--- a/src/elements/command.rs
+++ b/src/elements/command.rs
@@ -330,7 +330,11 @@ impl CommandState {
     /// Show the palette, empty the query and put focus in it.
     pub fn open(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.open = true;
-        self.query.update(cx, |state, cx| state.set_content("", cx));
+        // Silent: `open` resets the query itself and rematches below, so the
+        // palette must not hear this write back through its own `TextChanged`
+        // subscription as a user edit (which would re-emit `QueryChanged("")`).
+        self.query
+            .update(cx, |state, cx| state.set_content_silent("", cx));
         self.rematch(cx);
         let handle = self.query.read(cx).focus_handle(cx);
         window.focus(&handle, cx);
@@ -619,6 +623,97 @@ impl Render for CommandState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::{
+        div, px, size, AppContext, Entity, IntoElement, Render, TestAppContext, VisualTestContext,
+    };
+    use std::cell::RefCell;
+    use std::ops::Deref;
+    use std::rc::Rc;
+
+    struct CommandTestView {
+        command: Entity<CommandState>,
+    }
+
+    impl Render for CommandTestView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+        }
+    }
+
+    /// A live `CommandState` in a real window, with a matcher installed, and a
+    /// sink that records every `CommandEvent` it emits.
+    fn open_command(
+        cx: &mut TestAppContext,
+    ) -> (
+        Entity<CommandState>,
+        Rc<RefCell<Vec<String>>>,
+        gpui::Subscription,
+        &'static mut VisualTestContext,
+    ) {
+        cx.update(crate::init);
+        let window = cx.open_window(size(px(400.), px(300.)), |window, cx| {
+            let command = cx.new(|cx| {
+                CommandState::new("cmd", "Commands", items(), window, cx).matcher(|query, items| {
+                    items
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, item)| {
+                            item.haystack()
+                                .to_lowercase()
+                                .contains(&query.to_lowercase())
+                        })
+                        .map(|(index, _)| index)
+                        .collect()
+                })
+            });
+            CommandTestView { command }
+        });
+        let command = window
+            .read_with(cx, |view, _cx| view.command.clone())
+            .expect("the window's root view is the command test view");
+        let sink = Rc::new(RefCell::new(Vec::new()));
+        let sub = cx.update(|cx| {
+            let sink = sink.clone();
+            cx.subscribe(&command, move |_command, event: &CommandEvent, _cx| {
+                if let CommandEvent::QueryChanged(query) = event {
+                    sink.borrow_mut().push(query.to_string());
+                }
+            })
+        });
+        let cx = VisualTestContext::from_window(*window.deref(), cx).into_mut();
+        cx.run_until_parked();
+        (command, sink, sub, cx)
+    }
+
+    /// Opening the palette when the query is already dirty must not fire a
+    /// `QueryChanged` — that is the palette hearing its own programmatic reset
+    /// as if the user typed. Assert *after* `run_until_parked`, since the event
+    /// only reaches the subscriber on the effect flush (#224's house rule).
+    #[gpui::test]
+    fn opening_does_not_emit_query_changed(cx: &mut TestAppContext) {
+        let (command, sink, _sub, cx) = open_command(cx);
+
+        // Dirty the query the way a user would leave it from a prior session.
+        cx.update(|_window, cx| {
+            command.update(cx, |this, cx| {
+                let query = this.query.clone();
+                query.update(cx, |query, cx| query.set_content("quit", cx));
+            });
+        });
+        cx.run_until_parked();
+        sink.borrow_mut().clear();
+
+        cx.update(|window, cx| {
+            command.update(cx, |this, cx| this.open(window, cx));
+        });
+        cx.run_until_parked();
+
+        assert!(
+            sink.borrow().is_empty(),
+            "opening the palette must not emit QueryChanged; it heard its own reset: {:?}",
+            sink.borrow(),
+        );
+    }
 
     fn items() -> Vec<CommandItem> {
         vec![

--- a/src/input/state.rs
+++ b/src/input/state.rs
@@ -361,15 +361,49 @@ impl InputState {
     /// Sets the text content, resetting selection to the beginning.
     /// This clears the undo/redo history.
     ///
+    /// Emits [`InputStateEvent::TextChanged`] only when the content actually
+    /// changes; setting the current content back is a no-op. If the caller is a
+    /// component writing its *own* field and does not want to hear the write
+    /// back through its `TextChanged` subscription, use
+    /// [`set_content_silent`](Self::set_content_silent).
+    ///
     /// Programmatic, so [`read_only`](Self::read_only) does not apply.
     pub fn set_content(&mut self, content: impl Into<String>, cx: &mut Context<Self>) {
+        self.set_content_inner(content, true, cx);
+    }
+
+    /// Like [`set_content`](Self::set_content), but does not emit
+    /// [`InputStateEvent::TextChanged`].
+    ///
+    /// For components that both subscribe to their input's `TextChanged` and
+    /// write to it programmatically (a combobox committing a selection into its
+    /// field, a command palette resetting its query). Without this they would
+    /// hear their own writes as if the user typed them and re-enter their
+    /// change handler. Still re-renders and clears undo/redo history like
+    /// `set_content`; only the event is suppressed.
+    pub fn set_content_silent(&mut self, content: impl Into<String>, cx: &mut Context<Self>) {
+        self.set_content_inner(content, false, cx);
+    }
+
+    fn set_content_inner(
+        &mut self,
+        content: impl Into<String>,
+        emit: bool,
+        cx: &mut Context<Self>,
+    ) {
         let content = content.into();
-        self.content = if self.multiline {
+        let normalized = if self.multiline {
             content
         } else {
             // Strip newlines for single-line input
             content.replace('\n', " ").replace('\r', "")
         };
+        // Setting the current content back changes nothing — don't reset
+        // selection/history and, above all, don't emit as if the text moved.
+        if normalized == self.content {
+            return;
+        }
+        self.content = normalized;
         self.selected_range = 0..0;
         self.selection_reversed = false;
         self.marked_range = None;
@@ -378,7 +412,9 @@ impl InputState {
         self.redo_stack.clear();
         self.cached_utf16_len = None;
         self.pause_cursor_blink(cx);
-        cx.emit(InputStateEvent::TextChanged);
+        if emit {
+            cx.emit(InputStateEvent::TextChanged);
+        }
         cx.notify();
     }
 
@@ -1950,6 +1986,7 @@ mod tests {
         TestAppContext, TextStyle, WindowHandle,
     };
     use std::cell::Cell;
+    use std::cell::RefCell;
     use std::rc::Rc;
 
     struct TestView {
@@ -3420,6 +3457,94 @@ mod tests {
             });
         })
         .unwrap();
+    }
+
+    /// Subscribes to `input`'s events for the life of the returned
+    /// `Subscription`, recording every one into `sink`.
+    fn record_events(
+        view: &WindowHandle<TestView>,
+        cx: &mut TestAppContext,
+    ) -> (Rc<RefCell<Vec<InputStateEvent>>>, gpui::Subscription) {
+        let sink = Rc::new(RefCell::new(Vec::new()));
+        let sub = view
+            .update(cx, |view, _window, cx| {
+                let sink = sink.clone();
+                cx.subscribe(&view.input, move |_this, _input, event, _cx| {
+                    sink.borrow_mut().push(event.clone());
+                })
+            })
+            .unwrap();
+        (sink, sub)
+    }
+
+    fn text_changed_count(events: &Rc<RefCell<Vec<InputStateEvent>>>) -> usize {
+        events
+            .borrow()
+            .iter()
+            .filter(|e| matches!(e, InputStateEvent::TextChanged))
+            .count()
+    }
+
+    #[gpui::test]
+    fn test_set_content_unchanged_does_not_emit_text_changed(cx: &mut TestAppContext) {
+        let view = create_test_input(cx, "hello", 5..5);
+        let (events, _sub) = record_events(&view, cx);
+
+        view.update(cx, |view, _window, cx| {
+            view.input
+                .update(cx, |input, cx| input.set_content("hello", cx));
+        })
+        .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(
+            text_changed_count(&events),
+            0,
+            "set_content with unchanged content must not emit TextChanged"
+        );
+    }
+
+    #[gpui::test]
+    fn test_set_content_changed_still_emits_text_changed(cx: &mut TestAppContext) {
+        let view = create_test_input(cx, "hello", 5..5);
+        let (events, _sub) = record_events(&view, cx);
+
+        view.update(cx, |view, _window, cx| {
+            view.input
+                .update(cx, |input, cx| input.set_content("world", cx));
+        })
+        .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(
+            text_changed_count(&events),
+            1,
+            "set_content with new content must still emit TextChanged"
+        );
+    }
+
+    #[gpui::test]
+    fn test_set_content_silent_updates_without_emitting(cx: &mut TestAppContext) {
+        let view = create_test_input(cx, "hello", 5..5);
+        let (events, _sub) = record_events(&view, cx);
+
+        view.update(cx, |view, _window, cx| {
+            view.input
+                .update(cx, |input, cx| input.set_content_silent("world", cx));
+        })
+        .unwrap();
+        cx.run_until_parked();
+
+        view.update(cx, |view, _window, cx| {
+            view.input
+                .update(cx, |input, _cx| assert_eq!(input.content(), "world"));
+        })
+        .unwrap();
+        assert_eq!(
+            text_changed_count(&events),
+            0,
+            "set_content_silent must update content without emitting TextChanged"
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixes the root cause behind the combobox bug (#223) and a milder Command misfire.

## The bug

`InputState::set_content` emitted `TextChanged` unconditionally — including when the caller is a component writing its *own* field programmatically. Any component that both subscribes to its input's `TextChanged` and writes to that input hears its own writes as if the user typed them.

## The fix (once, at the source)

- **`set_content` skips the emit when content is unchanged.** Setting the current content back is a no-op; it no longer resets selection/history or emits.
- **New `set_content_silent`** — updates content and re-renders, but never emits `TextChanged`. For components writing their own field that must not hear the write back.

Both route through a shared `set_content_inner(content, emit, cx)`.

## Consumer migrated here: Command

`Command::open` cleared its query with `set_content("")`, so opening a palette whose query was left dirty fired a spurious `CommandEvent::QueryChanged("")` one flush later (and double-rematched). It now uses `set_content_silent` — `open` already rematches itself.

**Combobox (the critical consumer) is #223**, which builds on this method.

## Tests

- `test_set_content_unchanged_does_not_emit_text_changed`
- `test_set_content_changed_still_emits_text_changed` (guards against over-suppression)
- `test_set_content_silent_updates_without_emitting`
- `opening_does_not_emit_query_changed` — a real `CommandState` in a window; asserts **after `run_until_parked`**, which is #224's cross-cutting house rule: the combobox bug survived eight tests because they all asserted before the effect flush.

`cargo test --lib`: 568 passed, 0 failed. No new clippy warnings.

Closes #224