### PR TITLE
Four controls that sit beside a Button were on no rung of the size scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **`Tabs`, `ToggleGroup`, `RadioGroup` and `Slider` are on the shared control
+  size scale.** All four implement `ControlSized`, so `.small()` / `.medium()`
+  / `.large()` work on them and they resolve every dimension through
+  `Themeable::control` instead of naming their own. Each was previously
+  padding-derived or hard-coded, which meant a tab bar stood 15px taller than
+  the button beside it, a radio lined up with a checkbox on no rung, and
+  changing the scale moved neither. `Medium` is the default, so a call site
+  that names no size keeps working — but the drawn heights change: a tab strip
+  and a segmented control are now 20px rather than ~35px, a radio is the
+  rung's ink rather than a fixed `rems(1.0)`, and a slider's row is the rung
+  with a thumb of the rung's ink. The row test in
+  `src/elements/control_size_tests.rs` measures all four now, so they cannot
+  drift back.
+- `ControlMetrics::inner_radius()` is new: the corner radius for a child drawn
+  inside a bordered control's border, which is what a segmented control's end
+  options need to sit in the border rather than cut across it.
+
 ## [0.8.0] - 2026-09-01
 
 The release 0.8.0 was always going to be, plus everything that landed while it

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -62,7 +62,7 @@ use gpuikit::{
     traits::control_sized::ControlSized,
     traits::disableable::Disableable,
     traits::labelable::Labelable,
-    traits::orientable::Orientable,
+    traits::orientable::{Orientable, Orientation},
     DefaultIcons,
 };
 use std::cell::RefCell;
@@ -719,6 +719,10 @@ struct Showcase {
     control_row_toggles: [Entity<Toggle>; 3],
     control_row_selects: [Entity<SelectState<Size>>; 3],
     control_row_fields: [Entity<InputState>; 3],
+    control_row_tabs: [Entity<Tabs>; 3],
+    control_row_toggle_groups: [Entity<ToggleGroup<Alignment>>; 3],
+    control_row_radios: [Entity<RadioGroup<Size>>; 3],
+    control_row_sliders: [Entity<Slider>; 3],
     textarea_example: Entity<InputState>,
     /// Its own state: sharing the live example's was both a duplicate element
     /// id and, now that `read_only` writes through to the state, a clobber
@@ -1044,6 +1048,61 @@ impl Showcase {
             })
         });
         let control_row_fields = ControlSize::ALL.map(|_| cx.new(InputState::new_singleline));
