### PR TITLE
Seven showcase defects, five of them the crate's rather than the page's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A combobox's chevron opens the popup.** It was an `Adornment::icon` — the
+  one part of the control that looks pressable, and the only part of it that
+  did nothing. It is a toggle: a second press closes what the first opened.
+- **Hovering a disabled context-menu item clears the highlight.** A disabled
+  row carried no `on_mouse_move` at all, so the highlight left by the last
+  enabled row the pointer crossed stayed lit — the menu saying Enter would run
+  something Enter would not. Headers and separators clear it too, for the same
+  reason.
+- **`Themeable::destructive_fg` picks black or white by contrast, not by HSL
+  lightness.** HSL lightness is not perceived brightness, and the old
+  `l > 0.6` rule chose white on Gruvbox Dark's `#fb4934` — 3.4:1, under WCAG
+  AA — where black on the same fill is 6.1:1. It was the only built-in theme
+  the rule got wrong, and the theme whose destructive button looked washed out.
+  Every other theme keeps the colour it had.
+- **The command palette draws its scrim over the window.** `CommandState`
+  wrapped its `deferred` scrim in a plain `div()`; `deferred` hands its child's
+  layout id straight up, so that wrapper became the containing block for an
+  absolutely positioned child and measured nothing. The scrim resolved
+  `size_full` against a box with no size and drew a black rectangle the shape
+  of whatever surrounded the palette. It is returned bare now, the way
+  `DialogState` already returned its own.
+
+### Changed
+
+- **Four `LoadingIndicator` variants are drawn rather than typed.** `Star`,
+  `Triangle`, `Braille` and `BrailleExtended` were built from `❊✳※`, `◢◣◤◥`
+  and the braille block. None of those codepoints is in either font gpui's web
+  platform bundles, and that platform loads no system fonts, so all four
+  rendered as empty boxes in a browser. They are lit-dot grids now — the
+  braille ones are the braille dot patterns, drawn — which depends on no font
+  at all. `no_variant_bets_on_a_font_having_a_glyph` holds the remaining text
+  variants to ASCII.
+
+  `BrailleExtended` is 255 frames over 25.5s, not the 30s its doc claimed; the
+  glyph version listed 192 frames while calling itself 256.
+
 ### Changed
 
 - **`Tabs`, `ToggleGroup`, `RadioGroup` and `Slider` are on the shared control

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -179,12 +179,21 @@ fn main() {
 
 /// Every module in `src/elements/`, and the nav page that shows it.
 ///
-/// Rendered by the Coverage page, so this is live code rather than a constant
-/// only a test reads — the list is in front of anyone who opens the showcase.
-/// Two tests in `src/elements.rs` cross-check it against the crate: every
-/// element module needs a row here, and every page named here has to be one
-/// the nav can actually reach. An element that genuinely should not have a
-/// page is spelled `("name", "none: <reason>")`.
+/// Read only by two tests in `src/elements.rs`, which cross-check it against
+/// the crate: every element module needs a row here, and every page named
+/// here has to be one the nav can actually reach. An element that genuinely
+/// should not have a page is spelled `("name", "none: <reason>")`.
+///
+/// It used to be rendered as a Coverage page in the nav as well. That page is
+/// gone: it is a maintenance ledger, and a visitor evaluating the toolkit has
+/// no use for a table of which module appears where. The table stays because
+/// the tests need it, not because anyone should look at it.
+#[expect(
+    dead_code,
+    reason = "read by src/elements.rs's showcase_coverage tests, which parse \
+              this file's source rather than link against it — so the value is \
+              never evaluated and the table is never dead"
+)]
 const ELEMENT_COVERAGE: &[(&str, &str)] = &[
     ("accordion", "collapsible"),
     ("alert", "alert"),
@@ -306,11 +315,7 @@ const NAV_SECTIONS: &[NavSection] = &[
         DefaultIcons::file_text,
         &[("markdown", "Markdown"), ("editor", "Editor")],
     ),
-    (
-        "System",
-        DefaultIcons::gear,
-        &[("theme", "Theme"), ("coverage", "Coverage")],
-    ),
+    ("System", DefaultIcons::gear, &[("theme", "Theme")]),
 ];
 
 /// One nav section: its label, the glyph its rail row draws when the sidebar
@@ -1860,7 +1865,6 @@ impl Showcase {
                     }
                 }),
             )
-            .child(palette)
     }
 
     fn render_select_page(&self, cx: &Context<Self>) -> impl IntoElement {
@@ -2399,7 +2403,7 @@ impl Showcase {
                     .child(loading_indicator().braille_extended().playing(playing)),
             )
             .child(div().text_sm().text_color(fg_muted).child(
-                "One shared clock wakes only when a glyph changes, and only the views \
+                "One shared clock wakes only when a frame changes, and only the views \
                          showing an indicator. Paused, it stops entirely.",
             ))
     }
@@ -2888,11 +2892,23 @@ impl Showcase {
             .child(separator())
             .child(button("sidebar-demo-action", "New project"));
 
-        let body = div().flex_1().p_4().text_sm().text_color(fg_muted).child(
-            "The panel beside this text is a Sidebar. Collapse it and it becomes a rail \
+        // `min_w_0`, for the same reason the content area needs it: this
+        // paragraph's minimum content width is wider than the frame leaves
+        // once the panel is docked, so without it the body refuses to shrink
+        // and pushes the panel out through `overflow_hidden`. Docked left that
+        // is invisible; docked right it is the panel itself that leaves, and
+        // "Wider" appears to do nothing.
+        let body = div()
+            .flex_1()
+            .min_w_0()
+            .p_4()
+            .text_sm()
+            .text_color(fg_muted)
+            .child(
+                "The panel beside this text is a Sidebar. Collapse it and it becomes a rail \
                  of icons rather than disappearing; make it overlay and it becomes a \
                  dismissible drawer with a scrim.",
-        );
+            );
 
         v_stack()
             .gap_2()
@@ -4036,63 +4052,6 @@ impl Showcase {
             )
     }
 
