### PR TITLE
Move to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gpuikit"
 version = "0.8.0"
-edition = "2021"
+edition = "2024"
 authors = ["Nate Butler <iamnbutler@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/iamnbutler/gpuikit"
@@ -16,9 +16,11 @@ categories = ["gui", "graphics"]
 # rust-embed, so anything in it is compiled into every consumer's binary.
 exclude = [".github/"]
 # This crate's own floor, not a promise about the whole dependency tree: it uses
-# async closures (stable in 1.85), and gpui is edition 2024, which needs the same
-# 1.85. The declared 1.75 was never true. Dependencies declare their own, higher
-# numbers and cargo does not hold them back — see README's "Minimum Rust version".
+# async closures (stable in 1.85), and edition 2024, which needs the same 1.85.
+# The declared 1.75 was never true. Dependencies already in `Cargo.lock` declare
+# their own, higher numbers; edition 2024's v3 resolver prefers to respect this
+# floor when it picks a new one, but only prefers — see the crate docs'
+# "Minimum Rust version".
 rust-version = "1.85"
 
 [lib]

--- a/examples/context_menu.rs
+++ b/examples/context_menu.rs
@@ -13,14 +13,14 @@
 //! Run with: cargo run --example context_menu
 
 use gpui::{
-    actions, div, prelude::*, px, size, App, Application, Bounds, Context, FocusHandle, Focusable,
-    IntoElement, KeyBinding, ParentElement, Render, SharedString, Styled, Window, WindowBounds,
-    WindowOptions,
+    App, Application, Bounds, Context, FocusHandle, Focusable, IntoElement, KeyBinding,
+    ParentElement, Render, SharedString, Styled, Window, WindowBounds, WindowOptions, actions, div,
+    prelude::*, px, size,
 };
+use gpuikit::DefaultIcons;
 use gpuikit::elements::context_menu::{context_menu, menu_item};
 use gpuikit::layout::v_stack;
 use gpuikit::theme::{ActiveTheme, Themeable};
-use gpuikit::DefaultIcons;
 
 actions!(context_menu_example, [Duplicate]);
 

--- a/examples/context_menu.rs
+++ b/examples/context_menu.rs
@@ -79,7 +79,7 @@ impl Demo {
         cx.notify();
     }
 
-    fn render_row(&self, index: usize, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_row(&self, index: usize, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let row = &self.rows[index];
         let selected = self.selected == index;

--- a/examples/dialog_example.rs
+++ b/examples/dialog_example.rs
@@ -5,11 +5,11 @@
 #![allow(missing_docs)]
 
 use gpui::{
-    div, prelude::*, px, size, App, Application, Bounds, Context, Entity, FocusHandle, Focusable,
-    ParentElement, Render, Styled, Window, WindowBounds, WindowOptions,
+    App, Application, Bounds, Context, Entity, FocusHandle, Focusable, ParentElement, Render,
+    Styled, Window, WindowBounds, WindowOptions, div, prelude::*, px, size,
 };
 use gpuikit::elements::button::button;
-use gpuikit::elements::dialog::{dialog, DialogClosed, DialogOpened, DialogState};
+use gpuikit::elements::dialog::{DialogClosed, DialogOpened, DialogState, dialog};
 use gpuikit::layout::h_stack;
 use gpuikit::theme::{ActiveTheme, Themeable};
 

--- a/examples/input/sandbox.rs
+++ b/examples/input/sandbox.rs
@@ -11,14 +11,14 @@
 mod fixtures;
 
 use gpui::{
-    actions, div, linear_color_stop, linear_gradient, prelude::*, px, rgb, size, App, Application,
-    Background, Bounds, Context, DefiniteLength, Div, Entity, FocusHandle, Focusable, FontWeight,
-    Hsla, KeyBinding, SharedString, Stateful, Window, WindowBounds, WindowOptions,
+    App, Application, Background, Bounds, Context, DefiniteLength, Div, Entity, FocusHandle,
+    Focusable, FontWeight, Hsla, KeyBinding, SharedString, Stateful, Window, WindowBounds,
+    WindowOptions, actions, div, linear_color_stop, linear_gradient, prelude::*, px, rgb, size,
 };
 use gpuikit::elements::input::{input, text_area};
-use gpuikit::elements::select::{select, SelectChanged, SelectState};
+use gpuikit::elements::select::{SelectChanged, SelectState, select};
 use gpuikit::elements::slider::{Slider, SliderChanged};
-use gpuikit::input::{bind_input_keys, InputState};
+use gpuikit::input::{InputState, bind_input_keys};
 
 use fixtures::SampleText;
 

--- a/examples/markdown_selection.rs
+++ b/examples/markdown_selection.rs
@@ -10,8 +10,8 @@
 #![allow(missing_docs)]
 
 use gpui::{
-    actions, div, prelude::*, px, size, App, Application, Bounds, ClipboardItem, Context, Entity,
-    KeyBinding, Window, WindowBounds, WindowOptions,
+    App, Application, Bounds, ClipboardItem, Context, Entity, KeyBinding, Window, WindowBounds,
+    WindowOptions, actions, div, prelude::*, px, size,
 };
 use gpuikit::markdown::{Markdown, MarkdownElement, MarkdownStyle};
 use gpuikit::theme::{ActiveTheme, Themeable};

--- a/examples/markdown_streaming.rs
+++ b/examples/markdown_streaming.rs
@@ -16,10 +16,10 @@
 use std::time::Duration;
 
 use gpui::{
-    actions, div, prelude::*, px, rems, size, App, Application, Bounds, Context, Entity,
-    KeyBinding, Window, WindowBounds, WindowOptions,
+    App, Application, Bounds, Context, Entity, KeyBinding, Window, WindowBounds, WindowOptions,
+    actions, div, prelude::*, px, rems, size,
 };
-use gpuikit::markdown::{preprocessing_available, Markdown, MarkdownElement, MarkdownStyle};
+use gpuikit::markdown::{Markdown, MarkdownElement, MarkdownStyle, preprocessing_available};
 use gpuikit::theme::{ActiveTheme, Themeable};
 
 actions!(markdown_streaming_example, [Restart]);

--- a/examples/popover_demo.rs
+++ b/examples/popover_demo.rs
@@ -3,11 +3,11 @@
 //! Run with: cargo run --example popover_demo
 
 use gpui::{
-    div, prelude::*, px, size, App, Application, Bounds, Context, Entity, FocusHandle, Focusable,
-    IntoElement, ParentElement, Render, Styled, Window, WindowBounds, WindowOptions,
+    App, Application, Bounds, Context, Entity, FocusHandle, Focusable, IntoElement, ParentElement,
+    Render, Styled, Window, WindowBounds, WindowOptions, div, prelude::*, px, size,
 };
 use gpuikit::elements::button::button;
-use gpuikit::elements::popover::{popover, PopoverState};
+use gpuikit::elements::popover::{PopoverState, popover};
 use gpuikit::layout::v_stack;
 use gpuikit::theme::{ActiveTheme, Themeable};
 

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -1379,7 +1379,7 @@ impl Showcase {
         &mut self,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -1422,7 +1422,7 @@ impl Showcase {
             )
     }
 
-    fn render_button_group_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_button_group_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -1464,7 +1464,7 @@ impl Showcase {
         &mut self,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -1561,7 +1561,7 @@ impl Showcase {
             )
     }
 
-    fn render_checkbox_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_checkbox_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -1580,7 +1580,7 @@ impl Showcase {
             )
     }
 
-    fn render_switch_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_switch_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -1600,7 +1600,7 @@ impl Showcase {
             )
     }
 
-    fn render_toggle_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_toggle_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -1625,7 +1625,7 @@ impl Showcase {
             )
     }
 
-    fn render_radio_group_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_radio_group_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -1639,7 +1639,7 @@ impl Showcase {
             .child(self.radio_notifications.clone())
     }
 
-    fn render_toggle_group_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_toggle_group_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -1682,7 +1682,7 @@ impl Showcase {
             )
     }
 
-    fn render_slider_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_slider_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -1709,7 +1709,7 @@ impl Showcase {
             )
     }
 
-    fn render_tabs_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_tabs_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -1725,7 +1725,7 @@ impl Showcase {
 
     /// The calendar page: a live grid, a disabled-day predicate, a week that
     /// starts on Monday, and the day the grid last reported beside it.
-    fn render_calendar_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_calendar_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
 
         v_stack()
@@ -1784,7 +1784,7 @@ impl Showcase {
     /// blur modes that are not the default. It draws real comboboxes rather
     /// than pointing `ELEMENT_COVERAGE` at the select page, which would answer
     /// the build gate without meeting it.
-    fn render_combobox_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_combobox_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let heading = |text: &'static str| div().text_sm().text_color(theme.fg_muted()).child(text);
 
@@ -1838,7 +1838,7 @@ impl Showcase {
 
     /// The command palette page. The palette itself is an overlay, so the page
     /// is a button that opens it and a note about the keyboard.
-    fn render_command_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_command_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let palette = self.command_palette.clone();
 
@@ -1867,7 +1867,7 @@ impl Showcase {
             )
     }
 
-    fn render_select_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_select_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let country_select = self.country_select.clone();
 
@@ -1987,7 +1987,7 @@ impl Showcase {
             )
     }
 
-    fn render_field_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_field_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -2060,7 +2060,7 @@ impl Showcase {
     /// The second fieldset is the whole argument: it says `disabled(true)`
     /// once, and neither field nor either checkbox inside it says anything
     /// about `disabled` at all.
-    fn render_form_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_form_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -2116,7 +2116,7 @@ impl Showcase {
             )
     }
 
-    fn render_text_field_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_text_field_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
 
         fn row(
@@ -2211,7 +2211,7 @@ impl Showcase {
             )
     }
 
-    fn render_textarea_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_textarea_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         card()
             .title("Textarea")
             .description("Multi-line text input for longer content")
@@ -2261,7 +2261,7 @@ impl Showcase {
             )
     }
 
-    fn render_avatar_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_avatar_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2279,7 +2279,7 @@ impl Showcase {
             )
     }
 
-    fn render_badge_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_badge_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2301,7 +2301,7 @@ impl Showcase {
             )
     }
 
-    fn render_kbd_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_kbd_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2338,7 +2338,7 @@ impl Showcase {
             )
     }
 
-    fn render_label_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_label_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2364,7 +2364,7 @@ impl Showcase {
     /// refresh rate. Pause stops that clock without leaving the page, so the
     /// cost of the indicators can be told apart from the cost of everything
     /// else here.
-    fn render_loading_indicator_page(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_loading_indicator_page(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let fg_muted = theme.fg_muted();
         let playing = self.loading_playing;
@@ -2408,7 +2408,7 @@ impl Showcase {
             ))
     }
 
-    fn render_progress_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_progress_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2429,7 +2429,7 @@ impl Showcase {
             )
     }
 
-    fn render_alert_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_alert_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2458,7 +2458,7 @@ impl Showcase {
             )
     }
 
-    fn render_tooltip_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_tooltip_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2486,7 +2486,7 @@ impl Showcase {
             )
     }
 
-    fn render_card_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_card_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2510,7 +2510,7 @@ impl Showcase {
             )
     }
 
-    fn render_aspect_ratio_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_aspect_ratio_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2597,7 +2597,7 @@ impl Showcase {
             )
     }
 