+
+        let control_row_tabs = ControlSize::ALL.map(|size| {
+            cx.new(|_cx| {
+                tabs(SharedString::from(format!(
+                    "control-row-tabs-{}",
+                    size.name()
+                )))
+                .tab(tab("edit", "Edit"))
+                .tab(tab("preview", "Preview"))
+                .control_size(size)
+            })
+        });
+
+        let control_row_toggle_groups = ControlSize::ALL.map(|size| {
+            cx.new(|_cx| {
+                toggle_group(
+                    SharedString::from(format!("control-row-toggle-group-{}", size.name())),
+                    vec![
+                        toggle_option(Alignment::Left, "Left"),
+                        toggle_option(Alignment::Center, "Center"),
+                    ],
+                )
+                .selected_value(Alignment::Left)
+                .control_size(size)
+            })
+        });
+
+        let control_row_radios = ControlSize::ALL.map(|size| {
+            cx.new(|_cx| {
+                radio_group(
+                    SharedString::from(format!("control-row-radio-{}", size.name())),
+                    vec![
+                        radio_option(Size::Small, "One"),
+                        radio_option(Size::Medium, "Two"),
+                    ],
+                )
+                .selected(Size::Small)
+                .orientation(Orientation::Horizontal)
+                .control_size(size)
+            })
+        });
+
+        // No label and no value: with either, a slider is two rows and has no
+        // single height to line up with the rest of the row.
+        let control_row_sliders = ControlSize::ALL.map(|size| {
+            cx.new(|_cx| {
+                slider(
+                    SharedString::from(format!("control-row-slider-{}", size.name())),
+                    60.,
+                    0.0..=100.,
+                )
+                .show_value(false)
+                .control_size(size)
+            })
+        });
         let textarea_example = cx.new(InputState::new_multiline);
         let textarea_disabled = cx.new(InputState::new_multiline);
         let textarea_read_only = cx.new(|cx| {
@@ -1291,6 +1350,10 @@ impl Showcase {
             control_row_toggles,
             control_row_selects,
             control_row_fields,
+            control_row_tabs,
+            control_row_toggle_groups,
+            control_row_radios,
+            control_row_sliders,
             textarea_example,
             textarea_disabled,
             textarea_read_only,
@@ -3956,6 +4019,16 @@ impl Showcase {
                                                 text_field(&self.control_row_fields[index], cx)
                                                     .placeholder("Field")
                                                     .control_size(size),
+                                            )
+                                            .child(self.control_row_tabs[index].clone())
+                                            .child(self.control_row_toggle_groups[index].clone())
+                                            .child(self.control_row_radios[index].clone())
+                                            // A slider is `w_full`, so it needs
+                                            // a width or it collapses to nothing.
+                                            .child(
+                                                div()
+                                                    .w(px(96.))
+                                                    .child(self.control_row_sliders[index].clone()),
                                             ),
                                     ),
                             )

--- a/src/elements/control_size_tests.rs
+++ b/src/elements/control_size_tests.rs
@@ -17,22 +17,27 @@ use crate::elements::button::button;
 use crate::elements::checkbox::{checkbox, Checkbox};
 use crate::elements::icon_button::icon_button;
 use crate::elements::kbd::kbd;
+use crate::elements::radio_group::{radio_group, radio_option, RadioGroup};
 use crate::elements::select::{select, SelectState};
+use crate::elements::slider::{slider, Slider};
 use crate::elements::switch::{switch, Switch};
+use crate::elements::tabs::{tab, tabs, Tabs};
 use crate::elements::text_field::text_field;
 use crate::elements::toggle::{toggle, Toggle};
+use crate::elements::toggle_group::{toggle_group, toggle_option, ToggleGroup};
 use crate::icons::Icons;
 use crate::input::InputState;
 use crate::layout::h_stack;
 use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::control_sized::ControlSized;
+use crate::traits::orientable::{Orientable, Orientation};
 
 /// The controls the row draws, in the order it draws them. Each name is also
 /// the `debug_selector` its box is measured through.
 ///
-/// Nine of the crate's seventeen `ControlSized` implementors. The other eight,
-/// and the six elements that are not on the scale at all, are enumerated on
-/// [`every_sized_control_on_a_row_is_the_same_height`].
+/// Thirteen of the crate's twenty-one `ControlSized` implementors. The other
+/// eight, and the two elements that are not on the scale at all, are
+/// enumerated on [`every_sized_control_on_a_row_is_the_same_height`].
 const CONTROLS: &[&str] = &[
     "button",
     "icon-button",
@@ -43,6 +48,10 @@ const CONTROLS: &[&str] = &[
     "toggle",
     "select",
     "text-field",
+    "tabs",
+    "toggle-group",
+    "radio-group",
+    "slider",
 ];
 
 /// A toolbar: one of every control *on the scale* that can share a row, on
@@ -54,6 +63,10 @@ struct Toolbar {
     toggle: Entity<Toggle>,
     select: Entity<SelectState<u8>>,
     field: Entity<InputState>,
+    tabs: Entity<Tabs>,
+    toggle_group: Entity<ToggleGroup<u8>>,
+    radio_group: Entity<RadioGroup<u8>>,
+    slider: Entity<Slider>,
 }
 
 impl Toolbar {
@@ -71,6 +84,41 @@ impl Toolbar {
                 )
             }),
             field: cx.new(InputState::new_singleline),
+            tabs: cx.new(|_cx| {
+                tabs("tabs")
+                    .tab(tab("one", "One"))
+                    .tab(tab("two", "Two"))
+                    .control_size(size)
+            }),
+            toggle_group: cx.new(|_cx| {
+                toggle_group(
+                    "tg-group",
+                    vec![toggle_option(0u8, "Left"), toggle_option(1u8, "Right")],
+                )
+                .selected_value(0u8)
+                .control_size(size)
+            }),
+            // Horizontal, because that is the form that shares a row: a
+            // `RadioGroup` defaults to `Orientation::Vertical`, which is a
+            // stack of rungs rather than one, and has no single height to
+            // agree with — the same reason `Textarea` is not in this row.
+            radio_group: cx.new(|_cx| {
+                radio_group(
+                    "rg",
+                    vec![radio_option(0u8, "Zero"), radio_option(1u8, "One")],
+                )
+                .selected(0u8)
+                .orientation(Orientation::Horizontal)
+                .control_size(size)
+            }),
+            // No label and no value, so the slider is the one track row a
+            // toolbar would put it on. With either it is two rows and has no
+            // single height to agree with, the same as `Textarea`.
+            slider: cx.new(|_cx| {
+                slider("slider", 50., 0.0..=100.)
+                    .show_value(false)
+                    .control_size(size)
+            }),
         }
     }
 }
@@ -111,6 +159,16 @@ impl Render for Toolbar {
                     .placeholder("Field")
                     .control_size(size),
             ))
+            .child(measured("tabs", self.tabs.clone()))
+            .child(measured("toggle-group", self.toggle_group.clone()))
+            .child(measured("radio-group", self.radio_group.clone()))
+            // A slider is `w_full`, and `measured` is `flex_none`, so without
+            // a width it collapses and the thumb has nowhere to sit. The width
+            // is arbitrary; only the height is asserted.
+            .child(measured(
+                "slider",
+                div().w(px(120.)).child(self.slider.clone()),
+            ))
     }
 }
 
@@ -130,26 +188,30 @@ fn measure_row(cx: &mut TestAppContext, size: ControlSize) -> Vec<(&'static str,
         .collect()
 }
 
-/// The whole point of the scale, as one assertion — over the nine controls
-/// [`CONTROLS`] names, which is **not** every control in the crate.
+/// The whole point of the scale, as one assertion — over the thirteen
+/// controls [`CONTROLS`] names, which is **not** every control in the crate.
 ///
 /// The name says "sized" rather than "control" because both halves of that
 /// gap are real, and neither is visible from the row itself. `grep "impl
