### PR TITLE
Doc examples that name functions this crate does not have

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@ distribution of gpui — your app should depend on the same one:
 ```toml
 [dependencies]
 gpui = { package = "gpui-unofficial", version = "1.14" }
+gpui_platform = { package = "gpui-platform-gpui-unofficial", version = "1.14", features = ["font-kit"] }
 gpuikit = "0.8"
 ```
+
+`gpui_platform` is what builds the windowing platform an `Application` runs on;
+gpuikit re-exports neither it nor `gpui`, so your app names all three.
 
 ```rust
 use gpui::Application;
 
 fn main() {
-    Application::new()
+    Application::with_platform(gpui_platform::current_platform(false))
         .with_assets(gpuikit::assets())
         .run(|cx| {
             gpuikit::init(cx);

--- a/src/elements/dialog.rs
+++ b/src/elements/dialog.rs
@@ -748,7 +748,7 @@ impl Render for DialogState {
 /// use gpuikit::elements::dialog::bind_dialog_keys;
 ///
 /// fn main() {
-///     Application::new().run(|cx| {
+///     Application::with_platform(gpui_platform::current_platform(false)).run(|cx| {
 ///         bind_dialog_keys(cx);
 ///         // ... rest of app initialization
 ///     });

--- a/src/elements/field.rs
+++ b/src/elements/field.rs
@@ -45,12 +45,17 @@ pub enum LabelPosition {
 /// # Example
 ///
 /// ```ignore
+/// use gpuikit::traits::labelable::Labelable;
+///
 /// field("username")
 ///     .label("Username")
 ///     .description("Enter your username")
 ///     .required(true)
-///     .child(input("username"))
+///     .child(input(&self.username, cx))
 /// ```
