### PR TITLE
Fix small audit defects: date panic, form handle leak, dialog/calendar docs (#231)

### DIFF
--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -58,3 +58,23 @@ the separate problem of *piping* a build's output and reading the pipeline's
 status instead of the command's — that belongs to whatever does the piping, and
 adding a recommendation about it here would only make this file look like the
 place it was solved.
+
+## One rule for state tests: assert after the flush
+
+An entity test that mutates state and then asserts **inside the same
+`cx.update`** proves nothing about what subscribers do. gpui delivers emitted
+events and runs `cx.subscribe`/`cx.observe` callbacks on the *next effect
+flush*, not synchronously — so an assertion in the same block sees the state
+before any subscriber has reacted.
+
+```rust
+cx.update(|window, cx| state.update(cx, |s, cx| s.do_the_thing(window, cx)));
+cx.run_until_parked(); // let subscribers react
+cx.update(|_window, cx| state.read_with(cx, |s, _| assert!(/* … */)));
+```
+
+This is not a style preference. The combobox bug in gpuikit#223 — a committed
+value that un-committed itself one flush later — survived eight dedicated tests
+because every one of them asserted before the flush. When a test's whole point
+is a reaction (a value that must survive, a popup that must stay closed), the
+`run_until_parked` between the act and the assert is the test.

--- a/src/date.rs
+++ b/src/date.rs
@@ -124,7 +124,13 @@ const MONTH_NAMES: [&str; 12] = [
 
 /// The English name of a month, `1..=12`. Out of range returns `""`.
 pub fn month_name(month: u32) -> &'static str {
-    MONTH_NAMES.get(month as usize - 1).copied().unwrap_or("")
+    // `checked_sub`, not `month - 1`: month 0 would underflow and panic in
+    // debug, contradicting the "out of range returns `\"\"`" promise above.
+    month
+        .checked_sub(1)
+        .and_then(|index| MONTH_NAMES.get(index as usize))
+        .copied()
+        .unwrap_or("")
 }
 
 /// Whether `year` is a leap year in the proleptic Gregorian calendar.
@@ -282,6 +288,17 @@ mod tests {
 
     fn date(year: i32, month: u32, day: u32) -> Date {
         Date::new(year, month, day).expect("a date the test wrote by hand exists")
+    }
+
+    #[test]
+    fn month_name_is_empty_out_of_range_and_never_panics() {
+        assert_eq!(month_name(1), "January");
+        assert_eq!(month_name(12), "December");
+        // 0 underflowed `month as usize - 1` and panicked in debug, against the
+        // doc's promise of `""`.
+        assert_eq!(month_name(0), "");
+        assert_eq!(month_name(13), "");
+        assert_eq!(month_name(u32::MAX), "");
     }
 
     #[test]

--- a/src/elements/calendar.rs
+++ b/src/elements/calendar.rs
@@ -598,7 +598,7 @@ impl Render for Calendar {
                     .when(!is_selected && is_focused, |this| {
                         this.border_1().border_color(accent)
                     })
-                    // Today is an underline rather than a second fill: a fill
+                    // Today is drawn bold rather than a second fill: a fill
                     // would be indistinguishable from the selection.
                     .when(is_today && !is_selected, |this| {
                         this.font_weight(gpui::FontWeight::BOLD)

--- a/src/elements/dialog.rs
+++ b/src/elements/dialog.rs
@@ -263,6 +263,12 @@ impl Dialog {
     }
 
     /// Configure whether pressing Escape closes the dialog.
+    ///
+    /// Passing `false` to a **confirmation** dialog voids the "Escape cancels"
+    /// promise this module's docs make for it: the Escape handler gates on this
+    /// flag, so Escape becomes inert and the only way out is a footer button.
+    /// Turn it off for a plain dialog if you like; leave it on for a
+    /// confirmation.
     pub fn close_on_escape(mut self, close: bool) -> Self {
         self.close_on_escape = close;
         self

--- a/src/elements/form.rs
+++ b/src/elements/form.rs
@@ -269,10 +269,9 @@ thread_local! {
     /// considered and not done: `FocusHandle` exposes no reference count, so
     /// "nobody else holds this" is not a question that can be asked from here,
     /// and dropping a handle a control still tracks would silently unfocus it.
-    /// The fix that is actually available is an explicit one — a
-    /// `clear_field_focus_handles()` a long-lived list view calls when its
-    /// backing collection changes — and it is not written until something
-    /// needs it.
+    /// The fix that is actually available is an explicit one:
+    /// [`clear_field_focus_handles`], which a long-lived list view calls when
+    /// its backing collection changes.
     static FIELD_FOCUS_HANDLES: RefCell<HashMap<ElementId, FocusHandle>> =
         RefCell::new(HashMap::new());
 }
@@ -290,6 +289,20 @@ pub fn field_focus_handle(id: &ElementId, cx: &mut App) -> FocusHandle {
             .or_insert_with(|| cx.focus_handle())
             .clone()
     })
+}
+
+/// Drop every cached field focus handle on this thread.
+///
+/// The explicit eviction [`FIELD_FOCUS_HANDLES`] describes: a long-lived view
+/// that derives field ids from a changing collection (a row, a record, a task)
+/// calls this when that collection changes, so the map does not grow one handle
+/// per id ever seen for the life of the process. The next
+/// [`field_focus_handle`] for any id mints a fresh handle; call it only when no
+/// field currently on screen still needs its handle to stay put (e.g. between
+/// tearing down one list and building the next), since a control that is still
+/// tracking a dropped handle would be silently unfocused.
+pub fn clear_field_focus_handles() {
+    FIELD_FOCUS_HANDLES.with(|handles| handles.borrow_mut().clear());
 }
 
 /// Wraps one child so that everything drawn inside it sees `context`.
@@ -807,5 +820,24 @@ mod tests {
 
         assert_eq!(first, second);
         assert_ne!(first, other);
+    }
+
+    #[gpui::test]
+    fn clearing_field_focus_handles_mints_fresh_ones(cx: &mut TestAppContext) {
+        let id = ElementId::Name("clear_field_focus_handles_test".into());
+        let before = cx.update(|cx| field_focus_handle(&id, cx));
+        assert_eq!(
+            before,
+            cx.update(|cx| field_focus_handle(&id, cx)),
+            "the handle is stable until cleared"
+        );
+
+        clear_field_focus_handles();
+
+        let after = cx.update(|cx| field_focus_handle(&id, cx));
+        assert_ne!(
+            before, after,
+            "clearing evicts the cache, so the same id mints a new handle"
+        );
     }
 }


### PR DESCRIPTION
The safe, well-specified subset of #231's small-defects list — each with a fix and, where it's behaviour, a test.

## Fixed here

- **`date::month_name(0)` panicked in debug.** `month as usize - 1` underflowed, contradicting the function's own "out of range returns `""`" doc. Now `checked_sub`. Test covers `0`, `13`, and `u32::MAX`.
- **`form::clear_field_focus_handles()` shipped.** `FIELD_FOCUS_HANDLES` documented this explicit eviction but never wrote it, so a form deriving field ids from a changing collection grew one `FocusHandle` per id for the life of the process. The function drops the thread's cache; the doc comment now points at it. Test: a handle is stable per id until cleared, fresh after.
- **`Dialog::close_on_escape` doc note.** `close_on_escape(false)` on a *confirmation* voids the "Escape cancels" guarantee its module docs make — now said at the builder.
- **Calendar today-marker comment** said "underline"; the code applies `FontWeight::BOLD`. Comment corrected to match.
- **`docs/running-tests.md`**: the assert-after-`run_until_parked` house rule — the one the #223 combobox bug slipped through eight tests by violating.

`cargo test --lib`: 566 passed, 0 failed.

## Deferred (left open on #231)

These are design decisions, not mechanical fixes, so I didn't make them blind:

- **Sidebar drawer has no Escape** + **`on_dismiss` fabricates a `ClickEvent`** — best fixed together, since an honest handler signature is what lets Escape call it without a synthetic mouse event. That's a public API change worth a maintainer's call.
- **Splitter `on_key_down` vs the actions doctrine** — migrate to scoped actions or write down why key-down is right here; needs the judgment, not a rote change.
- **Calendar showcase page** demos one configuration — example coverage, better with owner input on what to show.
- **Modal focus trap** — #200 / #226 already track it as one containment mechanism for two consumers.

Refs #231