-/// ControlSized"` finds seventeen implementors; this row measures nine. Someone
-/// who adds a tenth needs to be able to tell unfinished coverage from a broken
-/// scale, and this comment is the only thing that tells them.
+/// ControlSized"` finds twenty-one implementors; this row measures thirteen.
+/// Someone who adds a fourteenth needs to be able to tell unfinished coverage
+/// from a broken scale, and this comment is the only thing that tells them.
 ///
-/// **Six elements are not on the scale at all**, and would fail here for a
-/// reason that is not a bug in the scale. None of them mentions `ControlSized`
-/// or `control_size` anywhere in its module:
+/// **Two elements are not on the scale at all**, and would fail here for a
+/// reason that is not a bug in the scale. Neither mentions `ControlSized` or
+/// `control_size` anywhere in its module, and both are deliberate:
 ///
-/// - `elements::toggle_group`, `elements::tabs`, `elements::alert` — their
-///   height is whatever their padding plus a line box comes to
-///   (`rems(0.375)`, `rems(0.5)` and `rems(0.75)` respectively).
-/// - `elements::slider`, `elements::progress`, `elements::radio_group` — each
-///   hard-codes a track or glyph size instead: a `rems(0.75)` thumb, a
-///   `px(8.)` bar, a `rems(1.0)` radio. Not padding-derived, whatever the
-///   shorthand in iamnbutler/gpuikit#152 says.
+/// - `elements::alert` — a banner, not a row control. Its height is a
+///   `rems(0.75)` padding plus however many lines of message it was given, and
+///   there is no rung a two-line alert could sit on.
+/// - `elements::progress` — a `px(8.)` bar. Called out in iamnbutler/gpuikit#230
+///   as legitimately local under `crate::theme::control`'s "what belongs here"
+///   note: the bar is a graphic with no text and no interaction, and the
+///   element is being superseded by Gauge (iamnbutler/gpuikit#222) anyway.
+///
+/// `Tabs`, `ToggleGroup`, `RadioGroup` and `Slider` used to be on that list —
+/// they are the four #230 named as the ones that genuinely sit beside a
+/// `Button`, and they are in the row above now.
 ///
 /// **Eight more do implement `ControlSized` and are still not measured here**,
 /// which is the half that is easy to miss:
@@ -159,7 +221,9 @@ fn measure_row(cx: &mut TestAppContext, size: ControlSize) -> Vec<(&'static str,
 ///   the same box twice.
 /// - `CheckboxBox` — an internal sub-part, reached through `Checkbox`.
 /// - `Textarea` — multi-line by definition, so it has no single row height to
-///   agree with; its rung sets its text metrics, not its box.
+///   agree with; its rung sets its text metrics, not its box. A `Slider` with
+///   a label or a value readout is the same shape, which is why the one in the
+///   row above has neither.
 /// - `Table`, `Sidebar`, `SidebarTrigger` — containers rather than row
 ///   controls. `SidebarTrigger` is the arguable one: it is an `IconButton` in
 ///   all but name and could join the row.
@@ -167,10 +231,12 @@ fn measure_row(cx: &mut TestAppContext, size: ControlSize) -> Vec<(&'static str,
 ///   action buttons of a confirmation and the gap between them; the panel's
 ///   own padding is component-specific.
 ///
-/// Closing the gap is separate work, tracked as iamnbutler/gpuikit#152. The
-/// three worth doing first are `Tabs`, `ToggleGroup` and `Slider`: all three
-/// genuinely do sit on a toolbar next to a `Button`, and all three are visibly
-/// off it today.
+/// What is left of iamnbutler/gpuikit#230 after this row grew: `list`'s px
+/// constants, `context_menu`'s `px(180.)`/`px(420.)`/`px(14.)` literals, and
+/// the icon-slot literals repeated across `context_menu`, `accordion` and
+/// `collapsible`. None of the four is a control that shares a row, so none of
+/// them can be held by a test shaped like this one; #230's `metrics_coverage`
+/// guard is what would.
 #[gpui::test]
 fn every_sized_control_on_a_row_is_the_same_height(cx: &mut TestAppContext) {
     for size in ControlSize::ALL {

--- a/src/elements/radio_group.rs
+++ b/src/elements/radio_group.rs
@@ -1,10 +1,11 @@
 //! Radio group component for gpuikit
 
-use crate::theme::{ActiveTheme, Themeable};
+use crate::theme::{ActiveTheme, ControlSize, Themeable};
+use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use crate::traits::orientable::{Orientable, Orientation};
 use gpui::{
-    div, prelude::*, rems, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
+    div, prelude::*, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
     MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
 };
 
@@ -43,6 +44,7 @@ pub struct RadioGroup<T: Clone + PartialEq + 'static> {
     selected: Option<T>,
     disabled: bool,
     orientation: Orientation,
+    size: ControlSize,
 }
 
 impl<T: Clone + PartialEq + 'static> EventEmitter<RadioGroupChanged<T>> for RadioGroup<T> {}
@@ -55,6 +57,7 @@ impl<T: Clone + PartialEq + 'static> RadioGroup<T> {
             selected: None,
             disabled: false,
             orientation: Orientation::default(),
+            size: ControlSize::default(),
         }
     }
 
@@ -97,17 +100,27 @@ impl<T: Clone + PartialEq + 'static> RadioGroup<T> {
 impl<T: Clone + PartialEq + 'static> Render for RadioGroup<T> {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
+        let metrics = theme.control(self.size);
         let group_disabled = self.disabled;
         let selected = self.selected.clone();
         let orientation = self.orientation;
 
-        let radio_size = rems(1.0);
-        let dot_size = rems(0.5);
+        // The radio is the ink inside the rung, exactly as a checkbox's box
+        // is — the two are the same control with a different shape, and a
+        // radio that named `rems(1.0)` for itself lined up with a checkbox on
+        // no rung and moved with the scale on none either. The dot is half the
+        // ink, which is the ratio the old pair already had.
+        let radio_size = metrics.ink;
+        let dot_size = metrics.ink / 2.;
 
         let container = if orientation == Orientation::Vertical {
-            div().flex().flex_col().gap(rems(0.5))
+            div().flex().flex_col().gap(metrics.gap * 2.0)
         } else {
-            div().flex().flex_row().gap(rems(1.0)).items_center()
+            div()
+                .flex()
+                .flex_row()
+                .gap(metrics.gap * 4.0)
+                .items_center()
         };
 
         container.id(self.id.clone()).children(
@@ -149,7 +162,11 @@ impl<T: Clone + PartialEq + 'static> Render for RadioGroup<T> {
                         .id(ElementId::NamedInteger("radio-option".into(), index as u64))
                         .flex()
                         .flex_row()
-                        .gap(rems(0.5))
+                        // The row is the rung, so a radio lines up with the
+                        // checkbox beside it; a label outside the control's
+                        // own box wants more room than the gap inside one.
+                        .h(metrics.height)
+                        .gap(metrics.gap * 2.0)
                         .items_center()
                         .when(!is_disabled, |this| {
                             this.cursor_pointer()
@@ -185,7 +202,13 @@ impl<T: Clone + PartialEq + 'static> Render for RadioGroup<T> {
                                     this.child(div().size(dot_size).bg(dot_color).rounded_full())
                                 }),
                         )
-                        .child(div().text_sm().text_color(text_color).child(label))
+                        .child(
+                            div()
+                                .text_size(metrics.text_size)
+                                .line_height(metrics.line_height)
+                                .text_color(text_color)
+                                .child(label),
+                        )
                 })
                 .collect::<Vec<_>>(),
         )