-    fn render_breadcrumb_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_breadcrumb_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2634,7 +2634,7 @@ impl Showcase {
             )
     }
 
-    fn render_separator_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_separator_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -2654,7 +2654,7 @@ impl Showcase {
             )
     }
 
-    fn render_splitter_page(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_splitter_page(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let border = theme.border();
         let fg_muted = theme.fg_muted();
@@ -2811,7 +2811,11 @@ impl Showcase {
             )
     }
 
-    fn render_sidebar_page(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_sidebar_page(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement + use<> {
         // Colors resolved up front: `List::render` takes `cx` mutably.
         let theme = cx.theme();
         let border = theme.border();
@@ -3003,7 +3007,7 @@ impl Showcase {
             })
     }
 
-    fn render_collapsible_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_collapsible_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_2()
@@ -3022,7 +3026,7 @@ impl Showcase {
             )
     }
 
-    fn render_accordion_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_accordion_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -3036,7 +3040,7 @@ impl Showcase {
             .child(self.accordion.clone())
     }
 
-    fn render_scroll_area_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_scroll_area_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -3121,7 +3125,7 @@ impl Showcase {
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -3183,7 +3187,7 @@ impl Showcase {
             )
     }
 
-    fn render_popover_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_popover_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -3201,7 +3205,7 @@ impl Showcase {
         &mut self,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -3234,7 +3238,7 @@ impl Showcase {
             )
     }
 
-    fn render_context_menu_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_context_menu_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let this = cx.entity();
         let pinned = self.context_menu_pinned;
@@ -3330,7 +3334,7 @@ impl Showcase {
         &mut self,
         _window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -3366,7 +3370,7 @@ impl Showcase {
             )
     }
 
-    fn render_typography_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_typography_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -3413,7 +3417,7 @@ impl Showcase {
             )
     }
 
-    fn render_empty_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_empty_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
         v_stack()
             .gap_4()
@@ -3537,7 +3541,7 @@ impl Showcase {
         rows
     }
 
