### PR TITLE
The collapsed nav rail has no trigger: collapsing the showcase sidebar was a one-way door

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -4200,8 +4200,19 @@ impl Render for Showcase {
         let nav_state = SidebarState::from(!self.nav_collapsed);
         let current_section = section_of(&current_page);
 
+        // The panel shows its children when expanded and only the rail when
+        // collapsed, so a trigger that lives among the children is gone the
+        // moment it is used. The rail carries its own, or there is no way back.
         let rail = v_stack()
             .gap_1()
+            .child(
+                sidebar_trigger("showcase-nav-rail-trigger", nav_state)
+                    .label("Toggle navigation")
+                    .on_click(cx.listener(|this, _, _window, cx| {
+                        this.nav_collapsed = !this.nav_collapsed;
+                        cx.notify();
+                    })),
+            )
             .children(NAV_SECTIONS.iter().map(|(label, icon, items)| {
                 let first = items.first().map(|(id, _)| SharedString::from(*id));
                 let cell = self.active_page.clone();

--- a/src/elements/sidebar.rs
+++ b/src/elements/sidebar.rs
@@ -32,9 +32,19 @@
 //!     .label("Navigation")
 //!     .state(self.nav_open)
 //!     .width(rems(12.5))
-//!     .rail(v_stack().child(icon_button("nav-home", Icons::home())))
+//!     .rail(
+//!         v_stack()
+//!             .child(sidebar_trigger("app-nav-rail-trigger", self.nav_open).on_click(toggle))
+//!             .child(icon_button("nav-home", Icons::home())),
+//!     )
+//!     .child(sidebar_trigger("app-nav-trigger", self.nav_open).on_click(toggle))
 //!     .child(List::new("nav", entries).render(window, cx))
 //! ```
+//!
+//! The panel shows its children when expanded and only the rail when
+//! collapsed. A trigger that lives among the children is gone the moment it
+//! is used, so either the rail carries one too, or the trigger lives outside
+//! the panel altogether.
 //!
 //! # Overlays
 //!


### PR DESCRIPTION
Collapsing the showcase's navigation left a rail of eight section icons and nothing that expands it again; Escape (`on_dismiss`) led to the same place. Reported on the hosted showcase, but the path is platform-independent — native has it too.

**Root cause.** `Sidebar` renders its children when expanded and only the rail when collapsed. The showcase's `sidebar_trigger` was a child, so it disappeared the moment it was used. The element's own module-doc example shows a rail without a trigger, so it taught the trap.

**Fix.** The rail carries its own trigger as its first row, wired to the same listener. The doc example now shows a trigger in the rail and says why: either the rail carries one, or the trigger lives outside the panel altogether. The element is unchanged — the state is the caller's, and this was the caller's bug.

**Verified.** Clippy over all targets and features, lib tests, the wasm check of the example, `typos`; and in the browser on a dev build: collapse → nine-icon rail → click the top icon → expanded again, no console errors.