@@ -230,6 +253,13 @@ impl<T: Clone> Disableable for RadioOption<T> {
 impl<T: Clone + PartialEq + 'static> Orientable for RadioGroup<T> {
     fn orientation(mut self, orientation: Orientation) -> Self {
         self.orientation = orientation;
+        self
+    }
+}
+
+impl<T: Clone + PartialEq + 'static> ControlSized for RadioGroup<T> {
+    fn control_size(mut self, size: ControlSize) -> Self {
+        self.size = size;
         self
     }
 }

--- a/src/elements/slider.rs
+++ b/src/elements/slider.rs
@@ -24,30 +24,17 @@
 
 use crate::element_id::scoped;
 use crate::layout::{h_stack, v_stack};
-use crate::theme::{ActiveTheme, Themeable};
+use crate::theme::{ActiveTheme, ControlSize, Themeable};
+use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use crate::traits::labelable::Labelable;
 use crate::utils::element_manager::ElementManagerExt;
 use gpui::{
-    canvas, div, prelude::*, px, rems, App, Bounds, Context, DispatchPhase, ElementId,
-    EventEmitter, IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-    ParentElement, Pixels, Point, Rems, Render, SharedString, Styled, Window,
+    canvas, div, prelude::*, px, App, Bounds, Context, DispatchPhase, ElementId, EventEmitter,
+    IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels,
+    Point, Rems, Render, SharedString, Styled, Window,
 };
 use std::ops::RangeInclusive;
-
-/// The thumb's diameter — the one place it is written down.
-///
-/// The thumb is drawn at this size and `value_from_position` insets the usable
-/// track by half of it at each end, so the two are the same length by
-/// construction rather than by two literals agreeing. They only agreed at
-/// gpui's default 16px rem before: the inset was a hardcoded `px(6.)` while the
-/// thumb was `rems(0.75)`, which skewed the mapping at any other rem size.
-///
-/// **Both `render` and `value_from_position` must keep reading this.** If one
-/// of them goes back to a literal the drawn thumb and the mapping's inset can
-/// disagree again, and nothing in the test module catches it — the tests
-/// exercise the mapping only, never the painted thumb's bounds.
-const THUMB_SIZE: Rems = rems(0.75);
 
 /// Event emitted when the slider value changes
 pub struct SliderChanged {
@@ -65,6 +52,7 @@ pub struct Slider {
     track_bounds: Option<Bounds<Pixels>>,
     show_value: bool,
     disabled: bool,
+    size: ControlSize,
 }
 
 impl EventEmitter<SliderChanged> for Slider {}
@@ -81,6 +69,7 @@ impl Slider {
             track_bounds: None,
             show_value: true,
             disabled: false,
+            size: ControlSize::default(),
         }
     }
 