+///
+/// The child is any element. `input` takes the `Entity<InputState>` holding
+/// the text — the field wraps a control, it does not own one.
 #[derive(IntoElement)]
 pub struct Field {
     id: ElementId,

--- a/src/elements/select.rs
+++ b/src/elements/select.rs
@@ -27,7 +27,7 @@
 //! use gpuikit::traits::disableable::Disableable;
 //!
 //! // Create a select with enum options
-//! #[derive(Clone, PartialEq)]
+//! #[derive(Clone, Debug, PartialEq)]
 //! enum Country { US, UK, CA }
 //!
 //! let select_state = cx.new(|_cx| {

--- a/src/elements/toast.rs
+++ b/src/elements/toast.rs
@@ -17,7 +17,7 @@
 //!
 //! // With action:
 //! cx.toast("File deleted")
-//!     .action("Undo", |window, cx| { /* ... */ })
+//!     .action("Undo", |_event, window, cx| { /* ... */ })
 //!     .duration(Duration::from_secs(5))
 //!     .show(window, cx);
 //! ```
@@ -614,7 +614,7 @@ pub fn set_toast_position(cx: &mut App, position: ToastPosition) {
 /// use gpuikit::elements::toast;
 ///
 /// fn main() {
-///     Application::new().run(|cx| {
+///     Application::with_platform(gpui_platform::current_platform(false)).run(|cx| {
 ///         gpuikit::init(cx);
 ///         toast::init(cx);
 ///         // ... rest of app initialization

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -11,6 +11,7 @@ use gpui::{Svg, svg};
 /// # Example
 /// ```ignore
 /// use gpuikit::DefaultIcons;
+/// use gpuikit::elements::icon_button::icon_button;
 ///
 /// let icon = DefaultIcons::star();
 /// let button = icon_button("favorite", icon);

--- a/src/input/bidi.rs
+++ b/src/input/bidi.rs
@@ -33,7 +33,7 @@ impl TextDirection {
 /// # Examples
 ///
 /// ```ignore
-/// use gpui::input::bidi::detect_base_direction;
+/// use gpuikit::input::detect_base_direction;
 ///
 /// // English text is LTR
 /// assert!(detect_base_direction("Hello world").is_ltr());

--- a/src/input/bindings.rs
+++ b/src/input/bindings.rs
@@ -367,7 +367,10 @@ impl InputBindings {
     /// Use this as a starting point when you want to override only specific bindings:
     ///
     /// ```ignore
-    /// let bindings = InputBindings::empty();
+    /// use gpui::KeyBinding;
+    /// use gpuikit::input::bindings::{InputBindings, SelectAll, INPUT_CONTEXT};
+    ///
+    /// let mut bindings = InputBindings::empty();
     /// bindings.select_all = Some(KeyBinding::new("ctrl-shift-a", SelectAll, Some(INPUT_CONTEXT)));
     /// ```
     pub fn empty() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! use gpuikit::init;
 //!
 //! fn main() {
-//!     Application::new()
+//!     Application::with_platform(gpui_platform::current_platform(false))
 //!         .with_assets(gpuikit::assets())
 //!         .run(|cx| {
 //!             init(cx);
@@ -18,6 +18,10 @@
 //!         });
 //! }
 //! ```
+//!
+//! The platform comes from `gpui_platform`, which your app depends on
+//! alongside `gpui` — gpuikit does not re-export either. `false` asks for a
+//! real windowing platform rather than a headless one.
 //!
 //! # Feature Flags
 //!
@@ -137,11 +141,11 @@ mod wasm_compat_guard;
 #[folder = "assets"]
 pub struct Assets;
 
-/// Returns the gpuikit asset source for use with `Application::new().with_assets()`.
+/// Returns the gpuikit asset source, for `Application::with_assets`.
 ///
 /// # Example
 /// ```ignore
-/// Application::new()
+/// Application::with_platform(gpui_platform::current_platform(false))
 ///     .with_assets(gpuikit::assets())
 ///     .run(|cx| {
 ///         gpuikit::init(cx);

--- a/src/markdown/code_highlight.rs
+++ b/src/markdown/code_highlight.rs
@@ -16,7 +16,7 @@
 //! before this module existed.
 //!
 //! ```ignore
-//! Application::new().run(|cx| {
+//! Application::with_platform(gpui_platform::current_platform(false)).run(|cx| {
 //!     gpuikit::init(cx);
 //!     gpuikit::markdown::init_code_highlighting(cx);
 //! });

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1,12 +1,12 @@
 //! Markdown rendering for gpuikit
 //!
-//! This crate provides markdown parsing and rendering using GPUI elements.
+//! This module provides markdown parsing and rendering using GPUI elements.
 //! It supports CommonMark and GitHub Flavored Markdown.
 //!
 //! # Example
 //!
 //! ```ignore
-//! use gpuikit_markdown::{markdown, MarkdownStyle};
+//! use gpuikit::markdown::{markdown, MarkdownStyle};
 //!
 //! // Simple usage - create markdown element inline
 //! div().child(markdown("# Hello\n\nThis is **bold** text.", cx))


### PR DESCRIPTION
Found while exploring the "every doc example compiles and runs" brief: all 55
of `src/`'s `` ```ignore `` blocks were compiled against the real API, and eight
of them name things that do not exist. Every one is live on docs.rs; the first
is also on the README and crates.io.

No runtime code changes.

## `Application::new()` does not exist

Not in gpui, not anywhere in the dependency tree. It is
`Application::with_platform(gpui_platform::current_platform(false))` — what all
eight of this repo's own `examples/` do.

Five doc examples used the fictional one, including the **crate-root Quick
Start**, so the first code a reader meets on docs.rs could never have compiled.

The README was wrong in the matching way: its dependency block never named
`gpui_platform`, without which there is no platform to hand `with_platform`.
Following "Getting started" verbatim did not get you started. Both are fixed,
with a line saying where the platform comes from.

## The rest

| Example | Problem |
|---|---|
| `markdown/mod.rs` | `use gpuikit_markdown::{…}` — no such crate; it is `gpuikit::markdown`. The module docs also still opened "This crate provides…" from when it was one. |
| `input/bidi.rs` | `use gpui::input::bidi::detect_base_direction` — wrong crate entirely; it is `gpuikit::input::detect_base_direction`. |
| `icons.rs` | `icon_button` used with no import; it lives in `gpuikit::elements::icon_button`. |
| `elements/field.rs` | `.label(…)` used with no import; it comes from the `Labelable` trait. |
| `elements/field.rs` | `input("username")` — `input` takes the `Entity<InputState>` holding the text and an `&App`, not an id. |
| `elements/toast.rs` | `.action("Undo", \|window, cx\| …)` — the handler is given the `ClickEvent` first. |
| `input/bindings.rs` | `let bindings = InputBindings::empty();` then assigning to a field of it — no `mut`. The names it used were also unimported. |
| `elements/select.rs` | `println!("Selected: {:?}", value)` over a `Country` deriving only `Clone, PartialEq`. |

`Field::label` and `input`'s arity were caught by the compile-check itself, not
by reading — which is the argument for the whole exercise.

## How these were checked

Each corrected example was compiled against the crate before being written
back, as a scratch integration test (a `cargo check` of a single file — not 55
doctest links). It is not part of this PR: keeping a second copy of every
example in `tests/` is a drift bug waiting to happen. The real answer is
doctests.

Locally green: `cargo fmt --check`, `clippy --all-targets --all-features
-D warnings`, `cargo doc` under `-D warnings`, `typos`, and
`scripts/run-tests.sh` for both `--lib` and `--doc`.

## Why they are still `` ```ignore ``

Making them real needs edition 2024's merged doctests (now on `main`), a shared
hidden prelude, and a guard that forbids `ignore` outright. That is its own
change, and it is blocked on understanding a doctest compilation that took a
64 GB machine to ~155 GB. Fixing what is provably wrong should not wait for it.