-    fn render_table_page(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_table_page(&mut self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme().clone();
         // The handlers below run with `&mut App`, not with this view's
         // `Context`, so they reach the page through its own entity.
@@ -3732,7 +3736,7 @@ impl Showcase {
             )
     }
 
-    fn render_markdown_page(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_markdown_page(&mut self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme().clone();
 
         // `init_code_highlighting` is itself feature-gated, so the default
@@ -3888,7 +3892,7 @@ impl Showcase {
             )
     }
 
-    fn render_editor_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_editor_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
 
         // The page exists in both builds: requiring `--features editor` for
@@ -3938,7 +3942,7 @@ impl Showcase {
     ///
     /// Each row sits on a tinted stripe exactly the rung's height, so a control
     /// that is off its rung is visible immediately rather than only in a test.
-    fn render_control_sizes_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_control_sizes_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme();
 
         v_stack()
@@ -4052,7 +4056,7 @@ impl Showcase {
             )
     }
 
-    fn render_theme_page(&self, cx: &Context<Self>) -> impl IntoElement {
+    fn render_theme_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = cx.theme().clone();
 
         let sections: Vec<(&str, Vec<(&str, Hsla)>)> = vec![

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -1,59 +1,60 @@
 #![allow(missing_docs)]
 use gpui::prelude::FluentBuilder;
 use gpui::{
-    div, px, size, App, AppContext, Application, Bounds, ClipboardItem, Context, Entity,
-    FocusHandle, FontWeight, Hsla, InteractiveElement, IntoElement, Menu, ParentElement, Render,
-    Rgba, SharedString, StatefulInteractiveElement, Styled, TitlebarOptions, Window, WindowBounds,
-    WindowOptions,
+    App, AppContext, Application, Bounds, ClipboardItem, Context, Entity, FocusHandle, FontWeight,
+    Hsla, InteractiveElement, IntoElement, Menu, ParentElement, Render, Rgba, SharedString,
+    StatefulInteractiveElement, Styled, TitlebarOptions, Window, WindowBounds, WindowOptions, div,
+    px, size,
 };
 use gpuikit::a11y::FocusNavigation;
 use gpuikit::date::{Date, Weekday};
 use gpuikit::input::InputState;
-use gpuikit::markdown::{preprocessing_available, Markdown, MarkdownElement};
+use gpuikit::markdown::{Markdown, MarkdownElement, preprocessing_available};
 use gpuikit::theme::{ActiveTheme, GlobalTheme, Theme, Themeable};
 use gpuikit::{
+    DefaultIcons,
     elements::{
-        accordion::{accordion, accordion_item, AccordionState},
+        accordion::{AccordionState, accordion, accordion_item},
         alert::alert,
         aspect_ratio::{aspect_ratio, aspect_ratio_square, aspect_ratio_video},
         avatar::avatar,
         badge::badge,
-        breadcrumb::{breadcrumb, breadcrumb_item, BreadcrumbSeparator},
+        breadcrumb::{BreadcrumbSeparator, breadcrumb, breadcrumb_item},
         button::button,
         button_group::button_group,
         calendar::{Calendar, CalendarEvent},
         card::card,
-        checkbox::{checkbox, Checkbox},
-        collapsible::{collapsible, Collapsible},
-        combobox::{combobox, Combobox, ComboboxState},
+        checkbox::{Checkbox, checkbox},
+        collapsible::{Collapsible, collapsible},
+        combobox::{Combobox, ComboboxState, combobox},
         command::{CommandItem, CommandState},
         context_menu::{context_menu, menu_item},
-        dialog::{dialog, DialogState},
+        dialog::{DialogState, dialog},
         empty::empty,
-        field::{field, LabelPosition},
+        field::{LabelPosition, field},
         form::fieldset,
         icon_button::icon_button,
         kbd::{kbd, kbd_combo},
         label::label,
         list::{List, ListEntry},
         loading_indicator::loading_indicator,
-        popover::{popover, PopoverState},
-        progress::{progress, ProgressVariant},
-        radio_group::{radio_group, radio_option, RadioGroup},
+        popover::{PopoverState, popover},
+        progress::{ProgressVariant, progress},
+        radio_group::{RadioGroup, radio_group, radio_option},
         scroll_area::scroll_area,
-        select::{select, SelectState},
+        select::{SelectState, select},
         separator::separator,
-        sidebar::{sidebar, sidebar_trigger, SidebarEdge, SidebarState},
-        slider::{slider, Slider},
+        sidebar::{SidebarEdge, SidebarState, sidebar, sidebar_trigger},
+        slider::{Slider, slider},
         splitter::splitter,
-        switch::{switch, Switch},
-        table::{table, CellAlign, Column, Row, SortDescriptor, SortDirection},
-        tabs::{tab, tabs, Tabs},
-        text_field::{text_field, Adornment},
+        switch::{Switch, switch},
+        table::{CellAlign, Column, Row, SortDescriptor, SortDirection, table},
+        tabs::{Tabs, tab, tabs},
+        text_field::{Adornment, text_field},
         textarea::textarea,
         toast::ToastExt,
-        toggle::{toggle, Toggle},
-        toggle_group::{toggle_group, toggle_option, ToggleGroup, ToggleGroupMode},
+        toggle::{Toggle, toggle},
+        toggle_group::{ToggleGroup, ToggleGroupMode, toggle_group, toggle_option},
         tooltip::tooltip,
         typography::{blockquote, h1, h2, h3, h4, lead, p, small, text},
     },
@@ -63,7 +64,6 @@ use gpuikit::{
     traits::disableable::Disableable,
     traits::labelable::Labelable,
     traits::orientable::{Orientable, Orientation},
-    DefaultIcons,
 };
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -383,7 +383,7 @@ fn navigate_to(cell: &Rc<RefCell<SharedString>>, page: SharedString, window: &mu
 /// lives as long as the page does.
 #[cfg(target_family = "wasm")]
 fn follow_location(showcase: gpui::WindowHandle<Showcase>, cx: &mut App) {
-    use wasm_bindgen::{closure::Closure, JsCast};
+    use wasm_bindgen::{JsCast, closure::Closure};
 
     let Some(browser_window) = web_sys::window() else {
         return;

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -1,14 +1,14 @@
 #![allow(missing_docs)]
 
 use gpui::{
-    div, hsla, prelude::FluentBuilder, px, size, App, AppContext, Application, Bounds, ClickEvent,
-    Context, ElementId, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement,
-    Styled, TitlebarOptions, Window, WindowBounds, WindowOptions,
+    App, AppContext, Application, Bounds, ClickEvent, Context, ElementId, Entity, EventEmitter,
+    FocusHandle, Focusable, InteractiveElement, IntoElement, MouseButton, ParentElement, Render,
+    SharedString, StatefulInteractiveElement, Styled, TitlebarOptions, Window, WindowBounds,
+    WindowOptions, div, hsla, prelude::FluentBuilder, px, size,
 };
 use gpuikit::{
     elements::{
-        badge::{badge, BadgeVariant},
+        badge::{BadgeVariant, badge},
         button::button,
     },
     layout::{h_stack, v_stack},

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -549,7 +549,7 @@ impl Render for TasksApp {
 fn filter_button(
     label: &'static str,
     theme: &std::sync::Arc<gpuikit::theme::Theme>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     div()
         .id(label)
         .px(px(8.))
@@ -569,7 +569,7 @@ fn task_row(
     checkbox: Entity<RowCheckbox>,
     index: usize,
     theme: &std::sync::Arc<gpuikit::theme::Theme>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     let label_variant = match task.label {
         TaskLabel::Bug => BadgeVariant::Destructive,
         TaskLabel::Feature => BadgeVariant::Default,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+# Pinned, not inherited. rustfmt's *style* edition follows the crate's edition
+# unless it is set here, so bumping `edition` in Cargo.toml would silently
+# reformat every file in the crate — 2024 sorts `use` items case-sensitively,
+# which reorders almost every import block. That churn is a change worth making
+# on purpose, in its own commit, rather than a side effect of an unrelated one.
+# It is set to 2024 because that reformatting has happened; the next style
+# edition gets the same treatment.
+style_edition = "2024"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -46,7 +46,14 @@ cat "$log"
 echo
 
 # `Running …` and `Doc-tests …` each announce one binary; `test result: …` is
-# one summary. Every announced binary owes a summary.
+# one summary. Every announced binary owes *at least* one summary — the
+# comparison below is `<`, not `!=`, and since edition 2024 it has to be.
+# Edition 2024 merges a crate's doctests into a single binary, but rustdoc
+# cannot merge every block (one with its own `fn main`, or a `compile_fail`,
+# still compiles standalone), so one `Doc-tests` line now reports two
+# `test result:` lines: the merged group, then the leftovers. A binary killed
+# without reporting still shows up as fewer summaries than binaries, which is
+# the direction this guard exists to catch.
 binaries=$(grep -c -E '^[[:space:]]*(Running|Doc-tests) ' "$log" || true)
 summaries=$(grep -c '^test result:' "$log" || true)
 failed=$(grep -c '^test result: FAILED' "$log" || true)

--- a/src/a11y.rs
+++ b/src/a11y.rs
@@ -257,8 +257,8 @@
 //! derived cell ids first.
 
 use gpui::{
-    actions, App, FocusHandle, InteractiveElement, KeyBinding, Orientation, Role, SharedString,
-    StatefulInteractiveElement, Toggled,
+    App, FocusHandle, InteractiveElement, KeyBinding, Orientation, Role, SharedString,
+    StatefulInteractiveElement, Toggled, actions,
 };
 
 /// What an element announces: a role, a name, and whatever state goes with the
@@ -1064,7 +1064,7 @@ impl<E: StatefulInteractiveElement> Announce for E {}
 /// point, and hand back the node it would have built.
 #[cfg(test)]
 pub(crate) mod test_support {
-    use gpui::{accesskit, App, Element, ElementId, IntoElement, RenderOnce, Role, Window};
+    use gpui::{App, Element, ElementId, IntoElement, RenderOnce, Role, Window, accesskit};
 
     /// One element, as gpui's accessibility walk would have seen it.
     pub(crate) struct Announced {
@@ -1137,7 +1137,7 @@ pub(crate) mod test_support {
 mod tests {
     use super::test_support::announced_element;
     use super::*;
-    use gpui::{accesskit, div, Orientation, Role, Toggled};
+    use gpui::{Orientation, Role, Toggled, accesskit, div};
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -1440,12 +1440,16 @@ mod tests {
     #[test]
     fn a_required_name_is_absent_blank_or_given() {
         assert!(A11y::new(Role::Button).is_missing_a_required_name());
-        assert!(A11y::new(Role::Button)
-            .name("  ")
-            .is_missing_a_required_name());
-        assert!(!A11y::new(Role::Button)
-            .name("Save")
-            .is_missing_a_required_name());
+        assert!(
+            A11y::new(Role::Button)
+                .name("  ")
+                .is_missing_a_required_name()
+        );
+        assert!(
+            !A11y::new(Role::Button)
+                .name("Save")
+                .is_missing_a_required_name()
+        );
         assert!(!A11y::new(Role::Document).is_missing_a_required_name());
 
         assert_eq!(

--- a/src/editor/editor.rs
+++ b/src/editor/editor.rs
@@ -1,4 +1,4 @@
-use gpui::{px, rgb, ElementId, Pixels, Rgba, SharedString, TextRun};
+use gpui::{ElementId, Pixels, Rgba, SharedString, TextRun, px, rgb};
 
 use super::buffer::{GapBuffer, TextBuffer};
 use super::syntax_highlighter::SyntaxHighlighter;

--- a/src/editor/element.rs
+++ b/src/editor/element.rs
@@ -2,7 +2,7 @@
 
 use super::buffer::TextBuffer;
 use super::editor::Editor;
-use gpui::{canvas, Stateful, *};
+use gpui::{Stateful, canvas, *};
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/editor/meta_line.rs
+++ b/src/editor/meta_line.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    div, prelude::FluentBuilder, px, rgb, IntoElement, ParentElement, Point, RenderOnce,
-    SharedString, Styled,
+    IntoElement, ParentElement, Point, RenderOnce, SharedString, Styled, div,
+    prelude::FluentBuilder, px, rgb,
 };
 
 #[derive(Default, Debug, Clone)]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -28,7 +28,7 @@ pub use buffer::{GapBuffer, TextBuffer};
 pub use editor::{CursorPosition, Editor, EditorConfig};
 pub use element::EditorElement;
 // Re-export keymap types from keymap module
-pub use crate::keymap::extensions::{bind, create_bindings, BindingBuilder};
+pub use crate::keymap::extensions::{BindingBuilder, bind, create_bindings};
 pub use crate::keymap::{BindingSpec, Keymap, KeymapCollection};
 pub use meta_line::{Language, MetaLine, Selection};
 pub use syntax_highlighter::SyntaxHighlighter;

--- a/src/elements/accordion.rs
+++ b/src/elements/accordion.rs
@@ -25,8 +25,8 @@
 use crate::icons::Icons;
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::*, px, rems, Context, ElementId, EventEmitter, IntoElement, ParentElement,
-    Render, SharedString, Styled, Window,
+    Context, ElementId, EventEmitter, IntoElement, ParentElement, Render, SharedString, Styled,
+    Window, div, prelude::*, px, rems,
 };
 use std::collections::HashSet;
 

--- a/src/elements/alert.rs
+++ b/src/elements/alert.rs
@@ -6,9 +6,9 @@ use crate::element_id::scoped;
 use crate::icons::Icons;
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::FluentBuilder, px, rems, App, ClickEvent, Context, ElementId, Entity, Hsla,
-    InteractiveElement, IntoElement, MouseButton, ParentElement, RenderOnce, SharedString,
-    StatefulInteractiveElement, Styled, Svg, Window,
+    App, ClickEvent, Context, ElementId, Entity, Hsla, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, RenderOnce, SharedString, StatefulInteractiveElement, Styled, Svg,
+    Window, div, prelude::FluentBuilder, px, rems,
 };
 
 /// Creates a new alert with an optional message

--- a/src/elements/aspect_ratio.rs
+++ b/src/elements/aspect_ratio.rs
@@ -4,8 +4,8 @@
 //! Useful for images, videos, and other media that need consistent proportions.
 
 use gpui::{
-    div, prelude::FluentBuilder, relative, AnyElement, App, IntoElement, ParentElement, Pixels,
-    RenderOnce, Styled, Window,
+    AnyElement, App, IntoElement, ParentElement, Pixels, RenderOnce, Styled, Window, div,
+    prelude::FluentBuilder, relative,
 };
 
 /// Common aspect ratio presets

--- a/src/elements/avatar.rs
+++ b/src/elements/avatar.rs
@@ -1,7 +1,7 @@
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, img, rems, AbsoluteLength, App, ImageSource, Img, IntoElement, ParentElement, RenderOnce,
-    Styled, Window,
+    AbsoluteLength, App, ImageSource, Img, IntoElement, ParentElement, RenderOnce, Styled, Window,
+    div, img, rems,
 };
 
 pub fn avatar(src: impl Into<ImageSource>) -> Avatar {

--- a/src/elements/badge.rs
+++ b/src/elements/badge.rs
@@ -1,7 +1,7 @@
 use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::control_sized::ControlSized;
 use gpui::{
-    div, App, FontWeight, IntoElement, ParentElement, RenderOnce, SharedString, Styled, Window,
+    App, FontWeight, IntoElement, ParentElement, RenderOnce, SharedString, Styled, Window, div,
 };
 
 pub fn badge(label: impl Into<SharedString>) -> Badge {

--- a/src/elements/breadcrumb.rs
+++ b/src/elements/breadcrumb.rs
@@ -3,9 +3,8 @@
 use crate::layout::h_stack;
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::*, rems, App, ClickEvent, ElementId, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, RenderOnce, SharedString, StatefulInteractiveElement, Styled,
-    Window,
+    App, ClickEvent, ElementId, InteractiveElement, IntoElement, MouseButton, ParentElement,
+    RenderOnce, SharedString, StatefulInteractiveElement, Styled, Window, div, prelude::*, rems,
 };
 
 /// A single breadcrumb item

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -1,13 +1,13 @@
 use crate::a11y::{A11y, Announce};
-use crate::theme::{focus_ring, ActiveTheme, ControlSize, Themeable};
+use crate::theme::{ActiveTheme, ControlSize, Themeable, focus_ring};
 use crate::{
     layout::h_stack, traits, traits::accessible::Accessible, traits::control_sized::ControlSized,
     traits::disableable::Disableable,
 };
 use gpui::{
-    prelude::FluentBuilder, AnyView, App, ClickEvent, ElementId, FocusHandle, FontWeight,
-    InteractiveElement, IntoElement, MouseButton, ParentElement, RenderOnce, Role, SharedString,
-    StatefulInteractiveElement, Styled, Window,
+    AnyView, App, ClickEvent, ElementId, FocusHandle, FontWeight, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, RenderOnce, Role, SharedString, StatefulInteractiveElement, Styled,
+    Window, prelude::FluentBuilder,
 };
 
 pub fn button(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Button {
@@ -250,11 +250,11 @@ impl ControlSized for Button {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::a11y::test_support::announced;
     use crate::a11y::FocusNavigation;
+    use crate::a11y::test_support::announced;
     use gpui::{
-        accesskit, div, px, size, AnyElement, Context, ElementId, FocusHandle, KeyUpEvent,
-        Keystroke, PlatformInput, Render, TestAppContext, VisualTestContext,
+        AnyElement, Context, ElementId, FocusHandle, KeyUpEvent, Keystroke, PlatformInput, Render,
+        TestAppContext, VisualTestContext, accesskit, div, px, size,
     };
     use std::cell::RefCell;
     use std::rc::Rc;
@@ -472,7 +472,10 @@ mod tests {
         cx.run_until_parked();
 
         let now = focused(cx);
-        assert!(now.is_some() && now != Some(root), "Tab did not reach the button. `announce` makes a focusable element a tab stop with `.tab_stop(true)`; a focusable element that is not a stop is walked straight past by `TabStopMap::next`");
+        assert!(
+            now.is_some() && now != Some(root),
+            "Tab did not reach the button. `announce` makes a focusable element a tab stop with `.tab_stop(true)`; a focusable element that is not a stop is walked straight past by `TabStopMap::next`"
+        );
     }
 
     /// The caller-handle path, which `track_focus` does *not* make a stop on

--- a/src/elements/button_group.rs
+++ b/src/elements/button_group.rs
@@ -6,8 +6,8 @@ use crate::theme::{ActiveTheme, Themeable};
 use crate::traits::disableable::Disableable;
 use crate::traits::orientable::{Orientable, Orientation};
 use gpui::{
-    div, rems, AnyElement, App, ElementId, InteractiveElement, IntoElement, ParentElement,
-    RenderOnce, Styled, Window,
+    AnyElement, App, ElementId, InteractiveElement, IntoElement, ParentElement, RenderOnce, Styled,
+    Window, div, rems,
 };
 
 /// Create a new button group with the given ID.

--- a/src/elements/calendar.rs
+++ b/src/elements/calendar.rs
@@ -420,7 +420,7 @@ impl Calendar {
         delta: i32,
         icon: gpui::Svg,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let metrics = theme.control(self.size);
         let fg = theme.fg_muted();

--- a/src/elements/calendar.rs
+++ b/src/elements/calendar.rs
@@ -66,16 +66,16 @@
 //! breaking change to make deliberately, not a field to bolt on.
 
 use crate::a11y::{A11y, Announce};
-use crate::date::{month_name, Date, Weekday};
+use crate::date::{Date, Weekday, month_name};
 use crate::element_id::scoped;
 use crate::icons::Icons;
-use crate::theme::{focus_ring, ActiveTheme, ControlSize, Themeable};
+use crate::theme::{ActiveTheme, ControlSize, Themeable, focus_ring};
 use crate::traits::accessible::Accessible;
 use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use gpui::{
-    actions, div, prelude::*, App, Context, ElementId, EventEmitter, FocusHandle, Focusable,
-    IntoElement, KeyBinding, ParentElement, Rems, Render, Role, SharedString, Styled, Window,
+    App, Context, ElementId, EventEmitter, FocusHandle, Focusable, IntoElement, KeyBinding,
+    ParentElement, Rems, Render, Role, SharedString, Styled, Window, actions, div, prelude::*,
 };
 use std::rc::Rc;
 
@@ -684,7 +684,7 @@ impl Render for Calendar {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{px, size, Entity, TestAppContext, VisualTestContext};
+    use gpui::{Entity, TestAppContext, VisualTestContext, px, size};
     use std::cell::RefCell;
     use std::ops::Deref;
 

--- a/src/elements/card.rs
+++ b/src/elements/card.rs
@@ -1,7 +1,7 @@
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::FluentBuilder, rems, AnyElement, App, IntoElement, ParentElement, RenderOnce,
-    SharedString, Styled, Window,
+    AnyElement, App, IntoElement, ParentElement, RenderOnce, SharedString, Styled, Window, div,
+    prelude::FluentBuilder, rems,
 };
 
 pub fn card() -> Card {

--- a/src/elements/checkbox.rs
+++ b/src/elements/checkbox.rs
@@ -9,9 +9,9 @@ use crate::traits::disableable::Disableable;
 use crate::traits::labelable::Labelable;
 use crate::traits::selectable::Selectable;
 use gpui::{
-    div, prelude::*, px, App, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, Render, RenderOnce, SharedString, StatefulInteractiveElement,
-    Styled, Window,
+    App, Context, ElementId, EventEmitter, InteractiveElement, IntoElement, MouseButton,
+    ParentElement, Render, RenderOnce, SharedString, StatefulInteractiveElement, Styled, Window,
+    div, prelude::*, px,
 };
 
 /// Event emitted when the checkbox state changes

--- a/src/elements/collapsible.rs
+++ b/src/elements/collapsible.rs
@@ -5,9 +5,9 @@ use crate::layout::h_stack;
 use crate::theme::{ActiveTheme, Themeable};
 use crate::traits::disableable::Disableable;
 use gpui::{
-    div, prelude::*, px, rems, AnyElement, App, Context, ElementId, EventEmitter,
-    InteractiveElement, IntoElement, MouseButton, ParentElement, Render, SharedString,
-    StatefulInteractiveElement, Styled, Window,
+    AnyElement, App, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
+    div, prelude::*, px, rems,
 };
 use std::rc::Rc;
 

--- a/src/elements/combobox.rs
+++ b/src/elements/combobox.rs
@@ -100,8 +100,8 @@
 
 use crate::a11y::{A11y, Announce};
 use crate::element_id::scoped;
-use crate::elements::listbox::{matches_query, Listbox, ListboxFocus, LISTBOX_GAP};
-use crate::elements::text_field::{text_field, Adornment};
+use crate::elements::listbox::{LISTBOX_GAP, Listbox, ListboxFocus, matches_query};
+use crate::elements::text_field::{Adornment, text_field};
 use crate::icons::Icons;
 use crate::input::{InputState, InputStateEvent};
 use crate::theme::{ActiveTheme, ControlSize, Themeable};
@@ -109,9 +109,9 @@ use crate::traits::accessible::Accessible;
 use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use gpui::{
-    actions, anchored, deferred, div, point, prelude::*, px, App, Context, DismissEvent, ElementId,
-    Entity, EventEmitter, IntoElement, KeyBinding, ParentElement, Render, Role, SharedString,
-    Styled, Window,
+    App, Context, DismissEvent, ElementId, Entity, EventEmitter, IntoElement, KeyBinding,
+    ParentElement, Render, Role, SharedString, Styled, Window, actions, anchored, deferred, div,
+    point, prelude::*, px,
 };
 use std::rc::Rc;
 
@@ -776,7 +776,7 @@ impl<T: Clone + PartialEq + 'static> Render for ComboboxState<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{px, size, Entity, TestAppContext, VisualTestContext};
+    use gpui::{Entity, TestAppContext, VisualTestContext, px, size};
     use std::cell::RefCell;
     use std::ops::Deref;
 

--- a/src/elements/command.rs
+++ b/src/elements/command.rs
@@ -74,9 +74,9 @@ use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::accessible::Accessible;
 use crate::traits::control_sized::ControlSized;
 use gpui::{
-    actions, deferred, div, prelude::*, px, App, Context, ElementId, Entity, EventEmitter,
-    Focusable, IntoElement, KeyBinding, ParentElement, Rems, Render, Role, SharedString, Styled,
-    Svg, Window,
+    App, Context, ElementId, Entity, EventEmitter, Focusable, IntoElement, KeyBinding,
+    ParentElement, Rems, Render, Role, SharedString, Styled, Svg, Window, actions, deferred, div,
+    prelude::*, px,
 };
 use std::rc::Rc;
 
@@ -639,7 +639,7 @@ impl Render for CommandState {
 mod tests {
     use super::*;
     use gpui::{
-        div, px, size, AppContext, Entity, IntoElement, Render, TestAppContext, VisualTestContext,
+        AppContext, Entity, IntoElement, Render, TestAppContext, VisualTestContext, div, px, size,
     };
     use std::cell::RefCell;
     use std::ops::Deref;

--- a/src/elements/context_menu.rs
+++ b/src/elements/context_menu.rs
@@ -29,9 +29,9 @@
 use std::rc::Rc;
 
 use gpui::{
-    anchored, deferred, div, prelude::*, px, Action, AnyElement, App, Context, ElementId, Entity,
-    FocusHandle, IntoElement, KeyDownEvent, MouseButton, MouseDownEvent, ParentElement, Pixels,
-    Point, ScrollHandle, SharedString, Styled, Svg, Window,
+    Action, AnyElement, App, Context, ElementId, Entity, FocusHandle, IntoElement, KeyDownEvent,
+    MouseButton, MouseDownEvent, ParentElement, Pixels, Point, ScrollHandle, SharedString, Styled,
+    Svg, Window, anchored, deferred, div, prelude::*, px,
 };
 
 use crate::element_id::scoped;
@@ -209,11 +209,7 @@ impl MenuItems {
 
     /// Applies `f` only when `condition` holds.
     pub fn when(self, condition: bool, f: impl FnOnce(Self) -> Self) -> Self {
-        if condition {
-            f(self)
-        } else {
-            self
-        }
+        if condition { f(self) } else { self }
     }
 
     /// Whether no entries have been added.
@@ -783,7 +779,7 @@ fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{point, Modifiers, MouseUpEvent, Render, TestAppContext, VisualTestContext};
+    use gpui::{Modifiers, MouseUpEvent, Render, TestAppContext, VisualTestContext, point};
     use std::cell::RefCell;
 
     fn labels(entries: &[MenuEntry]) -> Vec<&str> {

--- a/src/elements/context_menu.rs
+++ b/src/elements/context_menu.rs
@@ -583,7 +583,7 @@ fn menu_popup(
     min_width: Pixels,
     max_height: Pixels,
     cx: &App,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     let theme = cx.theme();
 
     div()
@@ -670,7 +670,7 @@ fn clears_the_highlight(
     }
 }
 
-fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement {
+fn menu_row(row: Row, state: Entity<MenuState>, cx: &App) -> impl IntoElement + use<> {
     let theme = cx.theme();
 
     match row {

--- a/src/elements/control_size_tests.rs
+++ b/src/elements/control_size_tests.rs
@@ -10,21 +10,21 @@
 //! [`CONTROLS`] and [`every_sized_control_on_a_row_is_the_same_height`] for
 //! which elements are left out and why.
 
-use gpui::{div, prelude::*, px, Context, Entity, Pixels, Render, TestAppContext, Window};
+use gpui::{Context, Entity, Pixels, Render, TestAppContext, Window, div, prelude::*, px};
 
 use crate::elements::badge::badge;
 use crate::elements::button::button;
-use crate::elements::checkbox::{checkbox, Checkbox};
+use crate::elements::checkbox::{Checkbox, checkbox};
 use crate::elements::icon_button::icon_button;
 use crate::elements::kbd::kbd;
-use crate::elements::radio_group::{radio_group, radio_option, RadioGroup};
-use crate::elements::select::{select, SelectState};
-use crate::elements::slider::{slider, Slider};
-use crate::elements::switch::{switch, Switch};
-use crate::elements::tabs::{tab, tabs, Tabs};
+use crate::elements::radio_group::{RadioGroup, radio_group, radio_option};
+use crate::elements::select::{SelectState, select};
+use crate::elements::slider::{Slider, slider};
+use crate::elements::switch::{Switch, switch};
+use crate::elements::tabs::{Tabs, tab, tabs};
 use crate::elements::text_field::text_field;
-use crate::elements::toggle::{toggle, Toggle};
-use crate::elements::toggle_group::{toggle_group, toggle_option, ToggleGroup};
+use crate::elements::toggle::{Toggle, toggle};
+use crate::elements::toggle_group::{ToggleGroup, toggle_group, toggle_option};
 use crate::icons::Icons;
 use crate::input::InputState;
 use crate::layout::h_stack;

--- a/src/elements/dialog.rs
+++ b/src/elements/dialog.rs
@@ -40,9 +40,9 @@ use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::accessible::Accessible;
 use crate::traits::control_sized::ControlSized;
 use gpui::{
-    actions, deferred, div, prelude::*, px, AnyElement, App, Context, DismissEvent, ElementId,
-    EventEmitter, FocusHandle, Focusable, IntoElement, KeyBinding, ParentElement, Render, Role,
-    SharedString, Styled, Window,
+    AnyElement, App, Context, DismissEvent, ElementId, EventEmitter, FocusHandle, Focusable,
+    IntoElement, KeyBinding, ParentElement, Render, Role, SharedString, Styled, Window, actions,
+    deferred, div, prelude::*, px,
 };
 use std::rc::Rc;
 
@@ -806,9 +806,11 @@ mod tests {
     /// would trip `announce`'s own `debug_assert!`.
     #[test]
     fn an_untitled_dialog_has_no_name_to_announce() {
-        assert!(DialogState::new(dialog("plain"))
-            .a11y()
-            .is_missing_a_required_name());
+        assert!(
+            DialogState::new(dialog("plain"))
+                .a11y()
+                .is_missing_a_required_name()
+        );
     }
 
     /// The refining builders adjust a confirmation and refuse to create one,
@@ -831,7 +833,7 @@ mod tests {
 
     #[test]
     fn a_destructive_button_reports_its_variant() {
-        use crate::elements::button::{button, ButtonVariant};
+        use crate::elements::button::{ButtonVariant, button};
 
         // `b.variant()` with no argument resolves to the inherent *builder*
         // and fails to compile; the getter is reached through the trait.

--- a/src/elements/empty.rs
+++ b/src/elements/empty.rs
@@ -1,7 +1,7 @@
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::FluentBuilder, px, rems, AnyElement, App, IntoElement, ParentElement, RenderOnce,
-    SharedString, Styled, Svg, Window,
+    AnyElement, App, IntoElement, ParentElement, RenderOnce, SharedString, Styled, Svg, Window,
+    div, prelude::FluentBuilder, px, rems,
 };
 
 pub fn empty() -> Empty {

--- a/src/elements/field.rs
+++ b/src/elements/field.rs
@@ -14,9 +14,9 @@ use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use crate::traits::labelable::Labelable;
 use gpui::{
-    div, prelude::FluentBuilder, rems, AnyElement, App, ElementId, InteractiveElement, IntoElement,
-    ParentElement, Rems, RenderOnce, Role, SharedString, StatefulInteractiveElement, Styled,
-    Window,
+    AnyElement, App, ElementId, InteractiveElement, IntoElement, ParentElement, Rems, RenderOnce,
+    Role, SharedString, StatefulInteractiveElement, Styled, Window, div, prelude::FluentBuilder,
+    rems,
 };
 
 /// Width of the label column in the beside layout.

--- a/src/elements/form.rs
+++ b/src/elements/form.rs
@@ -81,9 +81,9 @@ use crate::traits::accessible::Accessible;
 use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use gpui::{
-    div, prelude::FluentBuilder, rems, AnyElement, App, Bounds, ElementId, FocusHandle,
-    GlobalElementId, InspectorElementId, InteractiveElement, IntoElement, LayoutId, ParentElement,
-    Pixels, RenderOnce, Role, SharedString, Styled, Window,
+    AnyElement, App, Bounds, ElementId, FocusHandle, GlobalElementId, InspectorElementId,
+    InteractiveElement, IntoElement, LayoutId, ParentElement, Pixels, RenderOnce, Role,
+    SharedString, Styled, Window, div, prelude::FluentBuilder, rems,
 };
 
 /// What a group tells the controls inside it.
@@ -562,12 +562,12 @@ impl RenderOnce for Fieldset {
 mod tests {
     use super::*;
     use crate::a11y::test_support::announced;
-    use crate::elements::checkbox::{checkbox, Checkbox};
+    use crate::elements::checkbox::{Checkbox, checkbox};
     use crate::elements::field::field;
     use crate::traits::labelable::Labelable;
     use gpui::{
-        px, size, AnyElement, AppContext, Bounds, Context, Modifiers, Render, TestAppContext,
-        VisualTestContext,
+        AnyElement, AppContext, Bounds, Context, Modifiers, Render, TestAppContext,
+        VisualTestContext, px, size,
     };
 
     /// Draws whatever the test's closure builds, every frame.

--- a/src/elements/icon_button.rs
+++ b/src/elements/icon_button.rs
@@ -4,9 +4,9 @@ use crate::traits::{
     selectable::Selectable,
 };
 use gpui::{
-    prelude::FluentBuilder, AnyView, App, ClickEvent, Context, ElementId, Entity,
-    InteractiveElement, IntoElement, MouseButton, ParentElement, Rems, RenderOnce,
-    StatefulInteractiveElement, Styled, Svg, Window,
+    AnyView, App, ClickEvent, Context, ElementId, Entity, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, Rems, RenderOnce, StatefulInteractiveElement, Styled, Svg, Window,
+    prelude::FluentBuilder,
 };
 
 pub fn icon_button(id: impl Into<ElementId>, icon: Svg) -> IconButton {

--- a/src/elements/input.rs
+++ b/src/elements/input.rs
@@ -10,20 +10,20 @@
 use std::sync::Arc;
 
 use gpui::{
-    fill, point, px, relative, size, Action, App, Bounds, ContentMask, Context, CursorStyle,
-    DispatchPhase, Element, ElementId, Entity, FocusHandle, Focusable, GlobalElementId, Hitbox,
-    HitboxBehavior, Hsla, InspectorElementId, InteractiveElement, Interactivity, IntoElement,
-    LayoutId, Length, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point,
-    ScrollWheelEvent, SharedString, StyleRefinement, Styled, TextAlign, TextRun, TextStyle,
-    TextStyleRefinement, Window, WrappedLine,
+    Action, App, Bounds, ContentMask, Context, CursorStyle, DispatchPhase, Element, ElementId,
+    Entity, FocusHandle, Focusable, GlobalElementId, Hitbox, HitboxBehavior, Hsla,
+    InspectorElementId, InteractiveElement, Interactivity, IntoElement, LayoutId, Length,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, ScrollWheelEvent,
+    SharedString, StyleRefinement, Styled, TextAlign, TextRun, TextStyle, TextStyleRefinement,
+    Window, WrappedLine, fill, point, px, relative, size,
 };
 
 use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::control_sized::ControlSized;
 
 use crate::input::{
-    bindings::Escape, ElementInputHandler, InputLineLayout, InputState, TextDirection,
-    INPUT_CONTEXT,
+    ElementInputHandler, INPUT_CONTEXT, InputLineLayout, InputState, TextDirection,
+    bindings::Escape,
 };
 
 const CURSOR_WIDTH: f32 = 2.0;

--- a/src/elements/kbd.rs
+++ b/src/elements/kbd.rs
@@ -1,7 +1,7 @@
 use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::control_sized::ControlSized;
 use gpui::{
-    div, App, FontWeight, IntoElement, ParentElement, RenderOnce, SharedString, Styled, Window,
+    App, FontWeight, IntoElement, ParentElement, RenderOnce, SharedString, Styled, Window, div,
 };
 
 /// Creates a keyboard key display element.

--- a/src/elements/label.rs
+++ b/src/elements/label.rs
@@ -2,8 +2,8 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::FluentBuilder, rems, App, Div, ElementId, FontWeight, IntoElement, ParentElement,
-    RenderOnce, SharedString, Styled, Window,
+    App, Div, ElementId, FontWeight, IntoElement, ParentElement, RenderOnce, SharedString, Styled,
+    Window, div, prelude::FluentBuilder, rems,
 };
 
 /// Creates a label with the given text

--- a/src/elements/list.rs
+++ b/src/elements/list.rs
@@ -22,9 +22,9 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::FluentBuilder, px, uniform_list, AnyElement, App, ClickEvent, ElementId,
-    InteractiveElement, IntoElement, ParentElement, Pixels, SharedString,
-    StatefulInteractiveElement, Styled, UniformListScrollHandle, Window,
+    AnyElement, App, ClickEvent, ElementId, InteractiveElement, IntoElement, ParentElement, Pixels,
+    SharedString, StatefulInteractiveElement, Styled, UniformListScrollHandle, Window, div,
+    prelude::FluentBuilder, px, uniform_list,
 };
 use std::rc::Rc;
 

--- a/src/elements/list.rs
+++ b/src/elements/list.rs
@@ -137,7 +137,7 @@ impl List {
     }
 
     /// Render the list into an element.
-    pub fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+    pub fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement + use<> {
         let item_height = self.item_height;
         let font_size = self.font_size;
         let entries = self.entries.clone();

--- a/src/elements/listbox.rs
+++ b/src/elements/listbox.rs
@@ -37,9 +37,9 @@ use crate::icons::Icons;
 use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::accessible::Accessible;
 use gpui::{
-    actions, div, prelude::*, px, App, Context, DismissEvent, ElementId, Entity, EventEmitter,
-    FocusHandle, Focusable, IntoElement, KeyBinding, KeyDownEvent, ParentElement, Rems, Render,
-    Role, ScrollHandle, SharedString, Styled, Window,
+    App, Context, DismissEvent, ElementId, Entity, EventEmitter, FocusHandle, Focusable,
+    IntoElement, KeyBinding, KeyDownEvent, ParentElement, Rems, Render, Role, ScrollHandle,
+    SharedString, Styled, Window, actions, div, prelude::*, px,
 };
 use std::rc::Rc;
 

--- a/src/elements/loading_indicator.rs
+++ b/src/elements/loading_indicator.rs
@@ -19,8 +19,8 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::FluentBuilder, rems, App, AsyncApp, EntityId, Hsla, IntoElement, ParentElement,
-    Rems, RenderOnce, SharedString, Styled, Task, Window,
+    App, AsyncApp, EntityId, Hsla, IntoElement, ParentElement, Rems, RenderOnce, SharedString,
+    Styled, Task, Window, div, prelude::FluentBuilder, rems,
 };
 use std::cell::RefCell;
 use std::time::Duration;
@@ -676,7 +676,7 @@ impl LoadingClock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{px, Context, Render, TestAppContext};
+    use gpui::{Context, Render, TestAppContext, px};
 
     /// The clock outlives an individual `App`, so a test states its own
     /// starting point rather than inheriting one.

--- a/src/elements/popover.rs
+++ b/src/elements/popover.rs
@@ -24,9 +24,9 @@
 use crate::element_id::for_entity;
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    anchored, deferred, div, point, prelude::*, px, AnyElement, App, Context, DismissEvent,
-    ElementId, Entity, EventEmitter, FocusHandle, Focusable, IntoElement, ParentElement, Pixels,
-    Point, Render, Styled, Window,
+    AnyElement, App, Context, DismissEvent, ElementId, Entity, EventEmitter, FocusHandle,
+    Focusable, IntoElement, ParentElement, Pixels, Point, Render, Styled, Window, anchored,
+    deferred, div, point, prelude::*, px,
 };
 use std::rc::Rc;
 

--- a/src/elements/progress.rs
+++ b/src/elements/progress.rs
@@ -1,7 +1,7 @@
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::FluentBuilder, px, relative, App, IntoElement, ParentElement, Pixels, RenderOnce,
-    Styled, Window,
+    App, IntoElement, ParentElement, Pixels, RenderOnce, Styled, Window, div,
+    prelude::FluentBuilder, px, relative,
 };
 
 pub fn progress(value: f32) -> Progress {

--- a/src/elements/radio_group.rs
+++ b/src/elements/radio_group.rs
@@ -5,8 +5,8 @@ use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use crate::traits::orientable::{Orientable, Orientation};
 use gpui::{
-    div, prelude::*, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
+    Context, ElementId, EventEmitter, InteractiveElement, IntoElement, MouseButton, ParentElement,
+    Render, SharedString, StatefulInteractiveElement, Styled, Window, div, prelude::*,
 };
 
 /// Event emitted when the radio group selection changes

--- a/src/elements/scroll_area.rs
+++ b/src/elements/scroll_area.rs
@@ -28,8 +28,8 @@
 //! ```
 
 use gpui::{
-    div, prelude::*, px, AnyElement, App, ElementId, IntoElement, Length, ParentElement,
-    RenderOnce, Styled, Window,
+    AnyElement, App, ElementId, IntoElement, Length, ParentElement, RenderOnce, Styled, Window,
+    div, prelude::*, px,
 };
 
 /// Scroll direction for the scroll area

--- a/src/elements/select.rs
+++ b/src/elements/select.rs
@@ -128,14 +128,14 @@
 use crate::a11y::{A11y, Announce};
 #[cfg(test)]
 use crate::elements::listbox::option_a11y;
-use crate::elements::listbox::{Listbox, ListboxFocus, LISTBOX_GAP};
-use crate::theme::{focus_ring, ActiveTheme, ControlSize, Themeable};
+use crate::elements::listbox::{LISTBOX_GAP, Listbox, ListboxFocus};
+use crate::theme::{ActiveTheme, ControlSize, Themeable, focus_ring};
 use crate::traits::accessible::Accessible;
 use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use gpui::{
-    anchored, deferred, div, point, prelude::*, px, App, Context, DismissEvent, ElementId, Entity,
-    EventEmitter, IntoElement, ParentElement, Rems, Render, Role, SharedString, Styled, Window,
+    App, Context, DismissEvent, ElementId, Entity, EventEmitter, IntoElement, ParentElement, Rems,
+    Render, Role, SharedString, Styled, Window, anchored, deferred, div, point, prelude::*, px,
 };
 
 use crate::icons::Icons;
@@ -614,8 +614,8 @@ impl<T: Clone + PartialEq + 'static> Render for SelectState<T> {
 mod tests {
     use super::*;
     use gpui::{
-        px, size, Bounds, KeyUpEvent, Keystroke, Pixels, PlatformInput, Render, TestAppContext,
-        VisualTestContext,
+        Bounds, KeyUpEvent, Keystroke, Pixels, PlatformInput, Render, TestAppContext,
+        VisualTestContext, px, size,
     };
     use std::ops::Deref;
 

--- a/src/elements/select.rs
+++ b/src/elements/select.rs
@@ -463,7 +463,11 @@ impl<T: Clone + PartialEq + 'static> SelectState<T> {
             .map(|(_, label)| label.clone())
     }
 
-    pub fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    pub fn render(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement + use<T> {
         let is_open = self.listbox.is_some();
         // Before `theme` borrows `cx`, and before the label below shadows the
         // control's own name.

--- a/src/elements/separator.rs
+++ b/src/elements/separator.rs
@@ -4,7 +4,7 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use crate::traits::orientable::{Orientable, Orientation};
-use gpui::{div, px, IntoElement, Pixels, Styled};
+use gpui::{IntoElement, Pixels, Styled, div, px};
 
 /// A separator component for visually dividing content.
 #[derive(IntoElement)]

--- a/src/elements/sidebar.rs
+++ b/src/elements/sidebar.rs
@@ -53,15 +53,15 @@
 //! of the ladder that document states.
 
 use gpui::{
-    anchored, deferred, div, point, prelude::*, px, AnyElement, App, ClickEvent, Div, ElementId,
-    FocusHandle, IntoElement, ParentElement, Pixels, Rems, RenderOnce, Role, SharedString,
-    Stateful, Styled, Svg, Window,
+    AnyElement, App, ClickEvent, Div, ElementId, FocusHandle, IntoElement, ParentElement, Pixels,
+    Rems, RenderOnce, Role, SharedString, Stateful, Styled, Svg, Window, anchored, deferred, div,
+    point, prelude::*, px,
 };
 
 use crate::a11y::{A11y, Announce};
 use crate::element_id::scoped;
 use crate::icons::Icons;
-use crate::theme::{focus_ring, ActiveTheme, ControlMetrics, ControlSize, Themeable};
+use crate::theme::{ActiveTheme, ControlMetrics, ControlSize, Themeable, focus_ring};
 use crate::traits::accessible::Accessible;
 use crate::traits::clickable::Clickable;
 use crate::traits::control_sized::ControlSized;
@@ -694,7 +694,7 @@ mod tests {
     use crate::elements::list::{List, ListEntry};
     use crate::elements::separator::separator;
     use crate::theme::ControlScale;
-    use gpui::{size, Context, Entity, Render, TestAppContext, VisualTestContext};
+    use gpui::{Context, Entity, Render, TestAppContext, VisualTestContext, size};
 
     // --- what it announces ---
 
@@ -737,9 +737,11 @@ mod tests {
     /// that section exists for.
     #[test]
     fn the_trigger_takes_focus_and_a_disabled_one_declines_it() {
-        assert!(sidebar_trigger("nav-toggle", SidebarState::Expanded)
-            .a11y()
-            .is_focusable());
+        assert!(
+            sidebar_trigger("nav-toggle", SidebarState::Expanded)
+                .a11y()
+                .is_focusable()
+        );
 
         let disabled = sidebar_trigger("nav-toggle", SidebarState::Expanded)
             .disabled(true)
@@ -752,10 +754,12 @@ mod tests {
     /// The panel is a landmark, so it is never asked the question.
     #[test]
     fn the_region_is_not_asked_about_keyboard_focus() {
-        assert!(!sidebar("app-nav")
-            .label("Navigation")
-            .a11y()
-            .is_missing_a_focus_decision());
+        assert!(
+            !sidebar("app-nav")
+                .label("Navigation")
+                .a11y()
+                .is_missing_a_focus_decision()
+        );
     }
 
     #[test]

--- a/src/elements/slider.rs
+++ b/src/elements/slider.rs
@@ -30,9 +30,9 @@ use crate::traits::disableable::Disableable;
 use crate::traits::labelable::Labelable;
 use crate::utils::element_manager::ElementManagerExt;
 use gpui::{
-    canvas, div, prelude::*, px, App, Bounds, Context, DispatchPhase, ElementId, EventEmitter,
-    IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels,
-    Point, Rems, Render, SharedString, Styled, Window,
+    App, Bounds, Context, DispatchPhase, ElementId, EventEmitter, IntoElement, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Point, Rems, Render,
+    SharedString, Styled, Window, canvas, div, prelude::*, px,
 };
 use std::ops::RangeInclusive;
 
@@ -419,7 +419,7 @@ impl ControlSized for Slider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{size, Entity, Modifiers, TestAppContext, VisualTestContext};
+    use gpui::{Entity, Modifiers, TestAppContext, VisualTestContext, size};
 
     // A `Slider` cannot be drawn with `VisualTestContext::draw`: registering a
     // mouse listener reads `Window::current_view`, which is only set while a

--- a/src/elements/splitter.rs
+++ b/src/elements/splitter.rs
@@ -75,9 +75,9 @@
 use std::rc::Rc;
 
 use gpui::{
-    canvas, div, prelude::*, px, AnyElement, App, Bounds, Context, CursorStyle, DispatchPhase, Div,
-    ElementId, Entity, FocusHandle, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, Pixels, Rems, Role, SharedString, Window,
+    AnyElement, App, Bounds, Context, CursorStyle, DispatchPhase, Div, ElementId, Entity,
+    FocusHandle, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
+    Rems, Role, SharedString, Window, canvas, div, prelude::*, px,
 };
 
 use crate::a11y::{A11y, Announce};
@@ -741,9 +741,9 @@ impl RenderOnce for Splitter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::a11y::{role_requires_a_name, role_requires_keyboard_focus, FocusNavigation};
+    use crate::a11y::{FocusNavigation, role_requires_a_name, role_requires_keyboard_focus};
     use crate::theme::ControlScale;
-    use gpui::{size, Modifiers, Point, Render, Size, TestAppContext, VisualTestContext};
+    use gpui::{Modifiers, Point, Render, Size, TestAppContext, VisualTestContext, size};
     use std::cell::RefCell;
 
     // --- the split maths, with no window ---
@@ -1050,9 +1050,11 @@ mod tests {
     fn a_splitter_is_one_of_the_roles_that_must_be_named() {
         assert!(role_requires_a_name(Role::Splitter));
         assert!(A11y::new(Role::Splitter).is_missing_a_required_name());
-        assert!(!splitter("panes", "Panes", 0.5)
-            .a11y()
-            .is_missing_a_required_name());
+        assert!(
+            !splitter("panes", "Panes", 0.5)
+                .a11y()
+                .is_missing_a_required_name()
+        );
     }
 
     /// The declaration half: the splitter answers the focus question its role

--- a/src/elements/switch.rs
+++ b/src/elements/switch.rs
@@ -10,8 +10,9 @@ use crate::traits::labelable::Labelable;
 use crate::traits::selectable::Selectable;
 use crate::utils::element_manager::ElementManagerExt;
 use gpui::{
-    div, prelude::*, App, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
+    App, Context, ElementId, EventEmitter, InteractiveElement, IntoElement, MouseButton,
+    ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window, div,
+    prelude::*,
 };
 
 /// Event emitted when the switch state changes

--- a/src/elements/table.rs
+++ b/src/elements/table.rs
@@ -80,12 +80,12 @@
 use std::rc::Rc;
 
 use gpui::{
-    div, prelude::*, px, AnyElement, App, Div, ElementId, FontWeight, IntoElement, Length,
-    MouseButton, ParentElement, RenderOnce, SharedString, Styled, Window,
+    AnyElement, App, Div, ElementId, FontWeight, IntoElement, Length, MouseButton, ParentElement,
+    RenderOnce, SharedString, Styled, Window, div, prelude::*, px,
 };
 
 use crate::element_id;
-use crate::elements::checkbox::{checkbox_box, CheckState};
+use crate::elements::checkbox::{CheckState, checkbox_box};
 use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::control_sized::ControlSized;
 

--- a/src/elements/tabs.rs
+++ b/src/elements/tabs.rs
@@ -7,8 +7,8 @@ use crate::theme::{ActiveTheme, ControlSize, Themeable};
 use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use gpui::{
-    div, prelude::*, px, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
+    Context, ElementId, EventEmitter, InteractiveElement, IntoElement, MouseButton, ParentElement,
+    Render, SharedString, StatefulInteractiveElement, Styled, Window, div, prelude::*, px,
 };
 
 /// Event emitted when the selected tab changes

--- a/src/elements/text_field.rs
+++ b/src/elements/text_field.rs
@@ -46,8 +46,8 @@
 //! [`Textarea`]: crate::elements::textarea::Textarea
 
 use gpui::{
-    div, prelude::*, AnyElement, App, ElementId, Entity, EntityId, FocusHandle, Focusable,
-    IntoElement, ParentElement, Rems, RenderOnce, SharedString, Styled, Svg, Window,
+    AnyElement, App, ElementId, Entity, EntityId, FocusHandle, Focusable, IntoElement,
+    ParentElement, Rems, RenderOnce, SharedString, Styled, Svg, Window, div, prelude::*,
 };
 
 use crate::element_id::for_entity;

--- a/src/elements/textarea.rs
+++ b/src/elements/textarea.rs
@@ -4,8 +4,8 @@
 //! styling with borders, padding, and theme colors.
 
 use gpui::{
-    div, prelude::*, App, ElementId, Entity, EntityId, FocusHandle, Focusable, IntoElement,
-    ParentElement, Pixels, Rems, RenderOnce, SharedString, Styled, Window,
+    App, ElementId, Entity, EntityId, FocusHandle, Focusable, IntoElement, ParentElement, Pixels,
+    Rems, RenderOnce, SharedString, Styled, Window, div, prelude::*,
 };
 
 use crate::element_id::for_entity;
@@ -360,7 +360,7 @@ mod tests {
     fn tab_stays_inside_a_focused_text_input(cx: &mut TestAppContext) {
         use crate::a11y::FocusNavigation;
         use crate::elements::button::button;
-        use gpui::{div, InteractiveElement, ParentElement};
+        use gpui::{InteractiveElement, ParentElement, div};
 
         cx.update(crate::init);
 

--- a/src/elements/toast.rs
+++ b/src/elements/toast.rs
@@ -26,13 +26,13 @@ use crate::element_id::{for_entity, scoped};
 use crate::icons::Icons;
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    deferred, div, prelude::*, px, rems, AnyElement, App, ClickEvent, Context, ElementId, Entity,
-    Global, Hsla, InteractiveElement, IntoElement, MouseButton, ParentElement, Render,
-    SharedString, StatefulInteractiveElement, Styled, Svg, Window,
+    AnyElement, App, ClickEvent, Context, ElementId, Entity, Global, Hsla, InteractiveElement,
+    IntoElement, MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement,
+    Styled, Svg, Window, deferred, div, prelude::*, px, rems,
 };
 use std::rc::Rc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 /// Default auto-dismiss duration for toasts

--- a/src/elements/toggle.rs
+++ b/src/elements/toggle.rs
@@ -8,8 +8,9 @@ use crate::traits::labelable::Labelable;
 use crate::traits::selectable::Selectable;
 use crate::utils::element_manager::ElementManagerExt;
 use gpui::{
-    div, prelude::*, App, Context, ElementId, EventEmitter, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
+    App, Context, ElementId, EventEmitter, InteractiveElement, IntoElement, MouseButton,
+    ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window, div,
+    prelude::*,
 };
 
 /// Event emitted when the toggle state changes

--- a/src/elements/toggle_group.rs
+++ b/src/elements/toggle_group.rs
@@ -7,9 +7,9 @@ use crate::traits::control_sized::ControlSized;
 use crate::traits::disableable::Disableable;
 use crate::traits::orientable::{Orientable, Orientation};
 use gpui::{
-    div, prelude::*, Context, Div, ElementId, EventEmitter, FontWeight, Hsla, InteractiveElement,
-    IntoElement, MouseButton, ParentElement, Render, SharedString, Stateful,
-    StatefulInteractiveElement, Styled, Window,
+    Context, Div, ElementId, EventEmitter, FontWeight, Hsla, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, Render, SharedString, Stateful, StatefulInteractiveElement, Styled,
+    Window, div, prelude::*,
 };
 
 /// Selection mode for the toggle group

--- a/src/elements/tooltip.rs
+++ b/src/elements/tooltip.rs
@@ -2,8 +2,8 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, px, AnyView, App, AppContext, Context, IntoElement, ParentElement, Render, SharedString,
-    Styled, Window,
+    AnyView, App, AppContext, Context, IntoElement, ParentElement, Render, SharedString, Styled,
+    Window, div, px,
 };
 
 /// A simple text tooltip.

--- a/src/elements/typography.rs
+++ b/src/elements/typography.rs
@@ -27,8 +27,8 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, rems, App, FontWeight, IntoElement, ParentElement, RenderOnce, SharedString, Styled,
-    Window,
+    App, FontWeight, IntoElement, ParentElement, RenderOnce, SharedString, Styled, Window, div,
+    rems,
 };
 
 /// The typescale ratio (minor third).

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -106,7 +106,7 @@ impl File {
     }
 
     /// Saves the file asynchronously
-    pub fn save_async(&mut self) -> impl std::future::Future<Output = Result<()>> {
+    pub fn save_async(&mut self) -> impl std::future::Future<Output = Result<()>> + use<> {
         let path = self.path.clone();
         let contents = self.contents.clone();
 
@@ -127,7 +127,7 @@ impl File {
     }
 
     /// Reloads the file from disk asynchronously
-    pub fn reload_async(&self) -> impl std::future::Future<Output = Result<String>> {
+    pub fn reload_async(&self) -> impl std::future::Future<Output = Result<String>> + use<> {
         let path = self.path.clone();
         let exists = self.exists_on_disk;
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,7 +7,7 @@
 //! instead of reaching for this module. `src/wasm_compat_guard.rs` tracks
 //! this exemption.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use gpui::Context;
 use gpui::TaskExt as _;
 use std::path::{Path, PathBuf};

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides convenient access to the bundled Radix icon set.
 
-use gpui::{svg, Svg};
+use gpui::{Svg, svg};
 
 /// Default icon set bundled with gpuikit (Radix Icons)
 ///

--- a/src/input.rs
+++ b/src/input.rs
@@ -31,8 +31,8 @@ mod blink;
 mod handler;
 mod state;
 
-pub use bidi::{detect_base_direction, TextDirection};
-pub use bindings::{bind_input_keys, InputBindings, INPUT_CONTEXT};
+pub use bidi::{TextDirection, detect_base_direction};
+pub use bindings::{INPUT_CONTEXT, InputBindings, bind_input_keys};
 pub use blink::CursorBlink;
 pub use handler::*;
 pub use state::{InputLineLayout, InputState, InputStateEvent, SubmitOn};

--- a/src/input/bidi.rs
+++ b/src/input/bidi.rs
@@ -1,4 +1,4 @@
-use unicode_bidi::{bidi_class, BidiClass};
+use unicode_bidi::{BidiClass, bidi_class};
 
 /// Text direction for bidirectional text support.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/input/bindings.rs
+++ b/src/input/bindings.rs
@@ -1,4 +1,4 @@
-use gpui::{actions, App, KeyBinding};
+use gpui::{App, KeyBinding, actions};
 
 actions!(
     input,

--- a/src/input/state.rs
+++ b/src/input/state.rs
@@ -6,16 +6,16 @@ use std::time::Duration;
 use web_time::Instant;
 
 use gpui::{
-    point, px, App, AppContext, Bounds, ClipboardItem, Context, Entity, EventEmitter, FocusHandle,
-    Focusable, Pixels, Point, SharedString, Subscription, TextRun, TextStyle, UTF16Selection,
-    Window, WrappedLine,
+    App, AppContext, Bounds, ClipboardItem, Context, Entity, EventEmitter, FocusHandle, Focusable,
+    Pixels, Point, SharedString, Subscription, TextRun, TextStyle, UTF16Selection, Window,
+    WrappedLine, point, px,
 };
 
 use super::blink::CursorBlink;
 use super::handler::EntityInputHandler;
 use unicode_segmentation::UnicodeSegmentation;
 
-use super::bidi::{detect_base_direction, TextDirection};
+use super::bidi::{TextDirection, detect_base_direction};
 use super::bindings::{
     Backspace, Copy, Cut, Delete, DeleteToBeginningOfLine, DeleteToEndOfLine, DeleteWordLeft,
     DeleteWordRight, Down, End, Enter, Home, InsertNewline, Left, MoveToBeginning, MoveToEnd,
@@ -1982,8 +1982,8 @@ impl Focusable for InputState {
 mod tests {
     use super::*;
     use gpui::{
-        div, AppContext, Entity, InteractiveElement, IntoElement, ParentElement, Render,
-        TestAppContext, TextStyle, WindowHandle,
+        AppContext, Entity, InteractiveElement, IntoElement, ParentElement, Render, TestAppContext,
+        TextStyle, WindowHandle, div,
     };
     use std::cell::Cell;
     use std::cell::RefCell;

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -8,7 +8,7 @@
 //! browser. On wasm, build a [`Keymap`] from a JSON string or in code
 //! instead. `src/wasm_compat_guard.rs` tracks this exemption.
 
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{Context as _, Result, anyhow};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,12 +39,14 @@
 //! # Minimum Rust version
 //!
 //! This crate declares `rust-version = "1.85"`, which is a statement about its
-//! own source — async closures, and gpui's edition 2024 — rather than a
-//! guarantee about a whole build. gpuikit is edition 2021, so cargo's v2
-//! feature resolver does not hold dependencies back to that floor, and several
-//! already declare more (cosmic-text and smol_str 1.89, oo7 1.92 on Linux); on
-//! a toolchain near 1.85 you will most likely meet one of theirs first. A
-//! recent stable is the practical answer.
+//! own source — async closures, and edition 2024 — rather than a guarantee
+//! about a whole build. Edition 2024 selects cargo's v3 resolver, which unlike
+//! v2 does take that floor into account: when it picks a *new* version of a
+//! dependency it prefers one whose own `rust-version` fits. That is a
+//! preference, not a wall, and it says nothing about the versions `Cargo.lock`
+//! already names — several of those declare more (cosmic-text and smol_str
+//! 1.89, oo7 1.92 on Linux), so on a toolchain near 1.85 you will most likely
+//! meet one of theirs first. A recent stable is the practical answer.
 //!
 //! The `stitch` feature raises gpuikit's own floor to **1.95**. It is the only
 //! one that does.

--- a/src/markdown/code_highlight.rs
+++ b/src/markdown/code_highlight.rs
@@ -89,8 +89,8 @@ pub fn normalize_language(info: &str) -> Option<String> {
 
 #[cfg(feature = "editor")]
 pub use editor_bridge::{
-    code_highlight_themes, init_code_highlighting, set_code_highlight_theme, CodeHighlightTheme,
-    DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME,
+    CodeHighlightTheme, DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME, code_highlight_themes,
+    init_code_highlighting, set_code_highlight_theme,
 };
 
 /// The highlights for one code block, or an empty vector if anything at all is

--- a/src/markdown/elements/code_block.rs
+++ b/src/markdown/elements/code_block.rs
@@ -70,7 +70,7 @@ pub fn inline_code(
     font_family: &SharedString,
     bg: Option<gpui::Hsla>,
     cx: &App,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     let theme = cx.theme();
 
     div()

--- a/src/markdown/elements/code_block.rs
+++ b/src/markdown/elements/code_block.rs
@@ -1,12 +1,12 @@
 //! Code block element for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, SharedString, Styled};
+use gpui::{App, ElementId, ParentElement, SharedString, Styled, div, prelude::*, rems};
 
 use super::super::code_highlight::code_highlights;
 use super::super::selectable_text::{RunRole, SelectableText};
 use super::super::style::TextStyle;
-use super::paragraph::{selection_styled_text, RunContext};
+use super::paragraph::{RunContext, selection_styled_text};
 
 /// Render a code block element. The text inside is a selectable run — code
 /// is the thing people copy most.

--- a/src/markdown/elements/divider.rs
+++ b/src/markdown/elements/divider.rs
@@ -4,7 +4,7 @@ use crate::theme::{ActiveTheme, Themeable};
 use gpui::{App, Styled, div, prelude::*, px, rems};
 
 /// Render a horizontal rule (divider) element.
-pub fn divider(color: Option<gpui::Hsla>, cx: &App) -> impl IntoElement {
+pub fn divider(color: Option<gpui::Hsla>, cx: &App) -> impl IntoElement + use<> {
     div()
         .h(px(1.0))
         .my(rems(1.5))

--- a/src/markdown/elements/divider.rs
+++ b/src/markdown/elements/divider.rs
@@ -1,7 +1,7 @@
 //! Horizontal rule/divider element for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, px, rems, App, Styled};
+use gpui::{App, Styled, div, prelude::*, px, rems};
 
 /// Render a horizontal rule (divider) element.
 pub fn divider(color: Option<gpui::Hsla>, cx: &App) -> impl IntoElement {

--- a/src/markdown/elements/heading.rs
+++ b/src/markdown/elements/heading.rs
@@ -1,12 +1,12 @@
 //! Heading element for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, Styled};
+use gpui::{App, ElementId, ParentElement, Styled, div, prelude::*, rems};
 
 use super::super::inline_style::{InlinePalette, RichText};
 use super::super::selectable_text::RunRole;
 use super::super::style::TextStyle;
-use super::paragraph::{rich_text_run, RunContext};
+use super::paragraph::{RunContext, rich_text_run};
 
 /// Heading level (h1-h6).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/markdown/elements/image.rs
+++ b/src/markdown/elements/image.rs
@@ -1,6 +1,6 @@
 //! Image element for markdown.
 
-use gpui::{img, prelude::*, px, App, SharedString, Styled};
+use gpui::{App, SharedString, Styled, img, prelude::*, px};
 
 /// Render an image element.
 ///

--- a/src/markdown/elements/link.rs
+++ b/src/markdown/elements/link.rs
@@ -2,8 +2,8 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::*, App, CursorStyle, ElementId, InteractiveElement, ParentElement, SharedString,
-    StatefulInteractiveElement, Styled,
+    App, CursorStyle, ElementId, InteractiveElement, ParentElement, SharedString,
+    StatefulInteractiveElement, Styled, div, prelude::*,
 };
 
 /// Render a link element.

--- a/src/markdown/elements/list.rs
+++ b/src/markdown/elements/list.rs
@@ -1,12 +1,12 @@
 //! List elements for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, rems, App, ElementId, ParentElement, Styled};
+use gpui::{App, ElementId, ParentElement, Styled, div, prelude::*, rems};
 
 use super::super::inline_style::{InlinePalette, RichText};
 use super::super::selectable_text::RunRole;
 use super::super::style::TextStyle;
-use super::paragraph::{rich_text_run, RunContext};
+use super::paragraph::{RunContext, rich_text_run};
 
 /// Render a list item element with plain text.
 pub fn list_item(

--- a/src/markdown/elements/paragraph.rs
+++ b/src/markdown/elements/paragraph.rs
@@ -2,8 +2,8 @@
 
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    combine_highlights, div, prelude::*, rems, App, ElementId, HighlightStyle, Hsla, ParentElement,
-    SharedString, Styled, StyledText,
+    App, ElementId, HighlightStyle, Hsla, ParentElement, SharedString, Styled, StyledText,
+    combine_highlights, div, prelude::*, rems,
 };
 
 use super::super::inline_style::{InlinePalette, RichText};

--- a/src/markdown/elements/quote.rs
+++ b/src/markdown/elements/quote.rs
@@ -1,12 +1,12 @@
 //! Block quote element for markdown.
 
 use crate::theme::{ActiveTheme, Themeable};
-use gpui::{div, prelude::*, px, rems, App, ElementId, ParentElement, Styled};
+use gpui::{App, ElementId, ParentElement, Styled, div, prelude::*, px, rems};
 
 use super::super::inline_style::{InlinePalette, RichText};
 use super::super::selectable_text::RunRole;
 use super::super::style::TextStyle;
-use super::paragraph::{rich_text_run, RunContext};
+use super::paragraph::{RunContext, rich_text_run};
 
 /// Render a block quote element with plain text.
 pub fn block_quote(

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -30,8 +30,8 @@ mod style;
 pub use code_highlight::normalize_language;
 #[cfg(feature = "editor")]
 pub use code_highlight::{
-    code_highlight_themes, init_code_highlighting, set_code_highlight_theme, CodeHighlightTheme,
-    DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME,
+    CodeHighlightTheme, DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME, code_highlight_themes,
+    init_code_highlighting, set_code_highlight_theme,
 };
 pub use elements::*;
 pub use inline_style::*;
@@ -44,8 +44,8 @@ pub use style::*;
 use crate::a11y::{A11y, Announce};
 use crate::theme::{ActiveTheme, Themeable};
 use gpui::{
-    div, prelude::*, rems, App, Context, ElementId, Entity, EntityId, IntoElement, ParentElement,
-    Role, SharedString, Styled, Task, Window,
+    App, Context, ElementId, Entity, EntityId, IntoElement, ParentElement, Role, SharedString,
+    Styled, Task, Window, div, prelude::*, rems,
 };
 use pulldown_cmark::{Alignment, Event, Tag, TagEnd};
 
@@ -1132,7 +1132,7 @@ impl MarkdownRenderer {
 mod tests {
     use super::selectable_text::recorder::{self, RecordedRun};
     use super::*;
-    use gpui::{point, px, size, AnyElement, Pixels, Render, TestAppContext, VisualTestContext};
+    use gpui::{AnyElement, Pixels, Render, TestAppContext, VisualTestContext, point, px, size};
     use std::cell::Cell;
     use std::collections::HashSet;
     use std::rc::Rc;
@@ -2061,10 +2061,12 @@ mod tests {
 
         markdown.read_with(cx, |markdown, _| {
             assert_eq!(rendered_text(markdown), "A partially written");
-            assert!(markdown
-                .events()
-                .iter()
-                .any(|event| matches!(event.event, Event::Start(Tag::Strong))));
+            assert!(
+                markdown
+                    .events()
+                    .iter()
+                    .any(|event| matches!(event.event, Event::Start(Tag::Strong)))
+            );
         });
     }
 

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -581,7 +581,7 @@ impl MarkdownRenderer {
         events: &[MarkdownEvent],
         document_id: ElementId,
         cx: &App,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         for event in events {
             self.handle_event(&event.event, cx);
         }
@@ -1069,7 +1069,7 @@ impl MarkdownRenderer {
         rows: Vec<Vec<RichText>>,
         alignments: Vec<Alignment>,
         cx: &App,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         let theme = cx.theme();
         let border_color = theme.border();
 

--- a/src/markdown/selectable_text.rs
+++ b/src/markdown/selectable_text.rs
@@ -26,12 +26,12 @@ use std::ops::Range;
 use std::rc::Rc;
 
 use gpui::{
-    accesskit, App, Bounds, CursorStyle, DispatchPhase, Element, ElementId, GlobalElementId,
-    Hitbox, HitboxBehavior, IntoElement, LayoutId, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-    Pixels, Role, SharedString, StyledText, TextLayout, Window,
+    App, Bounds, CursorStyle, DispatchPhase, Element, ElementId, GlobalElementId, Hitbox,
+    HitboxBehavior, IntoElement, LayoutId, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
+    Role, SharedString, StyledText, TextLayout, Window, accesskit,
 };
 
-use super::selection::{word_range_at, MarkdownSelection, SelectionPosition};
+use super::selection::{MarkdownSelection, SelectionPosition, word_range_at};
 
 /// One run's layout and text, registered into the document's selection state
 /// for the current frame.

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -10,7 +10,7 @@ pub mod control;
 
 pub use control::{ControlMetrics, ControlScale, ControlSize, TrackMetrics};
 
-use gpui::{hsla, px, App, BoxShadow, Global, Hsla, Pixels, SharedString};
+use gpui::{App, BoxShadow, Global, Hsla, Pixels, SharedString, hsla, px};
 use std::sync::Arc;
 
 /// How thick the ring around a keyboard-focused control is.

--- a/src/utils/element_manager.rs
+++ b/src/utils/element_manager.rs
@@ -1,6 +1,6 @@
 use gpui::{App, Global, SharedString};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Powers gpuikit's syntactic sugar, allowing elements to not
 /// have to specify ids manually when created.

--- a/src/wasm_compat_guard.rs
+++ b/src/wasm_compat_guard.rs
@@ -78,11 +78,26 @@ const FORBIDDEN: &[ForbiddenApi] = &[
               errors at runtime. Bundle files with the asset system, or document the API as \
               native-only and add it to this allowlist.",
         allowed: &[
-            ("fs.rs", "the file-editing module exists to read/write the local disk; native-only by design and documented as such"),
-            ("keymap/mod.rs", "loads keymap JSON from user-supplied paths; native-only by design and documented as such"),
-            ("editor/syntax_highlighter.rs", "`load_theme_from_file` reads a .tmTheme from disk; native-only by design and documented as such"),
-            ("a11y.rs", "test-only: golden-file assertions inside `#[cfg(test)] mod tests`"),
-            ("element_id.rs", "test-only: source scan inside `#[cfg(test)] mod tests`"),
+            (
+                "fs.rs",
+                "the file-editing module exists to read/write the local disk; native-only by design and documented as such",
+            ),
+            (
+                "keymap/mod.rs",
+                "loads keymap JSON from user-supplied paths; native-only by design and documented as such",
+            ),
+            (
+                "editor/syntax_highlighter.rs",
+                "`load_theme_from_file` reads a .tmTheme from disk; native-only by design and documented as such",
+            ),
+            (
+                "a11y.rs",
+                "test-only: golden-file assertions inside `#[cfg(test)] mod tests`",
+            ),
+            (
+                "element_id.rs",
+                "test-only: source scan inside `#[cfg(test)] mod tests`",
+            ),
             ("build_profile_guard.rs", "test-only guard module"),
             ("release_input_validation.rs", "test-only guard module"),
             ("release_version_guard.rs", "test-only guard module"),


### PR DESCRIPTION
Three commits, each green on its own.

### `40a7dba` — Reformat under rustfmt's 2024 style edition, and pin it

rustfmt's *style* edition follows the crate's `edition` unless a `rustfmt.toml`
says otherwise, so the bump would have dragged a crate-wide reformat along with
it: the 2024 style sorts `use` items case-sensitively, reordering nearly every
import block. Doing it first, alone, keeps the bump reviewable. `style_edition`
is pinned so the *next* edition bump does not silently do this again.

82 files, imports only. No behaviour change.

### `c5baa7b` — Move to edition 2024

The whole change to `src/` is eleven return types. Return-position `impl Trait`
captures every in-scope lifetime in 2024, so eleven `-> impl IntoElement` /
`-> impl Future` signatures gained a `use<>` bound spelling out what they
actually capture — which is nothing, except `SelectState::render`, which
captures `T`. `cargo fix --edition` wrote all eleven.

Two things `cargo fix` also did were reverted by hand:

* It rewrote two `else if let` chains (`Button` and `SidebarTrigger`'s `a11y`)
  into nested `match`es, to preserve the 2021 drop timing of the scrutinee. The
  scrutinee is `self.focus_handle.clone()`; dropping that `Option<FocusHandle>`
  before the `else` arm instead of after it is not observable, so the original
  reads better and means the same thing.
* It pinned `bindings!`'s `$key:expr` fragments to `expr_2021`. The 2024 `expr`
  also matches `const { … }` and `_`, which only widens what an exported macro
  accepts; no existing caller can break on it.

Edition 2024 also selects cargo's **v3 resolver**, which — unlike v2 — prefers
dependency versions whose own `rust-version` fits this crate's 1.85 floor. The
manifest comment and the crate docs' "Minimum Rust version" section both said
the opposite in so many words, so both are corrected here. `Cargo.lock` is
unchanged; every command below ran `--locked`.

### `6fd36e0` — `run-tests.sh`: say why the summary count is `<` and not `!=`

Merged doctests mean one `Doc-tests` line now prints *two* `test result:` lines
(the merged group, then the blocks rustdoc could not merge). The check already
tolerated that; the comment above it asserted a one-to-one correspondence that
is no longer true. Comment only.

## Verified locally, every CI job, one at a time

| Job | Result |
|---|---|
| `cargo clippy --all-targets --all-features -- -D warnings` | clean — the 2024 lint set adds nothing here |
| `scripts/run-tests.sh --lib --all-features --locked` | 724 passed |
| `cargo hack check --each-feature --locked` | all 8 combinations |
| `cargo doc --no-deps --all-features` under `--cfg docsrs -D warnings` | clean |
| `cargo build --features examples --examples` | all eight link |
| `cargo check --target wasm32-unknown-unknown -Z build-std` (pinned nightly) | clean |
| `scripts/run-tests.sh --doc --all-features --locked` | 1 passed, 55 ignored — unchanged |
| `cargo fmt --all -- --check` | clean |

## What this unblocks, and what it does not

Edition 2024 merges a crate's doctests into a single binary, which is the
precondition for ever making the 55 `` ```ignore `` blocks real: measured on
55 realistic examples, the merged path compiles in ~1 s at ~480 MB where
edition 2021 took ~13 s at ~2.9 GB across 56 separate links.

That work is **not** in this PR and should not start yet. Two findings from the
exploration gate it:

1. A configuration of ~110 doctests, most of them failing to compile, took a
   64 GB machine to ~155 GB and locked it. Bounded runs (N=12, 24, and 55 with
   27 broken) all stayed under 2 GB, so the cause is not understood. It needs a
   container with a hard memory cap before `cargo test --doc` is asked to
   compile anything at scale.
2. Separately and independently of all of the above: nine of the 55 examples
   document things that do not exist — `Application::new()` chief among them
   (five uses, including the crate-root Quick Start on docs.rs; the real entry
   point is `Application::with_platform(gpui_platform::current_platform(false))`).
   Those are worth fixing on their own, still as `` ```ignore ``.