### PR TITLE
Bump both rand copies past RUSTSEC-2026-0097

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,7 +2312,7 @@ dependencies = [
  "postage",
  "profiling",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.5",
  "raw-window-handle",
  "refineable-gpui-unofficial",
  "regex",
@@ -2430,7 +2430,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.5",
  "raw-window-handle",
  "smallvec",
  "uuid",
@@ -3464,7 +3464,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
  "smallvec",
  "zeroize",
@@ -4275,7 +4275,7 @@ dependencies = [
  "bitflags 2.11.0",
  "num-traits",
  "proptest-macro",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4401,9 +4401,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4412,9 +4412,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4506,7 +4506,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -4853,7 +4853,7 @@ dependencies = [
  "flume",
  "futures",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.5",
  "wasm_thread",
  "web-time",
 ]
@@ -7515,7 +7515,7 @@ dependencies = [
  "core-graphics-helmer-fork",
  "log",
  "objc",
- "rand 0.8.5",
+ "rand 0.8.8",
  "screencapturekit",
  "screencapturekit-sys",
  "sysinfo",


### PR DESCRIPTION
Dependabot raised [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097) twice — once per copy of `rand` in the lockfile it could finally read after #239. `0.9.2` arrives through gpui itself, `0.8.5` through `zed-scap`.

**Neither alert is reachable in this tree.** The advisory is `informational = "unsound"`, not a vulnerability, and the trigger needs rand's `log` feature enabled alongside a custom logger that drives `ThreadRng` from inside the log callback and lands on a 64 kB reseed. Nothing in the graph turns that feature on — `cargo tree -e features --all-features --target all` has no `rand feature "log"` edge on any target — so the path the advisory describes isn't compiled. The custom-logger half isn't hypothetical (`zlog` is one), which is why it's worth clearing rather than dismissing, but the feature gate is what makes it harmless today. gpuikit has no direct `rand` dependency; both copies are transitive.

Both patched versions are semver-compatible, so this is a lockfile-only change: `0.9.5` and `0.8.8`, above the advisory's `0.9.3` / `0.8.6` floors. No package added or removed — the diff is eleven version lines.

Verified before pushing: `cargo check --locked --all-features --all-targets` exit 0, and `cargo deny check` reports `advisories ok, bans ok, licenses ok, sources ok`.

## The part worth keeping

cargo-deny cannot catch this class. 2.x dropped the severity knobs for informational advisories, so the gate printed `advisories ok` against the *unpatched* tree — Dependabot is covering a real gap in CI here, not duplicating it. Leave the alerts on.

Unrelated, spotted in the same pass: `spin 0.10.0` is yanked (via gpui, every target). cargo-deny prints it as a warning and the job runs at `log-level error`, so it doesn't gate anything — but it's an upstream bump gpui owes, same bucket as the GPL `zlog`/`ztracing` exceptions in `deny.toml`.