-    fn render_coverage_page(&self, cx: &Context<Self>) -> impl IntoElement {
-        let theme = cx.theme().clone();
-
-        let mut table = v_stack().gap_0().child(
-            h_stack()
-                .gap_4()
-                .py_1()
-                .border_b_1()
-                .border_color(theme.border())
-                .child(
-                    div()
-                        .w(px(220.))
-                        .text_sm()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .child("src/elements/"),
-                )
-                .child(
-                    div()
-                        .text_sm()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .child("Shown on"),
-                ),
-        );
-
-        for (module, page) in ELEMENT_COVERAGE {
-            table = table.child(
-                h_stack()
-                    .gap_4()
-                    .py_1()
-                    .child(div().w(px(220.)).text_sm().child(format!("{module}.rs")))
-                    .child(
-                        div()
-                            .text_sm()
-                            .text_color(theme.fg_muted())
-                            .child(page.to_string()),
-                    ),
-            );
-        }
-
-        v_stack()
-            .gap_4()
-            .child(
-                div()
-                    .text_lg()
-                    .font_weight(FontWeight::SEMIBOLD)
-                    .text_color(theme.fg_muted())
-                    .child("Coverage"),
-            )
-            .child(div().text_sm().text_color(theme.fg_muted()).child(format!(
-                "{} element modules, each mapped to the page that shows it. Two tests in \
-                     src/elements.rs fail the build if a module gains no page, or if a page \
-                     named here is not reachable from the nav.",
-                ELEMENT_COVERAGE.len()
-            )))
-            .child(table)
-    }
-
     fn render_theme_page(&self, cx: &Context<Self>) -> impl IntoElement {
         let theme = cx.theme().clone();
 
@@ -4403,7 +4362,6 @@ impl Render for Showcase {
             "markdown" => self.render_markdown_page(cx).into_any_element(),
             "editor" => self.render_editor_page(cx).into_any_element(),
             "theme" => self.render_theme_page(cx).into_any_element(),
-            "coverage" => self.render_coverage_page(cx).into_any_element(),
             _ => div().child("Unknown page").into_any_element(),
         };
 
@@ -4427,13 +4385,31 @@ impl Render for Showcase {
                 div()
                     .id("content-area")
                     .flex_1()
+                    // A flex item's min-width is `auto`, which is its
+                    // *content's* minimum — a paragraph's longest
+                    // unbreakable run, and in practice its whole first line.
+                    // Without this the column is as wide as the widest prose
+                    // on the page, the window cannot shrink it, and every
+                    // page runs off the right edge under the root's
+                    // `overflow_hidden`. It is why the buttons below stretched
+                    // past the viewport and why the command palette's scrim
+                    // was the shape it was.
+                    .min_w_0()
                     .overflow_y_scroll()
                     .min_h_full()
                     .p_8()
                     .child(content),
             )
+            // Modals are mounted here, at the root, and not on the page
+            // that opens them. A `Dialog`'s and a `CommandState`'s scrim is
+            // `absolute` + `size_full`, which resolves against its parent —
+            // so a palette mounted inside a page draws its scrim over that
+            // page's box and centres its panel in it. The palette used to be
+            // `.child(palette)` at the bottom of `render_command_page`, which
+            // is what put a black rectangle under the button there.
             .child(self.dialog_example.clone())
             .child(self.destructive_dialog.clone())
+            .child(self.command_palette.clone())
             .child(cx.toast_manager().clone())
     }
 }

--- a/src/elements/combobox.rs
+++ b/src/elements/combobox.rs
@@ -99,6 +99,7 @@
 //!   entirely. It is a second issue, and nothing here prevents it.
 
 use crate::a11y::{A11y, Announce};
+use crate::element_id::scoped;
 use crate::elements::listbox::{matches_query, Listbox, ListboxFocus, LISTBOX_GAP};
 use crate::elements::text_field::{text_field, Adornment};
 use crate::icons::Icons;
@@ -342,6 +343,14 @@ pub struct ComboboxState<T: Clone + PartialEq + 'static> {
     /// owns the value, and the two are deliberately not the same field.
     input: Entity<InputState>,
     listbox: Option<Entity<Listbox>>,
+    /// Whether the *press* on the chevron found the popup open.
+    ///
+    /// The popup dismisses itself on any press outside it, and that runs
+    /// before this element sees the click — so by click time the popup is
+    /// always closed and a toggle written against `listbox` reopens what the
+    /// press just shut. This records what the press found, which is the state
+    /// the user was toggling from.
+    chevron_found_open: bool,
     /// Indices into `options` that survived the filter, in the order the popup
     /// draws them.
     ///
@@ -403,6 +412,7 @@ impl<T: Clone + PartialEq + 'static> ComboboxState<T> {
             selected: combobox.selected,
             input,
             listbox: None,
+            chevron_found_open: false,
             visible,
             on_change: combobox.on_change,
             on_create: combobox.on_create,
@@ -674,15 +684,53 @@ impl<T: Clone + PartialEq + 'static> Render for ComboboxState<T> {
         let full_width = self.full_width;
         let gap = LISTBOX_GAP.to_pixels(window.rem_size());
 
+        // The chevron is a trigger, not decoration. It was an
+        // `Adornment::icon` — the one affordance on the control that looks
+        // pressable and was the only part of it that did nothing.
+        let chevron = div().id(scoped(&self.id, "chevron")).flex().items_center();
+
+        #[cfg(test)]
+        let chevron = chevron.debug_selector(|| "gpuikit-combobox-chevron".into());
+
+        let chevron = chevron
+            .when(!self.disabled, |this| {
+                this.cursor_pointer()
+                    // Stop the press reaching the field beneath: the field
+                    // would take focus and swallow the click, and the toggle
+                    // below would never see the second press that closes an
+                    // open popup.
+                    .on_mouse_down(
+                        gpui::MouseButton::Left,
+                        cx.listener(|this, _, _window, cx| {
+                            this.chevron_found_open = this.listbox.is_some();
+                            cx.stop_propagation();
+                        }),
+                    )
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        // Focus first either way: the popup keeps focus in the
+                        // field (`ListboxFocus::Caller`), so a popup opened
+                        // from the pointer has to leave the keyboard where a
+                        // popup opened from the keyboard would.
+                        window.focus(&gpui::Focusable::focus_handle(this.input.read(cx), cx), cx);
+                        if this.chevron_found_open {
+                            this.listbox = None;
+                            cx.notify();
+                        } else {
+                            this.open(window, cx);
+                        }
+                    }))
+            })
+            .child(
+                Icons::chevron_down()
+                    .size(metrics.text_size)
+                    .text_color(theme.fg_muted()),
+            );
+
         let field = text_field(&self.input, cx)
             .control_size(self.size)
             .disabled(self.disabled)
             .full_width(full_width)
-            .suffix(Adornment::icon(
-                Icons::chevron_down()
-                    .size(metrics.text_size)
-                    .text_color(theme.fg_muted()),
-            ));
+            .suffix(Adornment::element(chevron));
 
         let wrapper = div()
             .id(self.id.clone())
