### PR TITLE
Host the showcase on GitHub Pages: the same binary, built for the browser (#245)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,3 +20,21 @@ rustflags = ["-Csplit-debuginfo=unpacked"]
 
 [target.aarch64-unknown-linux-gnu]
 rustflags = ["-Csplit-debuginfo=unpacked"]
+
+# The web build. gpui's web platform runs background executors on web workers
+# over a shared wasm memory, so the target needs atomics and a std rebuilt with
+# them. Rebuilding std is `build-std`, nightly-only and not target-scoped, so
+# it is *not* set here — a `[unstable]` table would rebuild std for native
+# nightly builds too. `scripts/showcase-web.sh` sets it, with the nightly, for
+# the one build that needs it. Flags copied from gpui-unofficial's `hello_web`.
+[target.wasm32-unknown-unknown]
+rustflags = [
+    "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals",
+    "-C", "link-arg=--shared-memory",
+    "-C", "link-arg=--max-memory=1073741824",
+    "-C", "link-arg=--import-memory",
+    "-C", "link-arg=--export=__wasm_init_tls",
+    "-C", "link-arg=--export=__tls_size",
+    "-C", "link-arg=--export=__tls_align",
+    "-C", "link-arg=--export=__tls_base",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,21 +191,29 @@ jobs:
       # executors on web workers over a shared wasm memory, so std itself is
       # rebuilt with atomics — `-Z build-std`, which is unstable cargo. A
       # stable check of this target cannot pass (wasm_thread needs a feature
-      # gate). The recipe is the working wasm example's rust-toolchain.toml +
-      # .cargo/config.toml, minus the link args a check never reaches. Pinned
-      # to the nightly it was verified against; bump deliberately.
+      # gate). Pinned to the nightly it was verified against; bump it and
+      # pages.yml's together, deliberately.
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-08-30
           components: rust-src
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      # Checking only — running wasm needs the trunk harness documented in the
-      # wasm example repo.
+      # Checking only. The flags restate `.cargo/config.toml`'s wasm table
+      # because a `RUSTFLAGS` environment replaces a config file's rustflags
+      # rather than adding to them, and the link args a check never reaches
+      # are the ones left out.
       - name: check
         env:
           RUSTFLAGS: -C target-feature=+atomics,+bulk-memory,+mutable-globals
         run: cargo check --locked --target wasm32-unknown-unknown -Z build-std=std,panic_abort
+      # The hosted showcase (pages.yml) is this example built for this target.
+      # Checked here so a PR that breaks the web build fails before merge; the
+      # deploy links it, this does not.
+      - name: check showcase
+        env:
+          RUSTFLAGS: -C target-feature=+atomics,+bulk-memory,+mutable-globals
+        run: cargo check --locked --example showcase --features examples --target wasm32-unknown-unknown -Z build-std=std,panic_abort
 
   # No Windows job on purpose: the hosted runners are slow enough to dominate
   # every run, and nothing here targets Windows today. If that changes, a

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,82 @@
+# The hosted showcase: examples/showcase.rs built for wasm32 and published to
+# GitHub Pages on every push to main. Separate from ci.yml on purpose — this
+# needs `pages: write` and `id-token: write`, and a broken deploy must block
+# neither a merge nor a release (#245).
+#
+# The build is `scripts/showcase-web.sh`, the same command a developer runs
+# locally, which is where the nightly is named and `build-std` is set. The
+# trunk harness is examples/showcase-web/; the wasm flags are
+# .cargo/config.toml's. Bump the nightly here, in that script and in ci.yml's
+# wasm job together.
+#
+# Repository rule: no `${{ }}` inside a `run:` body, anywhere, ever. Values a
+# script needs are bound under `env:` and read as `"$NAME"`.
+# `src/release_input_validation.rs` holds this file to that rule on every
+# `cargo test --lib`; this file is registered in its `WORKFLOWS` list.
+
+name: Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time, and a newer push supersedes a build still running.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+
+jobs:
+  build:
+    name: build (wasm32)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      # The script sets RUSTUP_TOOLCHAIN to this same nightly; the action is
+      # what installs it, with the pieces build-std needs.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-08-30
+          components: rust-src
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: install trunk
+        env:
+          TRUNK_VERSION: 0.21.14
+        run: |
+          curl -sSfL "https://github.com/trunk-rs/trunk/releases/download/v${TRUNK_VERSION}/trunk-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xzf- -C /usr/local/bin trunk
+          trunk --version
+      # PUBLIC_URL is the project-pages path under the account's custom
+      # domain. The `page_url` the deploy job reports is the authority if the
+      # two ever disagree.
+      - name: build
+        env:
+          GPUIKIT_SHOWCASE_SHA: ${{ github.sha }}
+          PUBLIC_URL: /gpuikit/
+        run: scripts/showcase-web.sh build --release --public-url "$PUBLIC_URL"
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: examples/showcase-web/dist
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Thumbs.db
 ehthumbs.db
 logs/
 scratch/
+/examples/showcase-web/dist/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "tempfile",
  "unicode-bidi",
  "unicode-segmentation",
+ "wasm-bindgen",
  "web-sys",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "tempfile",
  "unicode-bidi",
  "unicode-segmentation",
+ "web-sys",
  "web-time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,11 @@ pretty_assertions = "1.4"
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 gpui = { package = "gpui-unofficial", version = "1.14.2", features = ["test-support"] }
 
+# The hosted showcase mirrors its active page to the URL hash, so a component
+# can be linked to. A dev-dependency: only the example reads the location.
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+web-sys = { version = "0.3", features = ["Window", "Location"] }
+
 [features]
 default = []
 editor = ["dep:syntect", "dep:gpui_util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,9 +122,15 @@ schemars = { version = "0.8", optional = true }
 rust-embed = { version = "8.2.0", features = ["debug-embed"] }
 
 [dev-dependencies]
-gpui = { package = "gpui-unofficial", version = "1.14.2", features = ["test-support"] }
 tempfile = "3.8"
 pretty_assertions = "1.4"
+
+# Examples build with dev-dependencies unified in, and gpui's `test-support`
+# (leak detection → backtrace → proptest → rusty-fork → wait-timeout) does not
+# compile for wasm32. Tests never run on wasm, so the feature is asked for only
+# where they do; the showcase, built as an example for the web, gets plain gpui.
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+gpui = { package = "gpui-unofficial", version = "1.14.2", features = ["test-support"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,9 +133,11 @@ pretty_assertions = "1.4"
 gpui = { package = "gpui-unofficial", version = "1.14.2", features = ["test-support"] }
 
 # The hosted showcase mirrors its active page to the URL hash, so a component
-# can be linked to. A dev-dependency: only the example reads the location.
+# can be linked to, and listens for the hash changing under it (back button,
+# an edited address bar). Dev-dependencies: only the example reads the location.
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
-web-sys = { version = "0.3", features = ["Window", "Location"] }
+web-sys = { version = "0.3", features = ["Window", "Location", "EventTarget"] }
+wasm-bindgen = "0.2"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A UI toolkit for [gpui](https://www.gpui.rs) applications. Targeting a conceptual union of SwiftUI and web-style component libraries to make building modern gpui applications seamless.
 
-[See it in action &rarr;](https://nate.rip/gpuikit-demo/)
+[See it in action &rarr;](https://nate.rip/gpuikit/)
 
 ![The gpuikit showcase](https://raw.githubusercontent.com/iamnbutler/gpuikit/main/.github/media/showcase.png)
 
@@ -37,7 +37,10 @@ fn main() {
 }
 ```
 
-Browse every component in the showcase:
+Browse every component in the [showcase](https://nate.rip/gpuikit/), built
+from this repository on every push to `main` — a component can be linked to,
+as in [`#table`](https://nate.rip/gpuikit/#table). Offline, the same binary
+runs natively:
 
 ```sh
 cargo run --example showcase --features examples
@@ -59,10 +62,20 @@ All off by default:
 
 ## Web
 
-gpuikit runs in the browser on gpui's web platform (WebGPU via wgpu):
-[live demo](https://nate.rip/gpuikit-demo/), built from
-[gpuikit-demo](https://github.com/iamnbutler/gpuikit-demo), which also
-documents the wasm build setup.
+gpuikit runs in the browser on gpui's web platform (WebGPU via wgpu). The
+[hosted showcase](https://nate.rip/gpuikit/) is `examples/showcase.rs` built
+for `wasm32-unknown-unknown` by [`examples/showcase-web/`](examples/showcase-web),
+a [trunk](https://trunkrs.dev) harness. It needs nightly, because gpui's web
+platform runs background work on web workers over a shared wasm memory and
+std has to be rebuilt with atomics; `scripts/showcase-web.sh` names the
+nightly and sets that up:
+
+```sh
+scripts/showcase-web.sh serve
+```
+
+Then open <http://127.0.0.1:8081> in a WebGPU-capable browser. Nothing in
+your own app needs nightly unless it, too, is built for the web.
 
 ## Minimum Rust version
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,9 @@ Two kinds of example live here, and the difference decides where new work goes.
 **`showcase.rs` covers components.** One binary, one nav, one page per element:
 what it looks like, what its variants are, what it does when you click it. If
 you want to know whether `gpuikit` has a slider and what it looks like, this is
-the only place you should have to look.
+the only place you should have to look. It is also the hosted showcase at
+<https://nate.rip/gpuikit/>: the same file, built for the browser by
+`showcase-web/` on every push to `main`.
 
 **Every other example covers an interaction or an integration** — something
 that needs its own window, its own keymap, its own running loop, or a whole
@@ -65,6 +67,15 @@ Every example is behind the `examples` feature, which enables nothing else:
 cargo run --example showcase --features examples                     # every page, plain code fences
 cargo run --example showcase --features examples,editor              # + highlighted fences, live editor buffer
 cargo run --example markdown_streaming --features examples,stitch
+```
+
+The showcase for the browser is a [trunk](https://trunkrs.dev) build on
+nightly — std is rebuilt with wasm atomics, and the script is where that
+toolchain is named. `.github/workflows/pages.yml` runs the same script:
+
+```sh
+scripts/showcase-web.sh serve              # http://127.0.0.1:8081
+scripts/showcase-web.sh build --release    # examples/showcase-web/dist/
 ```
 
 Checks, in the order they are quickest to run:

--- a/examples/showcase-web/Trunk.toml
+++ b/examples/showcase-web/Trunk.toml
@@ -1,0 +1,21 @@
+# The web build of `examples/showcase.rs` — the same binary the README's
+# `cargo run --example showcase` runs, compiled for the browser. Run from the
+# repository root through the script that pins the toolchain:
+#
+#   scripts/showcase-web.sh serve
+#
+# `.github/workflows/pages.yml` runs `scripts/showcase-web.sh build --release`
+# with the `--public-url` GitHub Pages serves it from.
+[build]
+target = "index.html"
+example = "showcase"
+features = ["examples"]
+dist = "dist"
+
+[serve]
+addresses = ["127.0.0.1"]
+port = 8081
+open = false
+# Cross-origin isolation, for SharedArrayBuffer (wasm threads) and WebGPU.
+# GitHub Pages cannot send these headers; coi-serviceworker.js covers that.
+headers = { "Cross-Origin-Embedder-Policy" = "require-corp", "Cross-Origin-Opener-Policy" = "same-origin" }

--- a/examples/showcase-web/Trunk.toml
+++ b/examples/showcase-web/Trunk.toml
@@ -12,6 +12,11 @@ example = "showcase"
 features = ["examples"]
 dist = "dist"
 
+# Trunk watches the config's own directory by default, which is not where
+# the code is. Paths are relative to this file.
+[watch]
+watch = ["index.html", "coi-serviceworker.js", "../showcase.rs", "../../src", "../../Cargo.toml"]
+
 [serve]
 addresses = ["127.0.0.1"]
 port = 8081

--- a/examples/showcase-web/coi-serviceworker.js
+++ b/examples/showcase-web/coi-serviceworker.js
@@ -1,0 +1,63 @@
+/*
+ * Cross-origin isolation on hosts that cannot set response headers.
+ *
+ * gpui's web platform runs its background executor on web workers over a
+ * shared wasm memory, and SharedArrayBuffer is only available when the page
+ * is cross-origin isolated (COOP + COEP response headers). GitHub Pages
+ * cannot send custom headers, so this file does double duty:
+ *
+ *  - loaded as a page <script>, it registers itself as a service worker and
+ *    reloads the page once so the worker takes control;
+ *  - running as that service worker, it re-serves every same-scope fetch
+ *    with the two isolation headers attached.
+ *
+ * It is a no-op wherever real headers already exist (e.g. `trunk serve`,
+ * which sends them itself — see trunk.toml).
+ */
+
+if (typeof window !== "undefined") {
+    // Page context.
+    if (!window.crossOriginIsolated && "serviceWorker" in navigator) {
+        const swUrl = document.currentScript.src;
+        navigator.serviceWorker
+            .register(swUrl)
+            .then(() => {
+                if (navigator.serviceWorker.controller) return;
+                // First visit: reload once the worker has claimed the page so
+                // the app boots with SharedArrayBuffer available.
+                navigator.serviceWorker.addEventListener(
+                    "controllerchange",
+                    () => window.location.reload(),
+                    { once: true },
+                );
+            })
+            .catch((err) =>
+                console.error("coi-serviceworker: registration failed", err),
+            );
+    }
+} else {
+    // Service-worker context.
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) =>
+        event.waitUntil(self.clients.claim()),
+    );
+    self.addEventListener("fetch", (event) => {
+        const request = event.request;
+        if (request.cache === "only-if-cached" && request.mode !== "same-origin") {
+            return;
+        }
+        event.respondWith(
+            fetch(request).then((response) => {
+                if (response.status === 0) return response;
+                const headers = new Headers(response.headers);
+                headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+                headers.set("Cross-Origin-Opener-Policy", "same-origin");
+                return new Response(response.body, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers,
+                });
+            }),
+        );
+    });
+}

--- a/examples/showcase-web/index.html
+++ b/examples/showcase-web/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=0" />
+        <title>gpuikit showcase</title>
+        <!-- The crate root; Trunk.toml names the example and its feature. -->
+        <link data-trunk rel="rust" href="../../Cargo.toml" data-bindgen-target="web" data-wasm-opt="0" />
+        <link data-trunk rel="copy-file" href="coi-serviceworker.js" />
+        <!-- Must load before the wasm module: GitHub Pages cannot send the
+             COOP/COEP headers wasm threads need, so this shim adds them via a
+             service worker (no-op under `trunk serve`, which sends them). -->
+        <script src="coi-serviceworker.js"></script>
+        <script>
+            // Surface silent wasm aborts (panic_abort builds die as uncaught
+            // RuntimeErrors inside promise callbacks, which are easy to miss).
+            window.addEventListener("error", (e) =>
+                console.error("[window.onerror]", e.message, e.filename, e.lineno));
+            window.addEventListener("unhandledrejection", (e) =>
+                console.error("[unhandledrejection]", String(e.reason)));
+        </script>
+        <style>
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+            html,
+            body {
+                margin: 0;
+                height: 100%;
+            }
+            canvas {
+                display: block;
+                width: 100%;
+                height: 100%;
+                touch-action: none;
+                outline: none;
+                -webkit-user-select: none;
+                user-select: none;
+            }
+        </style>
+    </head>
+    <body></body>
+</html>

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -329,6 +329,59 @@ fn section_of(page: &str) -> Option<&'static str> {
         .find_map(|(label, _, items)| items.iter().any(|(id, _)| *id == page).then_some(*label))
 }
 
+/// Whether `page` is a page the nav can reach. Only the URL hash asks, and
+/// the hash is user input.
+#[cfg(target_family = "wasm")]
+fn is_nav_page(page: &str) -> bool {
+    NAV_SECTIONS
+        .iter()
+        .any(|(_, _, items)| items.iter().any(|(id, _)| *id == page))
+}
+
+/// The page the URL hash names, when running in a browser and the hash names
+/// a real page. `None` everywhere else, so a native run opens where it always
+/// has.
+fn page_from_location() -> Option<SharedString> {
+    #[cfg(target_family = "wasm")]
+    {
+        let hash = web_sys::window()?.location().hash().ok()?;
+        let page = hash.strip_prefix('#')?;
+        is_nav_page(page).then(|| SharedString::from(page.to_string()))
+    }
+    #[cfg(not(target_family = "wasm"))]
+    None
+}
+
+/// Mirror the active page to the URL hash, so the page can be linked to.
+/// `set_hash` pushes a history entry and reloads nothing.
+fn publish_page_to_location(page: &str) {
+    #[cfg(target_family = "wasm")]
+    if let Some(window) = web_sys::window() {
+        let _ = window.location().set_hash(page);
+    }
+    #[cfg(not(target_family = "wasm"))]
+    let _ = page;
+}
+
+/// The one way the active page changes: the nav rows and the rail both come
+/// here, so the URL hash cannot fall out of step with the cell `render` reads.
+fn navigate_to(cell: &Rc<RefCell<SharedString>>, page: SharedString, window: &mut Window) {
+    publish_page_to_location(&page);
+    *cell.borrow_mut() = page;
+    window.refresh();
+}
+
+/// What this build is: the crate version, and the commit when the deploy job
+/// says (`GPUIKIT_SHOWCASE_SHA`, set in `.github/workflows/pages.yml`). The
+/// hosted page can be ahead of the crates.io release; this is how it says so.
+fn build_stamp() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    match option_env!("GPUIKIT_SHOWCASE_SHA") {
+        Some(sha) if sha.len() >= 7 => format!("gpuikit {version} · {}", &sha[..7]),
+        _ => format!("gpuikit {version}"),
+    }
+}
+
 /// A `Select`'s value as the page prints it. Every select holds an
 /// `Option<T>`, including the ones built with `.selected(…)`, so "nothing
 /// chosen" is a state the page has to be able to say out loud.
@@ -370,10 +423,7 @@ fn nav_entries(active_page: &Rc<RefCell<SharedString>>) -> Vec<NavEntry> {
                     SharedString::from(format!("nav-{id}")),
                     move |_window, _cx| div().px_2().child(label.clone()).into_any_element(),
                 )
-                .on_click(move |_, window, _cx| {
-                    *cell.borrow_mut() = target.clone();
-                    window.refresh();
-                }),
+                .on_click(move |_, window, _cx| navigate_to(&cell, target.clone(), window)),
             });
         }
     }
@@ -1045,7 +1095,10 @@ impl Showcase {
         cx.observe(&table_filter, |_this, _filter, cx| cx.notify())
             .detach();
 
-        let active_page = Rc::new(RefCell::new(SharedString::from("button")));
+        // The URL decides on the web; native opens on Button.
+        let active_page = Rc::new(RefCell::new(
+            page_from_location().unwrap_or_else(|| SharedString::from("button")),
+        ));
         let nav = nav_entries(&active_page);
 
         let fruits = || {
@@ -4099,6 +4152,7 @@ impl Render for Showcase {
         // and border now, so only the window's own two colors are needed here.
         let bg = cx.theme().bg();
         let fg = cx.theme().fg();
+        let fg_muted = cx.theme().fg_muted();
 
         // The sidebar was built once in `Showcase::new`; a frame only decides
         // which row is highlighted.
@@ -4130,8 +4184,7 @@ impl Render for Showcase {
                     .tooltip(tooltip(*label))
                     .on_click(move |_, window, _cx| {
                         if let Some(page) = first.clone() {
-                            *cell.borrow_mut() = page;
-                            window.refresh();
+                            navigate_to(&cell, page, window);
                         }
                     })
             }));
@@ -4160,7 +4213,15 @@ impl Render for Showcase {
                     .flex_1()
                     .child(List::new("nav-list", entries).render(window, cx)),
             )
-            .child(self.theme_select.clone());
+            .child(self.theme_select.clone())
+            .child(
+                div()
+                    .px_2()
+                    .py_1()
+                    .text_xs()
+                    .text_color(fg_muted)
+                    .child(build_stamp()),
+            );
 
         let content = match current_page.as_ref() {
             "button" => v_stack()

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -4266,46 +4266,62 @@ impl Render for Showcase {
     }
 }
 
+fn boot(cx: &mut App) {
+    gpuikit::init(cx);
+
+    // Syntax highlighting for the Markdown page's ```rust fence.
+    // Opt-in, and itself gated on the feature that pulls in syntect,
+    // so this cannot be called unconditionally.
+    #[cfg(feature = "editor")]
+    gpuikit::markdown::init_code_highlighting(cx);
+
+    cx.set_menus(vec![Menu {
+        name: "GPUIKit Showcase".into(),
+        items: vec![],
+        disabled: false,
+    }]);
+
+    let window = cx
+        .open_window(
+            WindowOptions {
+                titlebar: Some(TitlebarOptions {
+                    title: Some("GPUIKit Component Showcase".into()),
+                    ..Default::default()
+                }),
+                window_bounds: Some(WindowBounds::Windowed(Bounds {
+                    origin: Default::default(),
+                    size: size(px(1200.0), px(680.0)),
+                })),
+                ..Default::default()
+            },
+            |window, cx| cx.new(|cx| Showcase::new(window, cx)),
+        )
+        .unwrap();
+
+    window
+        .update(cx, |showcase, window, cx| {
+            window.focus(&showcase.focus_handle, cx);
+            cx.activate(true);
+        })
+        .unwrap();
+}
+
 fn main() {
-    Application::with_platform(gpui_platform::current_platform(false))
-        .with_assets(gpuikit::assets())
-        .run(|cx: &mut App| {
-            gpuikit::init(cx);
+    let app = Application::with_platform(gpui_platform::current_platform(false))
+        .with_assets(gpuikit::assets());
 
-            // Syntax highlighting for the Markdown page's ```rust fence.
-            // Opt-in, and itself gated on the feature that pulls in syntect,
-            // so this cannot be called unconditionally.
-            #[cfg(feature = "editor")]
-            gpuikit::markdown::init_code_highlighting(cx);
+    // The browser owns the event loop: `Platform::run` schedules launch and
+    // returns at once, so plain `run` would drop the app right after boot —
+    // the canvas appears and vanishes. `run_embedded` hands back the owner;
+    // leaking it makes the page own the app for the lifetime of the tab.
+    // The menu and titlebar above are ignored there; the canvas fills the
+    // viewport whatever bounds are asked for.
+    #[cfg(target_family = "wasm")]
+    {
+        gpui_platform::web_init();
+        std::mem::forget(app.run_embedded(boot));
+    }
 
-            cx.set_menus(vec![Menu {
-                name: "GPUIKit Showcase".into(),
-                items: vec![],
-                disabled: false,
-            }]);
-
-            let window = cx
-                .open_window(
-                    WindowOptions {
-                        titlebar: Some(TitlebarOptions {
-                            title: Some("GPUIKit Component Showcase".into()),
-                            ..Default::default()
-                        }),
-                        window_bounds: Some(WindowBounds::Windowed(Bounds {
-                            origin: Default::default(),
-                            size: size(px(1200.0), px(680.0)),
-                        })),
-                        ..Default::default()
-                    },
-                    |window, cx| cx.new(|cx| Showcase::new(window, cx)),
-                )
-                .unwrap();
-
-            window
-                .update(cx, |showcase, window, cx| {
-                    window.focus(&showcase.focus_handle, cx);
-                    cx.activate(true);
-                })
-                .unwrap();
-        });
+    #[cfg(not(target_family = "wasm"))]
+    app.run(boot);
 }

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -371,6 +371,33 @@ fn navigate_to(cell: &Rc<RefCell<SharedString>>, page: SharedString, window: &mu
     window.refresh();
 }
 
+/// The other direction: the hash changing under the app — the back button,
+/// an edited address bar — moves the page. The browser calls this between
+/// frames, the same way it delivers gpui-web's own input events, so updating
+/// the window from here is the same thing those handlers do. The listener
+/// lives as long as the page does.
+#[cfg(target_family = "wasm")]
+fn follow_location(showcase: gpui::WindowHandle<Showcase>, cx: &mut App) {
+    use wasm_bindgen::{closure::Closure, JsCast};
+
+    let Some(browser_window) = web_sys::window() else {
+        return;
+    };
+    let mut cx = cx.to_async();
+    let on_hash_change = Closure::<dyn FnMut()>::new(move || {
+        let Some(page) = page_from_location() else {
+            return;
+        };
+        let _ = showcase.update(&mut cx, |showcase, window, _cx| {
+            *showcase.active_page.borrow_mut() = page;
+            window.refresh();
+        });
+    });
+    let _ = browser_window
+        .add_event_listener_with_callback("hashchange", on_hash_change.as_ref().unchecked_ref());
+    on_hash_change.forget();
+}
+
 /// What this build is: the crate version, and the commit when the deploy job
 /// says (`GPUIKIT_SHOWCASE_SHA`, set in `.github/workflows/pages.yml`). The
 /// hosted page can be ahead of the crates.io release; this is how it says so.
@@ -4365,6 +4392,9 @@ fn boot(cx: &mut App) {
             cx.activate(true);
         })
         .unwrap();
+
+    #[cfg(target_family = "wasm")]
+    follow_location(window, cx);
 }
 
 fn main() {

--- a/scripts/showcase-web.sh
+++ b/scripts/showcase-web.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# The showcase, built for the browser. One statement of the recipe, used by
+# a developer at a terminal and by `.github/workflows/pages.yml` alike:
+#
+#   scripts/showcase-web.sh serve                  # http://127.0.0.1:8081
+#   scripts/showcase-web.sh build --release ...    # examples/showcase-web/dist/
+#
+# Everything after the subcommand is passed to trunk. Run from the repository
+# root; trunk reads examples/showcase-web/Trunk.toml, which names the example
+# and its feature, and index.html there points back at Cargo.toml.
+#
+# Why this is a script and not a line in the README: the web build needs a
+# nightly (std is rebuilt with wasm atomics, which is `build-std`, unstable
+# cargo), and `build-std` cannot be scoped to one target in `.cargo/config.toml`
+# — a `[unstable]` table there would rebuild std for native nightly builds as
+# well. So the two settings that must only ever apply to this build are set
+# here, as environment, for this one process.
+#
+# The nightly is pinned to the date ci.yml's wasm job verifies against; bump
+# the two together. Needs `rust-src` and the wasm32 target on that toolchain:
+#
+#   rustup toolchain install nightly-2026-08-30 --component rust-src --target wasm32-unknown-unknown
+#
+# POSIX sh, and `exec`, so trunk's exit status is this script's.
+
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: scripts/showcase-web.sh <serve|build> [trunk args...]" >&2
+    exit 2
+fi
+
+RUSTUP_TOOLCHAIN=nightly-2026-08-30 \
+CARGO_UNSTABLE_BUILD_STD=std,panic_abort \
+exec trunk "$@" --config examples/showcase-web/Trunk.toml

--- a/src/release_input_validation.rs
+++ b/src/release_input_validation.rs
@@ -38,6 +38,7 @@ use std::process::Command;
 const RELEASE_YML: &str = include_str!("../.github/workflows/release.yml");
 const RELEASE_DEPLOY_YML: &str = include_str!("../.github/workflows/release-deploy.yml");
 const CI_YML: &str = include_str!("../.github/workflows/ci.yml");
+const PAGES_YML: &str = include_str!("../.github/workflows/pages.yml");
 
 /// The validator `release.yml` calls, and the one statement of the version
 /// grammar in this repository. Named once so a rename fails in one place.
@@ -60,10 +61,11 @@ const DEPLOY_SCRIPT: &str = ".github/scripts/validate-deploy-inputs.sh";
 /// Adding a file here is not what puts it under the rule — being in
 /// `.github/workflows/` is. `every_workflow_in_the_directory_is_accounted_for`
 /// compares this list against the directory.
-const WORKFLOWS: [(&str, &str, usize); 3] = [
+const WORKFLOWS: [(&str, &str, usize); 4] = [
     ("release.yml", RELEASE_YML, 10),
     ("release-deploy.yml", RELEASE_DEPLOY_YML, 8),
     ("ci.yml", CI_YML, 12),
+    ("pages.yml", PAGES_YML, 2),
 ];
 
 /// Workflows deliberately outside the rule, each with the reason it is outside

--- a/src/wasm_compat_guard.rs
+++ b/src/wasm_compat_guard.rs
@@ -1,20 +1,19 @@
 //! Tests for the rule that runtime code stays compilable *and runnable* on
 //! `wasm32-unknown-unknown`.
 //!
-//! gpuikit runs in the browser on gpui's web platform (see the demo at
-//! <https://github.com/iamnbutler/gpuikit-demo>, live at
-//! <https://nate.rip/gpuikit-demo/>). The failure mode this guards against is
-//! quiet: several std APIs *compile* for wasm and then fail at runtime —
-//! `std::time::Instant::now()` panics outright, and `std::fs` returns errors
-//! on a filesystem that does not exist. The first symptom is a crashed or
-//! broken page in a browser, on a target no local `cargo test` exercises.
+//! gpuikit runs in the browser on gpui's web platform: the showcase is hosted
+//! at <https://nate.rip/gpuikit/>, built by `examples/showcase-web/`. The
+//! failure mode this guards against is quiet: several std APIs *compile* for
+//! wasm and then fail at runtime — `std::time::Instant::now()` panics
+//! outright, and `std::fs` returns errors on a filesystem that does not
+//! exist. The first symptom is a crashed or broken page in a browser, on a
+//! target no local `cargo test` exercises.
 //!
-//! The real check would be `cargo check --target wasm32-unknown-unknown` in
-//! CI, but that build needs nightly, `build-std`, and the wasm-atomics
-//! rustflags (see the demo repo's `.cargo/config.toml`) — a heavier lift than
-//! this repository's CI carries today. Until it does, this scan is the guard:
-//! it forbids the APIs by name in source, with an explicit per-file allowlist
-//! for the uses that are legitimate.
+//! CI's wasm job proves the crate and the showcase *compile* for the target.
+//! Compiling is exactly what these APIs do, so that job cannot catch them;
+//! this scan is the guard for the runtime half: it forbids the APIs by name
+//! in source, with an explicit per-file allowlist for the uses that are
+//! legitimate.
 //!
 //! Two kinds of use are allowed, and each allowlist entry says which it is:
 //!


### PR DESCRIPTION
Closes #245. The showcase — `examples/showcase.rs`, the one binary `showcase_coverage` holds to every element — is built for `wasm32-unknown-unknown` with trunk and published to GitHub Pages on every push to `main`. Seeing the toolkit no longer costs a full link of gpui.

## What changed

- **`examples/showcase-web/`** — the trunk harness: `index.html`, `Trunk.toml` (names the example and its feature, points at the crate manifest), and the COOP/COEP service-worker shim GitHub Pages needs because it cannot send the headers wasm atomics require. Copied from the demo repo, with its comment.
- **`scripts/showcase-web.sh`** — the one statement of the web recipe: pins the nightly and sets `build-std` as environment for that one process. A developer runs `scripts/showcase-web.sh serve`; the workflow runs the same script with `build --release`. `build-std` cannot live in `.cargo/config.toml`: `build_profile_guard` requires every table there to be target-scoped, and it is right — an `[unstable]` table would rebuild std for native nightly builds too.
- **`.cargo/config.toml`** — the `[target.wasm32-unknown-unknown]` rustflags and link args. Nothing native reads them.
- **`examples/showcase.rs`** — `main` splits on `target_family = "wasm"`: the web calls `web_init` and forgets the `run_embedded` handle (plain `run` returns at once in the browser and drops the app). The active page is mirrored to the URL hash both ways — `#table` opens Table, clicking a nav row rewrites the hash, and a `hashchange` listener follows the back button and an edited address bar. The sidebar shows a build stamp: crate version, plus the short SHA when the deploy job supplies it.
- **`Cargo.toml`** — gpui's `test-support` dev-dependency moves to a `cfg(not(target_family = "wasm"))` table. Examples build with dev-dependencies unified in, and `test-support` pulls `proptest → rusty-fork → wait-timeout`, which does not compile for wasm32. Two wasm-only dev-dependencies (`web-sys`, `wasm-bindgen`) for the hash.
- **`.github/workflows/pages.yml`** — separate from `ci.yml` on purpose: it needs `pages: write` and `id-token: write`, and a broken deploy blocks neither a merge nor a release. Registered with `release_input_validation`; no `${{ }}` in any `run:` body.
- **`ci.yml`** — the `wasm` job also type-checks the showcase example, so a PR that breaks the web build fails before merge without linking anything.
- **README / examples README / `wasm_compat_guard` docs** — lead with the hosted link, keep `cargo run` as the offline path, and point at the in-repo harness instead of the demo repo.

## Verified

- `cargo check --example showcase --features examples --target wasm32-unknown-unknown` on `nightly-2026-08-30` through the script's environment: clean.
- `cargo clippy --locked --all-targets --all-features -- -D warnings`, `scripts/run-tests.sh --lib`, `cargo fmt --check`, `typos .`: clean.
- In a browser, served by `scripts/showcase-web.sh serve` (dev build): renders on WebGPU; `#table` opens the Table page; clicking Badge rewrites the URL to `#badge`; setting the hash in the open tab switches the page; the back button returns; typing into the Table filter works (the `web-time` port holds).
- `scripts/showcase-web.sh build --release --public-url /gpuikit/`, the workflow's command, run locally: the wasm is 18.5 MB, 5.6 MB gzipped (Pages compresses on the wire). The dev build is 31 MB.

## Not in this PR

- The `editor` feature on the web: syntect's default regex engine is a C library. The hosted Editor page shows its existing placeholder; switching to syntect's pure-Rust engine belongs with #246.
- `wasm-opt` (left at `0`, as the demo shipped). Size tuning is its own change.
- The input sandbox stays a native example — it is a text-input lab, not a component page.
- The nav and page reorganisation, which is #249.

## Before and after merge

- **Before:** enable Pages on this repository with source "GitHub Actions" (Settings → Pages, or `gh api -X POST repos/iamnbutler/gpuikit/pages -f build_type=workflow`). The deploy job cannot do this itself.
- **After the first green deploy:** confirm the page serves at <https://nate.rip/gpuikit/> (the account's Pages custom domain; `PUBLIC_URL` in the workflow assumes that path), then archive `iamnbutler/gpuikit-demo` with a README pointer.