@@ -124,12 +113,36 @@ impl Slider {
         }
     }
 
-    fn value_from_position(&self, position: Point<Pixels>, rem_size: Pixels) -> f32 {
+    /// The thumb's diameter — the one place it is read.
+    ///
+    /// It is the rung's ink, the same quantity a checkbox's box and a switch's
+    /// track are: the thumb is what the slider *fills* its row with, not the
+    /// row. `render` draws the thumb at this and `value_from_position` insets
+    /// the usable track by half of it at each end, so the drawn thumb and the
+    /// mapping are the same length by construction rather than by two literals
+    /// agreeing. They only agreed at gpui's default 16px rem before: the inset
+    /// was a hardcoded `px(6.)` while the thumb was `rems(0.75)`, which skewed
+    /// the mapping at any other rem size.
+    ///
+    /// **Both `render` and `value_from_position` must keep reading this.** If
+    /// one of them goes back to a literal the two can disagree again, and
+    /// nothing in the test module catches it — the tests exercise the mapping
+    /// only, never the painted thumb's bounds.
+    fn thumb_size(&self, cx: &App) -> Rems {
+        cx.theme().control(self.size).ink
+    }
+
+    fn value_from_position(
+        &self,
+        position: Point<Pixels>,
+        rem_size: Pixels,
+        thumb_size: Rems,
+    ) -> f32 {
         let Some(bounds) = self.track_bounds else {
             return self.value;
         };
 
-        let thumb_radius = THUMB_SIZE.to_pixels(rem_size) / 2.;
+        let thumb_radius = thumb_size.to_pixels(rem_size) / 2.;
         let usable_width = bounds.size.width - thumb_radius * 2.;
         let relative_x = (position.x - bounds.origin.x - thumb_radius).max(px(0.));
         let percentage = (relative_x / usable_width).clamp(0., 1.);
@@ -164,7 +177,8 @@ impl Slider {
         // mouse-down over an id'd hitbox, so a simulated press repaints either
         // way and cannot tell the two apart.
         cx.notify();
-        let new_value = self.value_from_position(event.position, window.rem_size());
+        let thumb_size = self.thumb_size(cx);
+        let new_value = self.value_from_position(event.position, window.rem_size(), thumb_size);
         self.set_value(new_value, cx);
     }
 
@@ -198,7 +212,8 @@ impl Slider {
             self.end_drag(cx);
             return;
         }
-        let new_value = self.value_from_position(event.position, window.rem_size());
+        let thumb_size = self.thumb_size(cx);
+        let new_value = self.value_from_position(event.position, window.rem_size(), thumb_size);
         self.set_value(new_value, cx);
     }
 
@@ -214,6 +229,7 @@ impl Slider {
 impl Render for Slider {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
+        let metrics = theme.control(self.size);
         let percentage = self.percentage();
         let label = self.label.clone();
         let display_value = self.display_value();
@@ -221,8 +237,15 @@ impl Render for Slider {
         let show_value = self.show_value;
         let disabled = self.disabled;
 
-        let track_height = rems(0.25);
-        let thumb_size = THUMB_SIZE;
+        // Shapes specific to this control, derived from the rung rather than
+        // named here: the thumb is the rung's ink, and the rail it slides on
+        // is a quarter of that. Both used to be literals, so a slider matched
+        // the button beside it on no rung and moved with the scale on none.
+        let thumb_size = metrics.ink;
+        let track_height = metrics.ink / 4.;
+        // The thumb is centred in the rung by hand: it is absolutely
+        // positioned, so `items_center` on the row does not reach it.
+        let thumb_top = (metrics.height - metrics.ink) / 2.;
 
         let track_color = theme.surface_secondary();
         let fill_color = if disabled {
@@ -240,7 +263,7 @@ impl Render for Slider {
         v_stack()
             .id(self.id.clone())
             .w_full()
-            .gap(rems(0.25))
+            .gap(metrics.gap)
             .when(label.is_some() || show_value, |this| {
                 this.child(
                     h_stack()
@@ -276,7 +299,7 @@ impl Render for Slider {
                     // `.id(self.id)`; it derives from that id directly now.
                     .id(scoped(&self.id, "track"))
                     .relative()
-                    .h(thumb_size)
+                    .h(metrics.height)
                     .w_full()
                     .flex()
                     .items_center()
@@ -346,7 +369,7 @@ impl Render for Slider {
                         div()
                             .absolute()
                             .left(gpui::relative(percentage))
-                            .top(px(0.))
+                            .top(thumb_top)
                             .size(thumb_size)
                             .bg(thumb_color)
                             .rounded_full()
@@ -386,6 +409,13 @@ impl Labelable for Slider {
     }
 }
 
+impl ControlSized for Slider {
+    fn control_size(mut self, size: ControlSize) -> Self {
+        self.size = size;
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -402,17 +432,18 @@ mod tests {
     const TRACK_LEFT: f32 = 100.;
     const TRACK_WIDTH: f32 = 200.;
     /// `value_from_position` insets the track by the thumb radius at each end.
-    const THUMB_RADIUS: f32 = 6.;
-    /// The track is `rems(0.75)` tall and is the slider's only row, since these
-    /// sliders show no label and no value.
-    const TRACK_Y: f32 = 6.;
+    /// The thumb is the `Medium` rung's ink, `rems(0.875)`.
+    const THUMB_RADIUS: f32 = 7.;
+    /// The track row is the `Medium` rung, `rems(1.25)`, and is the slider's
+    /// only row, since these sliders show no label and no value.
+    const TRACK_Y: f32 = 10.;
     /// The rem size `the_mapping_holds_at_a_non_default_rem_size` draws at, and
-    /// the thumb radius that follows from it: `rems(0.75) * 32 / 2`.
+    /// the thumb radius that follows from it: `rems(0.875) * 32 / 2`.
     const BIG_REM_SIZE: f32 = 32.;
-    const BIG_THUMB_RADIUS: f32 = 12.;
+    const BIG_THUMB_RADIUS: f32 = 14.;
     // These three restate the geometry by hand on purpose. A test that derived
-    // its expected x from `THUMB_SIZE` would agree with any value the constant
-    // took, including a wrong one, and so would pin nothing.
+    // its expected x from `Slider::thumb_size` would agree with any value the
+    // rung took, including a wrong one, and so would pin nothing.
 
     struct Harness {
         slider: Entity<Slider>,

--- a/src/elements/tabs.rs
+++ b/src/elements/tabs.rs
@@ -3,10 +3,11 @@
 //! A tabbed interface for organizing content into multiple panels.
 
 use crate::layout::h_stack;
-use crate::theme::{ActiveTheme, Themeable};
+use crate::theme::{ActiveTheme, ControlSize, Themeable};
+use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use gpui::{
-    div, prelude::*, px, rems, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
+    div, prelude::*, px, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
     MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
 };
 
@@ -55,6 +56,7 @@ pub struct Tabs {
     tabs: Vec<Tab>,
     selected: Option<SharedString>,
     disabled: bool,
+    size: ControlSize,
 }
 
 impl EventEmitter<TabChanged> for Tabs {}
@@ -67,6 +69,7 @@ impl Tabs {
             tabs: Vec::new(),
             selected: None,
             disabled: false,
+            size: ControlSize::default(),
         }
     }
 
@@ -125,14 +128,18 @@ impl Tabs {
 impl Render for Tabs {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
+        let metrics = theme.control(self.size);
         let group_disabled = self.disabled;
         let selected = self.selected.clone();
 
+        // The strip's own border is the rule the tabs sit on, and the tabs
+        // overlap it by the 1px they are pulled down. A tab is therefore the
+        // rung exactly, and so is the strip — a tab bar lines up with a button
+        // beside it instead of standing 15px taller than one.
         let tab_list = h_stack()
-            .gap(rems(0.25))
+            .gap(metrics.gap)
             .border_b_1()
-            .border_color(theme.border())
-            .pb(px(1.0));
+            .border_color(theme.border());
 
         div().id(self.id.clone()).flex().flex_col().child(
             tab_list.children(
@@ -169,15 +176,16 @@ impl Render for Tabs {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .px(rems(0.75))
-                            .py(rems(0.5))
-                            .text_sm()
+                            .h(metrics.height)
+                            .px(metrics.padding_x)
+                            .text_size(metrics.text_size)
+                            .line_height(metrics.line_height)
                             .text_color(text_color)
                             .bg(bg)
                             .border_b_2()
                             .border_color(border_color)
                             .mb(px(-1.0)) // Overlap with container border
-                            .rounded_t(px(4.0))
+                            .rounded_t(metrics.radius)
                             .when(!is_disabled, |this| {
                                 this.cursor_pointer()
                                     .on_mouse_down(MouseButton::Left, |_, window, _| {
@@ -222,6 +230,13 @@ impl Disableable for Tabs {
 
     fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
+        self
+    }
+}
+
+impl ControlSized for Tabs {
+    fn control_size(mut self, size: ControlSize) -> Self {
+        self.size = size;
         self
     }
 }

--- a/src/elements/toggle_group.rs
+++ b/src/elements/toggle_group.rs
@@ -2,12 +2,13 @@
 //!
 //! A toggle group allows selecting one or multiple options from a group of toggle buttons.
 
-use crate::theme::{ActiveTheme, Themeable};
+use crate::theme::{ActiveTheme, ControlSize, Themeable};
+use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use crate::traits::orientable::{Orientable, Orientation};
 use gpui::{
-    div, prelude::*, rems, Context, Div, ElementId, EventEmitter, FontWeight, Hsla,
-    InteractiveElement, IntoElement, MouseButton, ParentElement, Render, SharedString, Stateful,
+    div, prelude::*, Context, Div, ElementId, EventEmitter, FontWeight, Hsla, InteractiveElement,
+    IntoElement, MouseButton, ParentElement, Render, SharedString, Stateful,
     StatefulInteractiveElement, Styled, Window,
 };
 
@@ -99,6 +100,7 @@ pub struct ToggleGroup<T: Clone + PartialEq + 'static> {
     mode: ToggleGroupMode,
     disabled: bool,
     orientation: Orientation,
+    size: ControlSize,
 }
 
 impl<T: Clone + PartialEq + 'static> EventEmitter<ToggleGroupChanged<T>> for ToggleGroup<T> {}
@@ -113,6 +115,7 @@ impl<T: Clone + PartialEq + 'static> ToggleGroup<T> {
             mode: ToggleGroupMode::default(),
             disabled: false,
             orientation: Orientation::Horizontal,
+            size: ControlSize::default(),
         }
     }
 
@@ -193,15 +196,23 @@ impl<T: Clone + PartialEq + 'static> ToggleGroup<T> {
 impl<T: Clone + PartialEq + 'static> Render for ToggleGroup<T> {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
+        let metrics = theme.control(self.size);
         let group_disabled = self.disabled;
         let selected = self.selected.clone();
         let orientation = self.orientation;
         let num_options = self.options.len();
 
+        // The group is the control, and the options fill it. The old shape put
+        // 2px of padding inside the border and let each option's own padding
+        // decide the height, which is the emergent-size failure
+        // `crate::theme::control` exists to end: a segmented control matched a
+        // `Button` on no rung. A horizontal group is the rung exactly; a
+        // vertical one is a rung per option, which is the only reading of a
+        // stack of them that keeps each option the height of a button.
         let container = if orientation == Orientation::Vertical {
             div().flex().flex_col()
         } else {
-            div().flex().flex_row()
+            div().flex().flex_row().h(metrics.height)
         };
 
         container
@@ -209,9 +220,7 @@ impl<T: Clone + PartialEq + 'static> Render for ToggleGroup<T> {
             .bg(theme.surface_secondary())
             .border_1()
             .border_color(theme.border())
-            .rounded_md()
-            .p(rems(0.125))
-            .gap(rems(0.125))
+            .rounded(metrics.radius)
             .children(
                 self.options
                     .iter()
@@ -247,25 +256,37 @@ impl<T: Clone + PartialEq + 'static> Render for ToggleGroup<T> {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .px(rems(0.75))
-                            .py(rems(0.375))
-                            .text_sm()
+                            // A vertical group has no outer height to divide,
+                            // so each option declares the rung itself: a stack
+                            // of options is a stack of rungs, and the group is
+                            // taller than the sum only by its own border.
+                            .when(orientation == Orientation::Vertical, |this| {
+                                this.h(metrics.height)
+                            })
+                            .px(metrics.padding_x)
+                            .text_size(metrics.text_size)
+                            .line_height(metrics.line_height)
                             .font_weight(FontWeight::MEDIUM)
                             .when_some(bg, |this, bg| this.bg(bg))
                             .text_color(text_color)
                             .when(is_selected && !is_disabled, |this: Stateful<Div>| {
                                 this.shadow_sm()
                             })
-                            // Apply rounded corners based on orientation and position
-                            .when(orientation == Orientation::Horizontal, |this| {
-                                this.when(is_first, |t| t.rounded_l_sm())
-                                    .when(is_last, |t| t.rounded_r_sm())
-                                    .when(!is_first && !is_last, |t| t.rounded_none())
-                            })
-                            .when(orientation == Orientation::Vertical, |this| {
-                                this.when(is_first, |t| t.rounded_t_sm())
-                                    .when(is_last, |t| t.rounded_b_sm())
-                                    .when(!is_first && !is_last, |t| t.rounded_none())
+                            // The group's radius, less its own border, is what
+                            // an option's outer corner has to be to sit inside
+                            // the border rather than cut across it.
+                            .map(|this| {
+                                let radius = metrics.inner_radius();
+                                match orientation {
+                                    Orientation::Horizontal => this
+                                        .when(is_first, |t| t.rounded_l(radius))
+                                        .when(is_last, |t| t.rounded_r(radius))
+                                        .when(!is_first && !is_last, |t| t.rounded_none()),
+                                    Orientation::Vertical => this
+                                        .when(is_first, |t| t.rounded_t(radius))
+                                        .when(is_last, |t| t.rounded_b(radius))
+                                        .when(!is_first && !is_last, |t| t.rounded_none()),
+                                }
                             })
                             .when(!is_disabled, |this| {
                                 this.cursor_pointer()
@@ -318,6 +339,13 @@ impl<T: Clone + PartialEq + 'static> Disableable for ToggleGroup<T> {
 impl<T: Clone + PartialEq + 'static> Orientable for ToggleGroup<T> {
     fn orientation(mut self, orientation: Orientation) -> Self {
         self.orientation = orientation;
+        self
+    }
+}
+
+impl<T: Clone + PartialEq + 'static> ControlSized for ToggleGroup<T> {
+    fn control_size(mut self, size: ControlSize) -> Self {
+        self.size = size;
         self
     }
 }

--- a/src/theme/control.rs
+++ b/src/theme/control.rs
@@ -104,6 +104,16 @@ impl ControlMetrics {
         Rems(((self.height.0 - self.line_height.0) / 2.0 - BORDER_REMS).max(0.0))
     }
 
+    /// The corner radius for a child drawn *inside* a bordered control's
+    /// border — a segmented control's end options against its group.
+    ///
+    /// The rung's own radius is the outer one. A child that reuses it draws a
+    /// curve one pixel wider than the hole it sits in, and the border shows
+    /// through at the corner.
+    pub fn inner_radius(&self) -> Rems {
+        Rems((self.radius.0 - BORDER_REMS).max(0.0))
+    }
+
     /// The line height for text that is allowed to wrap — a textarea, a
     /// multi-line input. The rung's own `line_height` is tuned to fit *inside*
     /// the rung, which is too tight once there is a second line.

--- a/src/traits/control_sized.rs
+++ b/src/traits/control_sized.rs
@@ -4,10 +4,13 @@ use crate::theme::ControlSize;
 
 /// A control that can be put on a rung of the shared size scale.
 ///
-/// Implemented by every element that can share a row with another control:
-/// `Button`, `IconButton`, `Checkbox`, `Switch`, `Toggle`, `Select`,
-/// `TextField`, `Badge`, `Kbd`, `Input`, `Textarea` and `Field`. The rung
-/// resolves through the theme
+/// Implemented by every element that can share a row with another control.
+/// The list is not repeated here — it went stale twice, naming twelve
+/// implementors when there were twenty-two — so `grep "impl ControlSized"` is
+/// the answer, and
+/// `crate::elements::control_size_tests::every_sized_control_on_a_row_is_the_same_height`
+/// is the one that says which of them are held to the rung and which are not
+/// yet. The rung resolves through the theme
 /// ([`Themeable::control`](crate::theme::Themeable::control)), so a control
 /// never names a height of its own.
 ///


### PR DESCRIPTION
Closes part of #230.

`src/theme/control.rs` states the contract — "a control never names a height of its own" — and `Tabs`, `ToggleGroup`, `RadioGroup` and `Slider` all broke it. Their heights were padding plus a line box, or a literal:

| control | before (Medium) | after |
|---|---|---|
| `Tabs` | ~35px, emergent from `py(rems(0.5))` + `text_sm` | 20px |
| `ToggleGroup` | ~35px, emergent from `p(rems(0.125))` + option `py(rems(0.375))` | 20px |
| `RadioGroup` | 16px circle from a literal `rems(1.0)` | 14px circle (`metrics.ink`), 20px row |
| `Slider` | 12px row, the `rems(0.75)` thumb | 20px row, 14px thumb, 3.5px rail |

Moving the scale moved none of them, which is the failure `control.rs`'s header narrates and #230 filed. All four implement `ControlSized` now, so `.small()`/`.large()` work and every dimension resolves through `Themeable::control`.

### Notes on each

- **Tabs** — the strip's rule is what the tabs sit on, and they already overlapped it by the 1px they are pulled down. Removing the `pb(px(1.0))` that added the pixel back makes a tab *and* the strip the rung exactly.
- **ToggleGroup** — the group is the control and the options fill it, instead of 2px of padding around options whose own padding set the height. `ControlMetrics::inner_radius()` is new: the group's radius less its border, so an end option sits inside the border rather than cutting across it. A vertical group is a rung per option.
- **RadioGroup** — the circle is `metrics.ink`, the same quantity a checkbox's box is, and the dot is half of it. The row is the rung and the label gap is the checkbox's `gap * 2.0`.
- **Slider** — the thumb is the rung's ink and the rail a quarter of it, derived in the slider's own file as `control.rs`'s "what belongs here" note prescribes. `THUMB_SIZE` is gone and `value_from_position` takes the thumb size, so the drawn thumb and the mapping's inset still cannot disagree; the three hand-restated constants in its test module are restated for the new geometry.

### What holds it

`every_sized_control_on_a_row_is_the_same_height` measures thirteen controls rather than nine. Its coverage comment now lists only `alert` (a banner, no rung a two-line message could sit on) and `progress` (a graphic, called out in #230 as legitimately local) as off the scale. `ControlSized`'s implementor list — stale twice, naming twelve of twenty-two — is replaced by a pointer to that test.

The row measures the **horizontal** `RadioGroup`. The default is `Orientation::Vertical`, which is a stack of rungs rather than one and has no single height to agree with, the same reason `Textarea` is not in the row.

The showcase's Control Sizes page draws the same four, so the page a reader checks and the test that fails agree.

### Verified

- `cargo test --lib`: 573 passed.
- `cargo clippy --all-targets --features examples -- -D warnings`: clean.
- Built for wasm and driven in a browser: all thirteen controls sit inside the rung stripe on all three rungs; clicking a tab, a segment and a slider track all still work (a click at 96% of the track reads 0.9); no console errors.

### Left open on #230

`list`'s px constants, `context_menu`'s `px(180.)`/`px(420.)`/`px(14.)`, and the icon-slot literals shared with `accordion` and `collapsible`. None is a control that shares a row, so none can be held by a test shaped like this one — #230's `metrics_coverage` guard is what would.