@@ -767,6 +815,66 @@ mod tests {
         let cx = VisualTestContext::from_window(*window.deref(), cx).into_mut();
         cx.run_until_parked();
         (state, cx)
+    }
+
+    /// The chevron was an `Adornment::icon` — decoration. It is the one part
+    /// of the control that looks pressable, and pressing it did nothing at
+    /// all; the popup could only be opened by typing or by Down.
+    #[gpui::test]
+    fn clicking_the_chevron_opens_the_popup(cx: &mut TestAppContext) {
+        let (state, cx) = open(cx, |builder| builder.selected(0));
+
+        state.read_with(cx, |this, _| assert!(!this.is_open()));
+
+        let bounds = cx
+            .debug_bounds("gpuikit-combobox-chevron")
+            .expect("the chevron should have been laid out");
+        cx.simulate_click(bounds.center(), gpui::Modifiers::default());
+
+        state.read_with(cx, |this, _| {
+            assert!(
+                this.is_open(),
+                "clicking the chevron did not open the popup"
+            );
+        });
+    }
+
+    /// It is a toggle, not a one-way opener: the pointer has to be able to put
+    /// back what it just opened, or the chevron is a control that only ever
+    /// does one thing.
+    #[gpui::test]
+    fn clicking_the_chevron_again_closes_the_popup(cx: &mut TestAppContext) {
+        let (state, cx) = open(cx, |builder| builder.selected(0));
+
+        let bounds = cx
+            .debug_bounds("gpuikit-combobox-chevron")
+            .expect("the chevron should have been laid out");
+        cx.simulate_click(bounds.center(), gpui::Modifiers::default());
+        state.read_with(cx, |this, _| assert!(this.is_open()));
+
+        cx.simulate_click(bounds.center(), gpui::Modifiers::default());
+        cx.run_until_parked();
+
+        state.read_with(cx, |this, _| {
+            assert!(
+                !this.is_open(),
+                "a second press on the chevron left the popup open"
+            );
+        });
+    }
+
+    /// A disabled combobox has no popup to open, and the chevron must not be a
+    /// way around that.
+    #[gpui::test]
+    fn clicking_the_chevron_of_a_disabled_combobox_does_nothing(cx: &mut TestAppContext) {
+        let (state, cx) = open(cx, |builder| builder.selected(0).disabled(true));
+
+        let bounds = cx
+            .debug_bounds("gpuikit-combobox-chevron")
+            .expect("the chevron should have been laid out");
+        cx.simulate_click(bounds.center(), gpui::Modifiers::default());
+
+        state.read_with(cx, |this, _| assert!(!this.is_open()));
     }
 
     fn type_into(state: &Entity<ComboboxState<usize>>, text: &str, cx: &mut VisualTestContext) {

--- a/src/elements/command.rs
+++ b/src/elements/command.rs
@@ -475,6 +475,12 @@ impl ControlSized for CommandState {
 
 impl Render for CommandState {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // Closed is nothing at all, not an empty wrapper — see the note
+        // at the end of this function for why the wrapper mattered.
+        if !self.open {
+            return div().into_any_element();
+        }
+
         let theme = cx.theme();
         let metrics = theme.control(self.size);
         let list_a11y = self.a11y();
@@ -609,14 +615,23 @@ impl Render for CommandState {
             )
             .child(panel);
 
-        // Rung 10 of `docs/overlays.md`'s ladder — the dialog layer. A palette
-        // is a modal over a scrim and belongs at the same height as one. There
-        // is no trigger to hang off, so it is `anchored()`-free like `dialog`
-        // and its distance from the top is padding on the scrim rather than an
+        // Rung 10 of the overlay ladder — the dialog layer. A palette is a
+        // modal over a scrim and belongs at the same height as one. There is
+        // no trigger to hang off, so it is `anchored()`-free like `dialog` and
+        // its distance from the top is padding on the scrim rather than an
         // offset.
-        div().when(self.open, |this| {
-            this.child(deferred(scrimmed).with_priority(10))
-        })
+        //
+        // Returned bare, exactly as `DialogState` returns its own. `deferred`
+        // hands its child's layout id straight up, so the scrim — which is
+        // `absolute` — becomes an out-of-flow child of whatever flex container
+        // encloses this view, and `size_full` resolves against that container.
+        // Wrapping it in a plain `div()` first, which is what this used to do,
+        // makes *that wrapper* the containing block: a flex item whose only
+        // child is absolute measures nothing, and the scrim then resolves
+        // `size_full` against a box with no size. That is what drew a black
+        // rectangle the shape of whatever surrounded the palette instead of a
+        // scrim over the window.
+        deferred(scrimmed).with_priority(10).into_any_element()
     }
 }
 

--- a/src/elements/context_menu.rs
+++ b/src/elements/context_menu.rs
@@ -347,14 +347,21 @@ impl MenuState {
 
     /// Follows the pointer, so the mouse and the keyboard never disagree about
     /// which entry is about to be chosen.
-    fn focus_from_hover(&mut self, index: usize, cx: &mut Context<Self>) {
+    ///
+    /// `None` is the pointer being over something Enter could not run — a
+    /// disabled item, a header, a separator. It has to *clear* the highlight
+    /// rather than leave the last one standing: a highlighted row is the menu
+    /// saying "Enter runs this", and over a disabled item that is not true.
+    /// The keyboard then re-enters from the edge, which is where it enters
+    /// from when the menu opens.
+    fn focus_from_hover(&mut self, index: Option<usize>, cx: &mut Context<Self>) {
         let Some(open) = self.open.as_mut() else {
             return;
         };
-        if open.focused == Some(index) {
+        if open.focused == index {
             return;
         }
-        open.focused = Some(index);
+        open.focused = index;
         cx.notify();
     }
 
@@ -654,6 +661,19 @@ fn menu_popup(
         )
 }
 
+/// The mouse-move handler every row that Enter could not run carries.
+///
+/// Without it the highlight the pointer left behind stays on screen while the
+/// pointer sits on a disabled item, a header or a separator, and the menu is
+/// telling the user Enter will run a row the pointer is nowhere near.
+fn clears_the_highlight(
+    state: Entity<MenuState>,
+) -> impl Fn(&gpui::MouseMoveEvent, &mut Window, &mut App) + 'static {
+    move |_, _window, cx| {
+        state.update(cx, |menu, cx| menu.focus_from_hover(None, cx));
+    }
+}
+
 fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement {
     let theme = cx.theme();
 
@@ -662,6 +682,7 @@ fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement {
             .my_1()
             .h(px(1.))
             .bg(theme.border_subtle())
+            .on_mouse_move(clears_the_highlight(state))
             .into_any_element(),
         Row::Header(label) => div()
             .px_3()
@@ -670,6 +691,7 @@ fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement {
             .text_xs()
             .text_color(theme.fg_muted())
             .child(label)
+            .on_mouse_move(clears_the_highlight(state))
             .into_any_element(),
         Row::Item {
             index,
@@ -709,7 +731,12 @@ fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement {
                 .text_color(text_color);
 
             if disabled {
-                row = row.cursor_not_allowed();
+                row = row.cursor_not_allowed().on_mouse_move({
+                    let state = state.clone();
+                    move |_, _window, cx| {
+                        state.update(cx, |menu, cx| menu.focus_from_hover(None, cx));
+                    }
+                });
             } else {
                 row = row
                     .cursor_pointer()
@@ -717,7 +744,7 @@ fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement {
                     .on_mouse_move({
                         let state = state.clone();
                         move |_, _window, cx| {
-                            state.update(cx, |menu, cx| menu.focus_from_hover(index, cx));
+                            state.update(cx, |menu, cx| menu.focus_from_hover(Some(index), cx));
                         }
                     })
                     .on_click({
@@ -1017,6 +1044,48 @@ mod tests {
         cx.simulate_click(bounds.center(), Modifiers::default());
 
         assert_eq!(chosen.get(), vec!["Delete".to_string()]);
+    }
+
+    /// The highlight follows the pointer, so hovering a row Enter *can* run
+    /// arms Enter. Half of the pair below; without it the next test passes
+    /// against a menu whose hover does nothing at all.
+    #[gpui::test]
+    fn hovering_an_item_arms_enter_for_it(cx: &mut TestAppContext) {
+        let (chosen, cx) = open_menu(cx);
+
+        let delete = cx
+            .debug_bounds("gpuikit-context-menu-item-3")
+            .expect("the Delete row should have been laid out");
+        cx.simulate_mouse_move(delete.center(), None, Modifiers::default());
+        cx.simulate_keystrokes("enter");
+
+        assert_eq!(chosen.get(), vec!["Delete".to_string()]);
+    }
+
+    /// A disabled row used to carry no `on_mouse_move` at all, so the highlight
+    /// left behind by the last enabled row the pointer crossed stayed lit while
+    /// the pointer sat on a row Enter could not run — the menu claiming Enter
+    /// would run something it would not.
+    #[gpui::test]
+    fn hovering_a_disabled_item_clears_the_highlight(cx: &mut TestAppContext) {
+        let (chosen, cx) = open_menu(cx);
+
+        let copy = cx
+            .debug_bounds("gpuikit-context-menu-item-0")
+            .expect("the Copy row should have been laid out");
+        let paste = cx
+            .debug_bounds("gpuikit-context-menu-item-1")
+            .expect("the Paste row should have been laid out");
+
+        cx.simulate_mouse_move(copy.center(), None, Modifiers::default());
+        cx.simulate_mouse_move(paste.center(), None, Modifiers::default());
+        cx.simulate_keystrokes("enter");
+
+        assert!(
+            chosen.get().is_empty(),
+            "Enter ran {:?} while the pointer was on a disabled row",
+            chosen.get()
+        );
     }
 
     #[gpui::test]

--- a/src/elements/loading_indicator.rs
+++ b/src/elements/loading_indicator.rs
@@ -8,19 +8,19 @@
 //! cx.notify(current_view))`, so a repeating animation re-arms a notify of the
 //! *enclosing view* forever: one spinner pins its whole window — sidebar,
 //! scroll area and all — at the display refresh rate, whether or not the
-//! spinner's glyph actually changed.
+//! spinner's frame actually changed.
 //!
 //! Indicators therefore share one `LoadingClock`. It wakes at the union of
 //! the frame boundaries its subscribers asked for — 2–10 times a second rather
 //! than 60–120 — and notifies exactly the views that are displaying an
 //! indicator, which is the same invalidation gpui was doing, just at the rate
-//! the glyphs change. When the last indicator goes away the clock stops
+//! the frames change. When the last indicator goes away the clock stops
 //! entirely and costs nothing until one is rendered again.
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
     div, prelude::FluentBuilder, rems, App, AsyncApp, EntityId, Hsla, IntoElement, ParentElement,
-    RenderOnce, SharedString, Styled, Task, Window,
+    Rems, RenderOnce, SharedString, Styled, Task, Window,
 };
 use std::cell::RefCell;
 use std::time::Duration;
@@ -41,7 +41,94 @@ pub fn loading_indicator() -> LoadingIndicator {
     LoadingIndicator::new()
 }
 
-/// The glyph sequence a [`LoadingIndicator`] cycles through.
+/// One frame of an indicator: either characters, or lit dots on a grid.
+///
+/// Four of the seven variants used to be characters too — `❊✳※`, `◢◣◤◥` and
+/// the braille blocks. That made them a bet on the consumer's font, and the
+/// bet loses on gpui's own web platform, which bundles IBM Plex Sans and Lilex
+/// and calls `new_without_system_fonts`: neither font has U+2733, U+25E2 or
+/// anything in the braille block, there is no fallback to fall back to, and
+/// all four rendered as empty boxes. Drawing them removes the bet. A spinner
+/// in a GPU toolkit has no business depending on text at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Frame {
+    /// Characters. Kept for the variants whose whole identity *is* the
+    /// characters, and which only ever use ASCII: a dot is a dot everywhere.
+    Text(&'static str),
+    /// Lit dots on a `cols` x `rows` grid, one bit per cell, row-major from
+    /// the top left.
+    Dots { cols: u16, rows: u16, mask: u16 },
+}
+
+/// A braille byte as a row-major mask on the 2x4 grid its dots are drawn on.
+///
+/// The braille frames below stay written as the bytes they came from — `0xFE`
+/// is `⣾` — because that is what keeps the eight-frame spinner recognisable as
+/// the one every terminal draws. Braille numbers its dots down the left
+/// column, then down the right, then the low pair, so the byte is not itself a
+/// row-major bitmap and this is the translation.
+const fn braille(byte: u8) -> u16 {
+    /// `(bit in the braille byte, cell index on the 2-wide, 4-tall grid)`.
+    const CELLS: [(u8, u16); 8] = [
+        (0, 0), // dot 1: left column, row 0
+        (1, 2), // dot 2: left, row 1
+        (2, 4), // dot 3: left, row 2
+        (3, 1), // dot 4: right, row 0
+        (4, 3), // dot 5: right, row 1
+        (5, 5), // dot 6: right, row 2
+        (6, 6), // dot 7: left, row 3
+        (7, 7), // dot 8: right, row 3
+    ];
+
+    let mut mask = 0u16;
+    let mut i = 0;
+    while i < CELLS.len() {
+        let (bit, cell) = CELLS[i];
+        if byte & (1 << bit) != 0 {
+            mask |= 1 << cell;
+        }
+        i += 1;
+    }
+    mask
+}
+
+/// A 2x4 dot frame from a braille byte.
+const fn braille_frame(byte: u8) -> Frame {
+    Frame::Dots {
+        cols: 2,
+        rows: 4,
+        mask: braille(byte),
+    }
+}
+
+/// The eight-frame braille spinner: one dot dark, walking the ring.
+const BRAILLE_SPINNER: [Frame; 8] = [
+    braille_frame(0xFE),
+    braille_frame(0xFD),
+    braille_frame(0xFB),
+    braille_frame(0xBF),
+    braille_frame(0x7F),
+    braille_frame(0xDF),
+    braille_frame(0xEF),
+    braille_frame(0xF7),
+];
+
+/// Every non-empty braille pattern, in order — a binary counter on eight dots.
+///
+/// 255 frames, not 256: mask 0 draws nothing, and a spinner that vanishes for
+/// one frame per cycle reads as a dropped frame rather than as a count. The
+/// glyph version of this claimed 256 in its own doc comment and listed 192.
+const BRAILLE_COUNTER: [Frame; 255] = {
+    let mut frames = [braille_frame(1); 255];
+    let mut i = 0;
+    while i < frames.len() {
+        frames[i] = braille_frame((i + 1) as u8);
+        i += 1;
+    }
+    frames
+};
+
+/// The frame sequence a [`LoadingIndicator`] cycles through.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum LoadingIndicatorVariant {
     /// `.`, `..`, `...`
@@ -51,39 +138,89 @@ pub enum LoadingIndicatorVariant {
     Ellipsis,
     /// A spinning ASCII bar.
     Dash,
-    /// Pulsing asterisks.
+    /// A drawn star, twinkling: the centre, a plus, a cross, a plus.
     Star,
-    /// A triangle rotating through the four corners.
+    /// A drawn triangle rotating through the four corners — three lit dots of
+    /// a 2x2, with the dark one walking clockwise.
     Triangle,
-    /// The eight-frame braille spinner.
+    /// The eight-frame braille spinner, drawn as dots rather than typed.
     Braille,
-    /// A 256-frame braille counter.
+    /// A 255-frame braille counter, drawn as dots rather than typed.
     BrailleExtended,
 }
 
 impl LoadingIndicatorVariant {
-    fn frames(&self) -> &'static [&'static str] {
+    fn frames(&self) -> &'static [Frame] {
         match self {
-            LoadingIndicatorVariant::Dots => &[".  ", ".. ", "..."],
-            LoadingIndicatorVariant::Ellipsis => &["   ", ".  ", ".. ", "...", ".. ", ".  "],
-            LoadingIndicatorVariant::Dash => &["-", "\\", "|", "/"],
-            LoadingIndicatorVariant::Star => &["❊", "❊", "✳︎", "※"],
-            LoadingIndicatorVariant::Triangle => &["◢", "◣", "◤", "◥"],
-            LoadingIndicatorVariant::Braille => &["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"],
-            LoadingIndicatorVariant::BrailleExtended => &[
-                "⡀", "⡁", "⡂", "⡃", "⡄", "⡅", "⡆", "⡇", "⡈", "⡉", "⡊", "⡋", "⡌", "⡍", "⡎", "⡏",
-                "⡐", "⡑", "⡒", "⡓", "⡔", "⡕", "⡖", "⡗", "⡘", "⡙", "⡚", "⡛", "⡜", "⡝", "⡞", "⡟",
-                "⡠", "⡡", "⡢", "⡣", "⡤", "⡥", "⡦", "⡧", "⡨", "⡩", "⡪", "⡫", "⡬", "⡭", "⡮", "⡯",
-                "⡰", "⡱", "⡲", "⡳", "⡴", "⡵", "⡶", "⡷", "⡸", "⡹", "⡺", "⡻", "⡼", "⡽", "⡾", "⡿",
-                "⢀", "⢁", "⢂", "⢃", "⢄", "⢅", "⢆", "⢇", "⢈", "⢉", "⢊", "⢋", "⢌", "⢍", "⢎", "⢏",
-                "⢐", "⢑", "⢒", "⢓", "⢔", "⢕", "⢖", "⢗", "⢘", "⢙", "⢚", "⢛", "⢜", "⢝", "⢞", "⢟",
-                "⢠", "⢡", "⢢", "⢣", "⢤", "⢥", "⢦", "⢧", "⢨", "⢩", "⢪", "⢫", "⢬", "⢭", "⢮", "⢯",
-                "⢰", "⢱", "⢲", "⢳", "⢴", "⢵", "⢶", "⢷", "⢸", "⢹", "⢺", "⢻", "⢼", "⢽", "⢾", "⢿",
-                "⣀", "⣁", "⣂", "⣃", "⣄", "⣅", "⣆", "⣇", "⣈", "⣉", "⣊", "⣋", "⣌", "⣍", "⣎", "⣏",
-                "⣐", "⣑", "⣒", "⣓", "⣔", "⣕", "⣖", "⣗", "⣘", "⣙", "⣚", "⣛", "⣜", "⣝", "⣞", "⣟",
-                "⣠", "⣡", "⣢", "⣣", "⣤", "⣥", "⣦", "⣧", "⣨", "⣩", "⣪", "⣫", "⣬", "⣭", "⣮", "⣯",
-                "⣰", "⣱", "⣲", "⣳", "⣴", "⣵", "⣶", "⣷", "⣸", "⣹", "⣺", "⣻", "⣼", "⣽", "⣾", "⣿",
+            LoadingIndicatorVariant::Dots => {
+                &[Frame::Text(".  "), Frame::Text(".. "), Frame::Text("...")]
+            }
+            LoadingIndicatorVariant::Ellipsis => &[
+                Frame::Text("   "),
+                Frame::Text(".  "),
+                Frame::Text(".. "),
+                Frame::Text("..."),
+                Frame::Text(".. "),
+                Frame::Text(".  "),
             ],
+            LoadingIndicatorVariant::Dash => &[
+                Frame::Text("-"),
+                Frame::Text("\\"),
+                Frame::Text("|"),
+                Frame::Text("/"),
+            ],
+            // A 3x3: the centre alone, a plus, a cross, a plus. Read as bits
+            // from the top left, so `0b010_111_010` is the middle row full and
+            // the middle column full — a plus.
+            LoadingIndicatorVariant::Star => &[
+                Frame::Dots {
+                    cols: 3,
+                    rows: 3,
+                    mask: 0b000_010_000,
+                },
+                Frame::Dots {
+                    cols: 3,
+                    rows: 3,
+                    mask: 0b010_111_010,
+                },
+                Frame::Dots {
+                    cols: 3,
+                    rows: 3,
+                    mask: 0b101_010_101,
+                },
+                Frame::Dots {
+                    cols: 3,
+                    rows: 3,
+                    mask: 0b010_111_010,
+                },
+            ],
+            // Three lit dots of a 2x2 make a right triangle; which corner is
+            // dark is which way it points. The dark corner walks clockwise
+            // from the top left, so the triangle rotates.
+            LoadingIndicatorVariant::Triangle => &[
+                Frame::Dots {
+                    cols: 2,
+                    rows: 2,
+                    mask: 0b11_10,
+                },
+                Frame::Dots {
+                    cols: 2,
+                    rows: 2,
+                    mask: 0b11_01,
+                },
+                Frame::Dots {
+                    cols: 2,
+                    rows: 2,
+                    mask: 0b01_11,
+                },
+                Frame::Dots {
+                    cols: 2,
+                    rows: 2,
+                    mask: 0b10_11,
+                },
+            ],
+            LoadingIndicatorVariant::Braille => &BRAILLE_SPINNER,
+            LoadingIndicatorVariant::BrailleExtended => &BRAILLE_COUNTER,
         }
     }
 
@@ -95,22 +232,41 @@ impl LoadingIndicatorVariant {
             LoadingIndicatorVariant::Star => Duration::from_millis(1000),
             LoadingIndicatorVariant::Triangle => Duration::from_millis(1200),
             LoadingIndicatorVariant::Braille => Duration::from_millis(1000),
-            LoadingIndicatorVariant::BrailleExtended => Duration::from_millis(30000),
+            // 100ms a frame. Not the round 30s the glyph version named:
+            // `every_variant_divides_its_cycle_evenly` requires the cycle to
+            // be an exact multiple of the frame count, and 255 does not divide
+            // 30s in whole nanoseconds. 25.5s does, and reads as a counter.
+            LoadingIndicatorVariant::BrailleExtended => Duration::from_millis(25_500),
         }
     }
 
-    /// How long one glyph is on screen — the interval at which a view showing
+    /// How long one frame is on screen — the interval at which a view showing
     /// this variant needs to be redrawn, and nothing faster.
     fn frame_period(&self) -> Duration {
         self.duration() / self.frames().len() as u32
     }
 
-    fn char_width(&self) -> usize {
-        self.frames()
-            .iter()
-            .map(|f| f.chars().count())
-            .max()
-            .unwrap_or(1)
+    /// The width the indicator reserves, in multiples of its own height, so a
+    /// spinner does not shift the text beside it as its frames change width.
+    fn width_ratio(&self) -> f32 {
+        match self.frames().first() {
+            // 0.6em per character is the ratio the glyph version used.
+            Some(Frame::Text(_)) => {
+                let chars = self
+                    .frames()
+                    .iter()
+                    .map(|frame| match frame {
+                        Frame::Text(text) => text.chars().count(),
+                        Frame::Dots { .. } => 1,
+                    })
+                    .max()
+                    .unwrap_or(1);
+                chars as f32 * 0.6
+            }
+            // A grid is as wide as its columns are tall.
+            Some(Frame::Dots { cols, rows, .. }) => *cols as f32 / *rows as f32,
+            None => 1.0,
+        }
     }
 }
 
@@ -128,11 +284,16 @@ pub enum LoadingIndicatorSize {
     Large,
 }
 
-/// A text spinner.
+/// A spinner.
 ///
 /// Frames come from the shared `LoadingClock` rather than from a per-element
-/// animation, so an indicator costs its window one redraw per glyph rather than
-/// one per display refresh. See the [module docs](self).
+/// animation, so an indicator costs its window one redraw per frame rather
+/// than one per display refresh. See the [module docs](self).
+///
+/// Three variants are text and four are drawn. The drawn ones are drawn
+/// because they used to be text: their glyphs are absent from the fonts gpui's
+/// web platform bundles, and an indicator that renders as an empty box on a
+/// supported target is not an indicator. See [`Frame`].
 #[derive(IntoElement)]
 pub struct LoadingIndicator {
     variant: LoadingIndicatorVariant,
@@ -152,7 +313,7 @@ impl LoadingIndicator {
         }
     }
 
-    /// Set the glyph sequence.
+    /// Set the frame sequence.
     pub fn variant(mut self, variant: LoadingIndicatorVariant) -> Self {
         self.variant = variant;
         self
@@ -230,7 +391,8 @@ impl LoadingIndicator {
         self
     }
 
-    /// Override the glyph colour. Defaults to the theme's accent.
+    /// Override the colour of the text or the dots. Defaults to the theme's
+    /// accent.
     pub fn color(mut self, color: Hsla) -> Self {
         self.color = Some(color);
         self
@@ -253,13 +415,67 @@ impl Default for LoadingIndicator {
     }
 }
 
+impl LoadingIndicatorSize {
+    /// The indicator's height, and the font size a `Text` frame draws at.
+    ///
+    /// Named in rems rather than left to `text_xs()` and friends because a
+    /// `Dots` frame has to be *measured*, not just styled: the grid is sized
+    /// from this so a drawn frame occupies the same box a typed one would and
+    /// the two families line up beside the same paragraph.
+    fn height(self) -> Rems {
+        match self {
+            // The values `text_xs`, `text_sm`, `text_base` and `text_xl` set.
+            LoadingIndicatorSize::XSmall => rems(0.75),
+            LoadingIndicatorSize::Small => rems(0.875),
+            LoadingIndicatorSize::Medium => rems(1.0),
+            LoadingIndicatorSize::Large => rems(1.25),
+        }
+    }
+}
+
+/// One frame of lit dots, drawn.
+///
+/// The grid fills a `height`-tall box; a cell is that height over the row
+/// count, and the dot is most of a cell, which leaves the gap between dots
+/// without anyone naming a gap. Unlit cells are drawn as empty boxes rather
+/// than skipped, so every frame of a variant is the same size and the grid
+/// does not jitter as dots come and go.
+fn dot_grid(cols: u16, rows: u16, mask: u16, height: Rems, color: Hsla) -> impl IntoElement {
+    let cell = height / rows as f32;
+    let dot = cell * 0.72;
+
+    div()
+        .flex()
+        .flex_col()
+        .flex_none()
+        .h(height)
+        .children((0..rows).map(|row| {
+            div()
+                .flex()
+                .flex_row()
+                .h(cell)
+                .children((0..cols).map(move |col| {
+                    let lit = mask & (1 << (row * cols + col)) != 0;
+                    div()
+                        .w(cell)
+                        .h(cell)
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .when(lit, |this| {
+                            this.child(div().w(dot).h(dot).rounded_full().bg(color))
+                        })
+                }))
+        }))
+}
+
 impl RenderOnce for LoadingIndicator {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let theme = cx.theme();
         let color = self.color.unwrap_or_else(|| theme.accent());
 
         let frames = self.variant.frames();
-        let glyph = if self.playing && !cx.reduce_motion() {
+        let frame = if self.playing && !cx.reduce_motion() {
             let period = self.variant.frame_period();
             // Legal here: `draw_roots` enters `DrawPhase::Prepaint` before the
             // root view renders, and every view's element wraps its render in
@@ -272,29 +488,25 @@ impl RenderOnce for LoadingIndicator {
             frames[0]
         };
 
-        let size = self.size;
-        let width_rems = self.variant.char_width() as f32 * 0.6;
+        let height = self.size.height();
 
         div()
             .text_color(color)
             .flex_none()
-            .min_w(rems(width_rems))
-            .text_center()
-            .when(matches!(size, LoadingIndicatorSize::XSmall), |this| {
-                this.text_xs()
+            .flex()
+            .items_center()
+            .justify_center()
+            .min_w(height * self.variant.width_ratio())
+            .text_size(height)
+            .line_height(height)
+            .map(|this| match frame {
+                // `SharedString::new_static` on a `&'static str` that fits
+                // inline: no allocation, per indicator per frame.
+                Frame::Text(text) => this.child(SharedString::new_static(text)),
+                Frame::Dots { cols, rows, mask } => {
+                    this.child(dot_grid(cols, rows, mask, height, color))
+                }
             })
-            .when(matches!(size, LoadingIndicatorSize::Small), |this| {
-                this.text_sm()
-            })
-            .when(matches!(size, LoadingIndicatorSize::Medium), |this| {
-                this.text_base()
-            })
-            .when(matches!(size, LoadingIndicatorSize::Large), |this| {
-                this.text_xl()
-            })
-            // `SharedString::new_static` on a `&'static str` that fits inline:
-            // no allocation, per indicator per frame.
-            .child(SharedString::new_static(glyph))
     }
 }
 
@@ -406,7 +618,7 @@ impl LoadingClock {
             .map(|nanos| Duration::from_nanos(nanos as u64))
     }
 
-    /// Advance the timeline by `interval` and return the views whose glyphs
+    /// Advance the timeline by `interval` and return the views whose frames
     /// changed, dropping subscribers that have stopped re-registering.
     fn tick(&mut self, interval: Duration) -> Vec<EntityId> {
         self.elapsed += interval;
@@ -545,6 +757,112 @@ mod tests {
 
         assert!(with_clock(|clock| clock.subscribers.is_empty()));
         assert!(!with_clock(|clock| clock.running));
+    }
+
+    fn all_variants() -> [LoadingIndicatorVariant; 7] {
+        [
+            LoadingIndicatorVariant::Dots,
+            LoadingIndicatorVariant::Ellipsis,
+            LoadingIndicatorVariant::Dash,
+            LoadingIndicatorVariant::Star,
+            LoadingIndicatorVariant::Triangle,
+            LoadingIndicatorVariant::Braille,
+            LoadingIndicatorVariant::BrailleExtended,
+        ]
+    }
+
+    /// The defect that made four variants drawn ones: they were built from
+    /// `❊✳※`, `◢◣◤◥` and the braille block, none of which is in either font
+    /// gpui's web platform bundles, and that platform loads no system fonts.
+    /// All four rendered as empty boxes in the browser.
+    ///
+    /// ASCII is the line because it is the only repertoire the crate can
+    /// promise across a consumer's font choices. A variant that wants a shape
+    /// draws it.
+    #[test]
+    fn no_variant_bets_on_a_font_having_a_glyph() {
+        for variant in all_variants() {
+            for frame in variant.frames() {
+                if let Frame::Text(text) = frame {
+                    assert!(
+                        text.is_ascii(),
+                        "{variant:?} draws {text:?} as text, which is a bet on the \
+                         consumer's font; draw it as `Frame::Dots` instead"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A blank frame reads as a dropped frame, not as part of the animation.
+    #[test]
+    fn no_frame_is_empty() {
+        for variant in all_variants() {
+            for frame in variant.frames() {
+                match frame {
+                    Frame::Text(text) => {
+                        assert!(!text.is_empty(), "{variant:?} has an empty text frame")
+                    }
+                    Frame::Dots { cols, rows, mask } => {
+                        assert_ne!(*mask, 0, "{variant:?} has a frame with no lit dots");
+                        let cells = cols * rows;
+                        assert!(
+                            *mask < (1 << cells),
+                            "{variant:?} lights a cell outside its {cols}x{rows} grid"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Braille numbers its dots down the left column, then down the right,
+    /// then the low pair — so the byte is not a row-major bitmap, and the
+    /// spinner comes out mirrored if the translation is wrong.
+    #[test]
+    fn braille_bytes_map_to_the_cells_braille_names() {
+        // Dot 1 is the top left; dot 8 is the bottom right; all eight is all
+        // eight. Cell indices are row-major on the 2-wide, 4-tall grid.
+        assert_eq!(braille(0b0000_0001), 1 << 0, "dot 1 is the top left");
+        assert_eq!(braille(0b0000_1000), 1 << 1, "dot 4 is the top right");
+        assert_eq!(braille(0b0100_0000), 1 << 6, "dot 7 is the bottom left");
+        assert_eq!(braille(0b1000_0000), 1 << 7, "dot 8 is the bottom right");
+        assert_eq!(braille(0xFF), 0b1111_1111, "every dot is every cell");
+        assert_eq!(braille(0x00), 0, "no dots, no cells");
+    }
+
+    /// Each frame of the eight-frame spinner is the full cell minus one, and
+    /// over the cycle every cell takes its turn — which is what makes it read
+    /// as one dark dot going round rather than as flicker.
+    #[test]
+    fn the_braille_spinner_walks_one_dark_dot_around_the_ring() {
+        let mut dark = Vec::new();
+        for frame in BRAILLE_SPINNER {
+            let Frame::Dots { mask, .. } = frame else {
+                panic!("the braille spinner is drawn, not typed");
+            };
+            assert_eq!(
+                mask.count_ones(),
+                7,
+                "a spinner frame lights {} dots, not seven",
+                mask.count_ones()
+            );
+            dark.push((!mask) & 0xFF);
+        }
+
+        dark.sort_unstable();
+        dark.dedup();
+        assert_eq!(dark.len(), 8, "two frames leave the same dot dark");
+    }
+
+    /// A counter counts: 255 frames, each the next pattern, none of them
+    /// blank.
+    #[test]
+    fn the_braille_counter_counts() {
+        assert_eq!(BRAILLE_COUNTER.len(), 255);
+        for (index, frame) in BRAILLE_COUNTER.iter().enumerate() {
+            assert_eq!(*frame, braille_frame((index + 1) as u8));
+        }
     }
 
     #[test]

--- a/src/elements/loading_indicator.rs
+++ b/src/elements/loading_indicator.rs
@@ -293,7 +293,7 @@ pub enum LoadingIndicatorSize {
 /// Three variants are text and four are drawn. The drawn ones are drawn
 /// because they used to be text: their glyphs are absent from the fonts gpui's
 /// web platform bundles, and an indicator that renders as an empty box on a
-/// supported target is not an indicator. See [`Frame`].
+/// supported target is not an indicator.
 #[derive(IntoElement)]
 pub struct LoadingIndicator {
     variant: LoadingIndicatorVariant,

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -181,17 +181,31 @@ pub trait Themeable {
         hsla(base.h, base.s, (base.l - 0.08).max(0.0), base.a)
     }
 
-    /// Text on a destructive button.
+    /// Text on a destructive button: black or white, whichever the fill
+    /// actually reads better against.
     ///
-    /// Black or white off the fill's own lightness, not
-    /// [`fg`](Themeable::fg): a light theme's foreground is dark, and dark
-    /// text on a saturated red is the one combination this has to avoid.
+    /// Not [`fg`](Themeable::fg) — a light theme's foreground is dark, and
+    /// dark text on a saturated red is the one combination this has to avoid
+    /// — and not the fill's HSL lightness either, which is what this used to
+    /// pick by. HSL lightness is not perceived brightness: a saturated red
+    /// sits high on the L axis and low on the luminance one, so the rule
+    /// `l > 0.6 → black` chose *white* for Gruvbox Dark's `#fb4934`, which is
+    /// 3.4:1 — under WCAG AA — where black on the same fill is 6.1:1. It was
+    /// the only theme in the crate the old rule got wrong, and it was the one
+    /// whose destructive button looked washed out.
+    ///
+    /// Comparing contrast ratios picks the same answer as before for every
+    /// other built-in theme, and it keeps picking the readable one for a
+    /// consumer's `danger` colour whatever hue it is.
     fn destructive_fg(&self) -> Hsla {
+        let black = hsla(0.0, 0.0, 0.0, 1.0);
+        let white = hsla(0.0, 0.0, 1.0, 1.0);
         let bg = self.destructive_bg();
-        if bg.l > 0.6 {
-            hsla(0.0, 0.0, 0.0, 1.0)
+
+        if contrast_ratio(bg, white) >= contrast_ratio(bg, black) {
+            white
         } else {
-            hsla(0.0, 0.0, 1.0, 1.0)
+            black
         }
     }
 
@@ -284,6 +298,39 @@ pub trait Themeable {
     fn control(&self, size: ControlSize) -> ControlMetrics {
         self.control_scale().metrics(size)
     }
+}
+
+/// The WCAG 2.1 contrast ratio between two opaque colours, 1.0 to 21.0.
+///
+/// Alpha is ignored: both callers pass fills, and compositing a translucent
+/// one correctly needs the colour behind it, which a theme accessor does not
+/// have. A ratio computed against the fill as if it were opaque is the right
+/// answer for the fills the crate actually draws, and wrong in the same
+/// direction as simply reading the declared colour, which is what the code
+/// this replaced did.
+fn contrast_ratio(a: Hsla, b: Hsla) -> f32 {
+    let lighter = relative_luminance(a).max(relative_luminance(b));
+    let darker = relative_luminance(a).min(relative_luminance(b));
+    (lighter + 0.05) / (darker + 0.05)
+}
+
+/// WCAG relative luminance: sRGB channels linearised, then weighted by how
+/// much the eye gets from each.
+///
+/// This is the quantity HSL's `l` is often mistaken for and is not. `l` is the
+/// midpoint of the largest and smallest channel, so it says a fully saturated
+/// red and a fully saturated cyan are equally bright; luminance says the cyan
+/// is nearly four times brighter, which is what a reader sees.
+fn relative_luminance(color: Hsla) -> f32 {
+    let rgba = gpui::Rgba::from(color);
+    let channel = |c: f32| {
+        if c <= 0.03928 {
+            c / 12.92
+        } else {
+            ((c + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    0.2126 * channel(rgba.r) + 0.7152 * channel(rgba.g) + 0.0722 * channel(rgba.b)
 }
 
 pub fn init(cx: &mut App) {
@@ -865,6 +912,76 @@ mod tests {
     }
 
     /// A theme's scale has to actually reach the elements. `Themeable::control`
+    /// Every built-in theme, by name, so a new one has to be added here and
+    /// is then held to the contrast assertion below.
+    fn built_in_themes() -> Vec<(&'static str, Theme)> {
+        vec![
+            ("default", Theme::default()),
+            ("gruvbox_dark", Theme::gruvbox_dark()),
+            ("gruvbox_light", Theme::gruvbox_light()),
+            ("catppuccin_latte", Theme::catppuccin_latte()),
+            ("catppuccin_frappe", Theme::catppuccin_frappe()),
+            ("catppuccin_macchiato", Theme::catppuccin_macchiato()),
+            ("catppuccin_mocha", Theme::catppuccin_mocha()),
+        ]
+    }
+
+    /// The defect this replaced: `destructive_fg` picked black or white off
+    /// the fill's HSL lightness, and Gruvbox Dark's `#fb4934` sits at `l =
+    /// 0.594` — just inside the "dark enough for white text" side of a 0.6
+    /// threshold — while its *luminance* puts black nearly twice as far
+    /// ahead. The button was legible, badly, and looked washed out.
+    ///
+    /// 4.5:1 is WCAG AA for body text. Every built-in theme clears it on the
+    /// better of the two, so this is a floor the crate already meets rather
+    /// than an aspiration.
+    #[test]
+    fn destructive_text_clears_wcag_aa_on_every_built_in_theme() {
+        for (name, theme) in built_in_themes() {
+            let ratio = contrast_ratio(theme.destructive_bg(), theme.destructive_fg());
+            assert!(
+                ratio >= 4.5,
+                "{name}: destructive text is {ratio:.2}:1 on its own fill, under WCAG AA"
+            );
+        }
+    }
+
+    /// The rule has to pick the *better* of black and white, not merely one
+    /// that happens to pass. A theme whose fill clears 4.5:1 both ways would
+    /// satisfy the assertion above with the worse choice.
+    #[test]
+    fn destructive_text_is_the_better_of_black_and_white() {
+        let black = hsla(0.0, 0.0, 0.0, 1.0);
+        let white = hsla(0.0, 0.0, 1.0, 1.0);
+
+        for (name, theme) in built_in_themes() {
+            let bg = theme.destructive_bg();
+            let chosen = contrast_ratio(bg, theme.destructive_fg());
+            let best = contrast_ratio(bg, black).max(contrast_ratio(bg, white));
+            assert!(
+                (chosen - best).abs() < 0.001,
+                "{name}: chose {chosen:.2}:1 when {best:.2}:1 was available"
+            );
+        }
+    }
+
+    /// Relative luminance is not HSL lightness, which is the whole reason
+    /// `destructive_fg` changed. Saturated red and saturated cyan share an
+    /// `l` of 0.5 and are nowhere near each other in luminance.
+    #[test]
+    fn luminance_and_hsl_lightness_are_different_quantities() {
+        let red = hsla(0.0, 1.0, 0.5, 1.0);
+        let cyan = hsla(180.0 / 360.0, 1.0, 0.5, 1.0);
+
+        assert_eq!(red.l, cyan.l, "the premise: equal HSL lightness");
+        assert!(
+            relative_luminance(cyan) > relative_luminance(red) * 3.0,
+            "cyan {:.3} is not far brighter than red {:.3}",
+            relative_luminance(cyan),
+            relative_luminance(red),
+        );
+    }
+
     /// has a default impl, so this is the wire between `Theme::controls` and
     /// what a control reads at render time.
     #[test]


### PR DESCRIPTION
All seven reported against the hosted showcase. Five turned out to be defects in the elements or the theme; two were the showcase's own layout.

## The crate's

**Combobox's chevron did nothing.** It was an `Adornment::icon` — decoration, and the only affordance on the control that *looks* pressable. It toggles the popup now. The press records whether it **found** the popup open, because the popup dismisses itself on any press outside it and that runs before the click: a toggle written against `listbox` reopens what the press just shut. Three tests: opens, closes on a second press, does nothing when disabled.

**A disabled context-menu item left the previous highlight lit.** A disabled row carried no `on_mouse_move` at all, so the highlight stayed on whatever enabled row the pointer last crossed while the pointer sat somewhere Enter could not act. `focus_from_hover` takes an `Option` now; headers and separators clear it too, same defect. The test parks the pointer on the disabled row, presses Enter, and asserts nothing ran — it fails on the old code with `Enter ran ["Copy"]`.

**`destructive_fg` chose text colour by HSL lightness.** Lightness is not perceived brightness: a saturated red sits high on the L axis and low on the luminance one, so `l > 0.6 → black` picked **white** for Gruvbox Dark's `#fb4934`.

| theme | danger | old pick | white | black |
|---|---|---|---|---|
| **gruvbox_dark** | `#fb4934` | **white** | **3.44** | **6.10** |
| gruvbox_light | `#cc241d` | white | 5.47 | 3.84 |
| catppuccin_latte | `#d20f39` | white | 5.43 | 3.87 |
| catppuccin_frappe | `#e78284` | black | 2.65 | 7.92 |
| catppuccin_macchiato | `#ed8796` | black | 2.47 | 8.51 |
| catppuccin_mocha | `#f38ba8` | black | 2.32 | 9.07 |

3.44:1 is under WCAG AA. Gruvbox Dark was the only theme the rule got wrong and the one reported as looking off. Comparing WCAG contrast ratios keeps every other theme's colour exactly as it was. Two tests: every theme clears AA, and every theme gets the *better* of the two rather than merely one that passes.

**Four loading indicators rendered as empty boxes.** `Star`, `Triangle`, `Braille` and `BrailleExtended` were built from `❊✳※`, `◢◣◤◥` and the braille block. I parsed the cmap tables of the two fonts gpui's web platform bundles — IBM Plex Sans and Lilex — and none of those codepoints is in either; the platform calls `new_without_system_fonts`, so nothing falls back. They are lit-dot grids now: the braille ones are the braille dot patterns drawn rather than typed, so the eight-frame spinner is still the one every terminal draws, and `Triangle` is three dots of a 2×2 with the dark corner walking clockwise. `no_variant_bets_on_a_font_having_a_glyph` holds the remaining text variants to ASCII. The counter is 255 frames over 25.5s — 30s does not divide 255 in whole nanoseconds, and the glyph version claimed 256 frames while listing 192.

**The palette drew a black rectangle instead of a scrim.** `CommandState` wrapped its `deferred` scrim in a plain `div()`. `deferred` passes its child's layout id straight up, so that wrapper — not the enclosing flex container — became the containing block for an `absolute` child, and a flex item whose only child is absolute measures nothing. `size_full` then resolved against a box with no size. Returned bare now, the way `DialogState` already returned its own.

## The showcase's

**Every page ran off the right edge.** The content column is a flex item holding prose, and a flex item's `min-width` is `auto` — its content's minimum. The widest paragraph set the column's width, the window could not shrink it, and everything past the viewport was clipped by the root's `overflow_hidden`. `min_w_0` on the column, and on the Sidebar demo's body for the same reason: docked right the body refused to shrink and pushed the panel out through `overflow_hidden`, so "Wider" appeared to do nothing.

**The palette is mounted at the root**, beside the dialogs, rather than inside the page that opens it. A modal has no business inside a scrolling page.

**The Coverage page is gone.** It is a maintenance ledger; a visitor evaluating the toolkit has no use for a table of which module appears where. `ELEMENT_COVERAGE` stays because `showcase_coverage` parses it out of the file's source — now the only reason it exists, recorded on the constant with an `expect(dead_code)` that says so.

## Verified

- `cargo test --lib`: 586 passed (10 new).
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- Built for wasm and checked in a browser: text wraps and pages fit the window; the destructive button is black-on-red; the palette scrims the whole window; the sidebar panel stays visible docked right at max width; all seven indicators draw and animate.
- The context-menu and combobox fixes are pinned by tests that fail on the old code — I reverted each fix and watched them go red.