### PR TITLE
Every doc example compiles and runs, and a guard that keeps it that way

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -48,12 +48,12 @@ echo
 # `Running …` and `Doc-tests …` each announce one binary; `test result: …` is
 # one summary. Every announced binary owes *at least* one summary — the
 # comparison below is `<`, not `!=`, and since edition 2024 it has to be.
-# Edition 2024 merges a crate's doctests into a single binary, but rustdoc
-# cannot merge every block (one with its own `fn main`, or a `compile_fail`,
-# still compiles standalone), so one `Doc-tests` line now reports two
-# `test result:` lines: the merged group, then the leftovers. A binary killed
-# without reporting still shows up as fewer summaries than binaries, which is
-# the direction this guard exists to catch.
+# Edition 2024 merges a crate's doctests into a single binary, and rustdoc
+# compiles standalone whatever it cannot merge — a `compile_fail` block, for
+# one — reporting a `test result:` line per group. So a single `Doc-tests`
+# line can owe one summary or several, and only the shortfall means anything.
+# A binary killed without reporting still shows up as fewer summaries than
+# binaries, which is the direction this guard exists to catch.
 binaries=$(grep -c -E '^[[:space:]]*(Running|Doc-tests) ' "$log" || true)
 summaries=$(grep -c '^test result:' "$log" || true)
 failed=$(grep -c '^test result: FAILED' "$log" || true)

--- a/src/a11y.rs
+++ b/src/a11y.rs
@@ -7,24 +7,8 @@
 //! subtly different mechanisms. Each numbered section below answers one of
 //! that issue's questions, next to the code that implements it.
 //!
-//! ```ignore
-//! use gpuikit::a11y::{A11y, Announce};
-//! use gpuikit::traits::accessible::Accessible;
-//! use gpui::Role;
-//!
-//! impl Accessible for Button {
-//!     fn a11y(&self) -> A11y {
-//!         A11y::new(Role::Button).name(self.label.clone()).focusable()
-//!     }
-//! }
-//!
-//! impl RenderOnce for Button {
-//!     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-//!         let a11y = self.a11y();
-//!         h_stack().id(self.id).announce(a11y)/* … */
-//!     }
-//! }
-//! ```
+//! The worked example lives on the trait itself,
+//! [`Accessible`](crate::traits::accessible::Accessible).
 //!
 //! # 1. Where a role is declared
 //!

--- a/src/doctest_fence_guard.rs
+++ b/src/doctest_fence_guard.rs
@@ -1,0 +1,317 @@
+//! Tests for the rule that a rustdoc example which is not checked does not
+//! exist.
+//!
+//! `src/` used to hold 56 fenced examples, 55 of them `` ```ignore ``. rustdoc
+//! does not compile an `ignore`d block, so CI's doctest job reported
+//! `1 passed; 55 ignored` and went green while the examples on docs.rs
+//! drifted: `Application::new()` had not existed for some time, two examples
+//! named crates this workspace does not have, and one used a method that lives
+//! on a trait it never imported. Every one of them *looked* like Rust.
+//!
+//! This is the same rule [`showcase_coverage`](crate::elements) enforces for
+//! pages, applied to examples: the fence a block carries decides whether
+//! rustdoc will ever compile it, so the fence is what this guards.
+//!
+//! | Fence | Rule |
+//! |---|---|
+//! | bare, `rust` | allowed — an example that compiles *and runs* |
+//! | `no_run` | allowed only with an entry in [`NO_RUN`] |
+//! | `ignore` | never allowed, with no escape hatch |
+//! | `text` | allowed — not Rust, and it claims not to be |
+//! | `compile_fail` | allowed only with an entry in [`COMPILE_FAIL`] |
+//! | anything else | rejected by name |
+//!
+//! `ignore` has no allowlist on purpose. Every other fence here states
+//! something true about the block — `no_run` says "this compiles but must not
+//! run", `text` says "this is not Rust". `ignore` states nothing; it only
+//! asks rustdoc to look away, which is exactly the outcome this file exists to
+//! prevent. An example that cannot be made to compile is an example whose
+//! prose was doing the work all along, and the prose can stay without it.
+//!
+//! `compile_fail` is allowlisted for a different reason than `no_run`, and not
+//! a truth-related one: rustdoc *does* check a `compile_fail` block, but it
+//! can never fold one into the merged doctest binary, so each one is its own
+//! whole-program link of gpui. That is the cost gpuikit#180 was about. There
+//! are none today, and the empty list is how it stays deliberate.
+//!
+//! # Writing an example that runs
+//!
+//! Most of these need a live `App`, which a doctest gets from
+//! `gpui::TestAppContext::single()` — `test-support` is a dev-dependency, and
+//! doctests link dev-dependencies. Two shapes cover the crate:
+//!
+//! An element is rendered by a hidden view, because `VisualTestContext::draw`
+//! cannot draw one: any element carrying an `.id()` reaches
+//! `Window::current_view`, which unwraps an empty entity stack and panics.
+//! `add_window_view` draws a real frame, so the example is *rendered*, not
+//! merely constructed — omit the `gpuikit::init` line and the doctest panics,
+//! which is the proof that it runs.
+//!
+//! ```text
+//! /// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+//! /// use gpuikit::elements::button::button;
+//! /// # struct D;
+//! /// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+//! /// button("save", "Save")
+//! /// # }}
+//! /// # let mut tcx = gpui::TestAppContext::single();
+//! /// # tcx.update(gpuikit::init);
+//! /// # let _ = tcx.add_window_view(|_, _| D);
+//! ```
+//!
+//! Something that only needs an `App` — binding keys, building state — skips
+//! the view and uses `tcx.update(|cx| { … })` instead.
+//!
+//! Anything that spawns background work must drive it. The executor under
+//! `TestAppContext` is deterministic and runs nothing on its own, so a
+//! doctest that calls, say, `Markdown::append` and then returns leaves a
+//! parse queued and the binary never exits — a hang, not a failure. End it
+//! with `tcx.run_until_parked()`; `markdown::Markdown` is the worked example.
+//!
+//! Like the other guards this lives in the lib rather than `tests/`, so that
+//! `cargo test --lib` — the command that works in a constrained environment —
+//! is enough to run it. It reads fences out of the source rather than asking
+//! rustdoc, so it costs nothing and needs no doctest run of its own.
+
+use std::path::{Path, PathBuf};
+
+/// This module names every fence in its own prose and tables, so it would flag
+/// itself. It is the one file the scan skips, and the count is asserted so the
+/// exemption cannot silently widen.
+const SELF: &str = "doctest_fence_guard.rs";
+
+/// (path relative to `src/`, why running it is not an option). Every entry is
+/// asserted to still match a `no_run` fence in that file, so an example that
+/// stops needing the exemption fails the scan until its entry goes too.
+const NO_RUN: &[(&str, &str)] = &[
+    (
+        "lib.rs",
+        "calls `Application::run`, which takes over the thread and opens a real window",
+    ),
+    (
+        "elements/dialog.rs",
+        "calls `Application::run`, which takes over the thread and opens a real window",
+    ),
+    (
+        "elements/toast.rs",
+        "calls `Application::run`, which takes over the thread and opens a real window",
+    ),
+    (
+        "markdown/code_highlight.rs",
+        "calls `Application::run`, which takes over the thread and opens a real window",
+    ),
+];
+
+/// (path relative to `src/`, why the link is worth paying for). Empty, and
+/// meant to stay that way: a `compile_fail` block cannot join the merged
+/// doctest binary, so each one links gpui by itself.
+const COMPILE_FAIL: &[(&str, &str)] = &[];
+
+/// Fences that need no justification. `text` is prose in a box — it does not
+/// claim to be Rust, and rustdoc never compiles it.
+const ALWAYS_ALLOWED: &[&str] = &["", "rust", "text"];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn rust_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("source directory is readable") {
+            let path = entry.expect("directory entry is readable").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort();
+    files
+}
+
+/// The opening fence of every doc-comment code block in `source`, as
+/// `(line number, fence)` — `("", …)` for a bare ` ``` `. Only `//!` and `///`
+/// lines are read, so a fence inside ordinary code or a `//` comment is not a
+/// doc example and is not this file's business.
+///
+/// Openers and closers alternate, which is how a closing ` ``` ` is told from
+/// the next opener without parsing the block between them.
+fn doc_fences(source: &str) -> Vec<(usize, String)> {
+    let mut fences = Vec::new();
+    let mut open = false;
+
+    for (index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed
+            .strip_prefix("//!")
+            .or_else(|| trimmed.strip_prefix("///"))
+        else {
+            continue;
+        };
+        let Some(after) = rest.trim_start().strip_prefix("```") else {
+            continue;
+        };
+
+        if open {
+            open = false;
+            continue;
+        }
+        open = true;
+        fences.push((index + 1, after.trim().to_string()));
+    }
+
+    fences
+}
+
+#[test]
+fn every_doc_example_is_one_rustdoc_will_compile() {
+    let src = repo_root().join("src");
+    let files = rust_files(&src);
+    assert!(
+        files.len() > 20,
+        "walked src/ and found {} Rust files — the walker is broken",
+        files.len(),
+    );
+
+    let mut scanned = 0usize;
+    let mut fences_seen = 0usize;
+    let mut no_run_seen: Vec<String> = Vec::new();
+    let mut compile_fail_seen: Vec<String> = Vec::new();
+
+    for file in &files {
+        if file.file_name().is_some_and(|name| name == SELF) {
+            continue;
+        }
+        scanned += 1;
+
+        let relative = file
+            .strip_prefix(&src)
+            .expect("file is under src/")
+            .to_str()
+            .expect("source paths are UTF-8")
+            .to_string();
+        let source = std::fs::read_to_string(file).expect("source file is readable");
+
+        for (line, fence) in doc_fences(&source) {
+            fences_seen += 1;
+            let at = format!("{relative}:{line}");
+
+            assert_ne!(
+                fence, "ignore",
+                "{at} is a ```ignore example. rustdoc never compiles one, so nothing \
+                 keeps it true — this is the fence that let `Application::new()` sit \
+                 in the crate's own Quick Start after it stopped existing. There is no \
+                 allowlist for it. Make the example compile (see this module's docs for \
+                 the hidden prelude), mark it `no_run` and add an entry to `NO_RUN` in \
+                 {SELF} if running it opens a window, or delete it — an example whose \
+                 prose was doing the work does not lose anything by going."
+            );
+
+            if ALWAYS_ALLOWED.contains(&fence.as_str()) {
+                continue;
+            }
+
+            if fence == "no_run" {
+                assert!(
+                    NO_RUN.iter().any(|(path, _)| *path == relative),
+                    "{at} is a ```no_run example, but {relative} has no entry in `NO_RUN` \
+                     in {SELF}. `no_run` costs the one thing a doctest is for — running \
+                     — so add an entry saying why running it is not an option, or make \
+                     it run."
+                );
+                no_run_seen.push(relative.clone());
+                continue;
+            }
+
+            if fence == "compile_fail" {
+                assert!(
+                    COMPILE_FAIL.iter().any(|(path, _)| *path == relative),
+                    "{at} is a ```compile_fail example, but {relative} has no entry in \
+                     `COMPILE_FAIL` in {SELF}. rustdoc does check these, but it cannot \
+                     merge one into the shared doctest binary, so each is a whole-program \
+                     link of gpui — see gpuikit#180. Add an entry saying the link is \
+                     worth it."
+                );
+                compile_fail_seen.push(relative.clone());
+                continue;
+            }
+
+            panic!(
+                "{at} carries the fence ```{fence}, which this crate has no rule for. \
+                 Either it is a typo, or it is a rustdoc attribute worth a deliberate \
+                 decision — add it to `ALWAYS_ALLOWED` or give it an allowlist in {SELF}."
+            );
+        }
+    }
+
+    assert_eq!(
+        scanned,
+        files.len() - 1,
+        "exactly one file — `{SELF}`, which names every fence in its own prose — is \
+         exempt from this scan. {} were skipped.",
+        files.len() - scanned,
+    );
+    assert!(
+        fences_seen > 30,
+        "found only {fences_seen} doc-comment fences in src/ — the scanner is reading \
+         nothing, and its 'no ```ignore anywhere' verdict means nothing either",
+    );
+
+    // Every allowlist entry must still be earning its place, so an example
+    // that stops needing the exemption cannot leave a stale one behind for the
+    // next one to inherit.
+    for (path, justification) in NO_RUN {
+        assert!(
+            no_run_seen.iter().any(|seen| seen == path),
+            "`NO_RUN` in {SELF} still allows `{path}` ({justification}), but that file \
+             has no ```no_run example any more. Delete the entry.",
+        );
+    }
+    for (path, justification) in COMPILE_FAIL {
+        assert!(
+            compile_fail_seen.iter().any(|seen| seen == path),
+            "`COMPILE_FAIL` in {SELF} still allows `{path}` ({justification}), but that \
+             file has no ```compile_fail example any more. Delete the entry.",
+        );
+    }
+}
+
+/// The scanner reads fences out of doc comments only, and tells an opener from
+/// a closer. Without this, "found no `ignore` anywhere" could just mean the
+/// scan never saw a fence.
+#[test]
+fn the_scanner_reads_doc_fences_and_only_doc_fences() {
+    let source = r#"
+//! ```
+//! let module_level = 1;
+//! ```
+//!
+//! ```text
+//! not rust
+//! ```
+
+// ``` a plain comment fence is not a doc example
+/// ```no_run
+/// let item_level = 2;
+/// ```
+fn documented() {
+    let s = "``` a fence inside a string literal";
+}
+"#;
+
+    assert_eq!(
+        doc_fences(source),
+        vec![
+            (2, String::new()),
+            (6, "text".to_string()),
+            (11, "no_run".to_string()),
+        ],
+        "the scanner should report three openers — bare, text, no_run — and neither \
+         the closers, the `//` comment, nor the string literal",
+    );
+}

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -76,8 +76,16 @@ use gpui::{ElementId, EntityId, SharedString};
 /// a changed node id as a different element, so an id that moves every frame
 /// reads as the element being replaced every frame.
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, div, prelude::*};
+/// use gpuikit::element_id;
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 /// div().id(element_id::for_entity("select-listbox", cx.entity_id()))
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub fn for_entity(name: impl Into<SharedString>, entity_id: EntityId) -> ElementId {
     ElementId::NamedInteger(name.into(), entity_id.as_u64())
@@ -90,8 +98,16 @@ pub fn for_entity(name: impl Into<SharedString>, entity_id: EntityId) -> Element
 /// is not actually a descendant — a deferred panel, an element whose root
 /// carries no id — and it is harmless where it is.
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, ElementId, IntoElement, Render, Window, div, prelude::*};
+/// use gpuikit::element_id;
+/// # struct D { id: ElementId }
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 /// div().id(element_id::scoped(&self.id, "dismiss"))
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D { id: "panel".into() });
 /// ```
 pub fn scoped(parent: &ElementId, part: impl Into<SharedString>) -> ElementId {
     ElementId::NamedChild(Arc::new(parent.clone()), part.into())

--- a/src/elements/accordion.rs
+++ b/src/elements/accordion.rs
@@ -2,9 +2,11 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use gpuikit::elements::accordion::{accordion, accordion_item, AccordionState};
-//!
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+//! use gpuikit::elements::accordion::{AccordionState, accordion, accordion_item};
+//! # struct D;
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 //! // Create an accordion with multiple items
 //! let accordion_state = cx.new(|_cx| {
 //!     AccordionState::new(
@@ -16,10 +18,15 @@
 //! });
 //!
 //! // For single mode (only one item open at a time):
-//! accordion("my-accordion").single()
+//! let _ = accordion("my-accordion").single();
 //!
 //! // For multiple mode (default, multiple items can be open):
-//! accordion("my-accordion").multiple()
+//! let _ = accordion("my-accordion").multiple();
+//! # accordion_state
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 
 use crate::icons::Icons;

--- a/src/elements/aspect_ratio.rs
+++ b/src/elements/aspect_ratio.rs
@@ -70,12 +70,6 @@ pub struct AspectRatio {
 
 impl AspectRatio {
     /// Create a new AspectRatio container with the given ratio (width / height).
-    ///
-    /// # Example
-    /// ```ignore
-    /// aspect_ratio(16.0 / 9.0)
-    ///     .child(video_player)
-    /// ```
     pub fn new(ratio: f32) -> Self {
         Self {
             ratio: ratio.max(0.001), // Prevent division by zero
@@ -163,65 +157,44 @@ impl RenderOnce for AspectRatio {
 /// Create an AspectRatio container with a custom ratio (width / height).
 ///
 /// # Example
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, div, prelude::*};
+/// use gpuikit::elements::aspect_ratio::aspect_ratio;
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+/// # let video_thumbnail = div();
 /// aspect_ratio(16.0 / 9.0)
 ///     .child(video_thumbnail)
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub fn aspect_ratio(ratio: f32) -> AspectRatio {
     AspectRatio::new(ratio)
 }
 
 /// Create a 1:1 square aspect ratio container.
-///
-/// # Example
-/// ```ignore
-/// aspect_ratio_square()
-///     .child(avatar)
-/// ```
 pub fn aspect_ratio_square() -> AspectRatio {
     AspectRatio::preset(AspectRatioPreset::Square)
 }
 
 /// Create a 16:9 widescreen video aspect ratio container.
-///
-/// # Example
-/// ```ignore
-/// aspect_ratio_video()
-///     .child(video_player)
-/// ```
 pub fn aspect_ratio_video() -> AspectRatio {
     AspectRatio::preset(AspectRatioPreset::Video)
 }
 
 /// Create a 3:4 portrait aspect ratio container.
-///
-/// # Example
-/// ```ignore
-/// aspect_ratio_portrait()
-///     .child(profile_image)
-/// ```
 pub fn aspect_ratio_portrait() -> AspectRatio {
     AspectRatio::preset(AspectRatioPreset::Portrait)
 }
 
 /// Create a 4:3 standard aspect ratio container.
-///
-/// # Example
-/// ```ignore
-/// aspect_ratio_standard()
-///     .child(photo)
-/// ```
 pub fn aspect_ratio_standard() -> AspectRatio {
     AspectRatio::preset(AspectRatioPreset::Standard)
 }
 
 /// Create a 21:9 ultrawide aspect ratio container.
-///
-/// # Example
-/// ```ignore
-/// aspect_ratio_ultrawide()
-///     .child(cinematic_content)
-/// ```
 pub fn aspect_ratio_ultrawide() -> AspectRatio {
     AspectRatio::preset(AspectRatioPreset::Ultrawide)
 }

--- a/src/elements/calendar.rs
+++ b/src/elements/calendar.rs
@@ -165,12 +165,22 @@ pub enum CalendarEvent {
 /// Built with [`Calendar::new`] inside `cx.new`, because it owns focus and the
 /// month it is showing:
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::date::Date;
+/// use gpuikit::elements::calendar::Calendar;
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 /// let calendar = cx.new(|cx| {
 ///     Calendar::new("calendar", Date::new(2026, 8, 1).unwrap(), cx)
 ///         .today(Date::new(2026, 8, 20).unwrap())
 ///         .selected(Date::new(2026, 8, 20))
 /// });
+/// # calendar
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub struct Calendar {
     id: ElementId,

--- a/src/elements/context_menu.rs
+++ b/src/elements/context_menu.rs
@@ -6,15 +6,26 @@
 //! whatever a view renders — a list row, a card, a piece of text — without
 //! restructuring that view:
 //!
-//! ```ignore
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, actions, div, prelude::*};
 //! use gpuikit::elements::context_menu::{context_menu, menu_item};
-//!
+//! use gpuikit::traits::disableable::Disableable;
+//! # actions!(doc, [Rename]);
+//! # struct D;
+//! # impl D { fn render_row(&self, _ix: usize, _cx: &mut Context<Self>) -> gpui::AnyElement {
+//! #     div().child("a row").into_any_element() } }
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+//! # let (ix, can_delete) = (0usize, true);
 //! context_menu("row", self.render_row(ix, cx)).menu(move |menu, _window, _cx| {
 //!     menu.item(menu_item("Copy").kbd("⌘C").on_click(|_window, _cx| { /* … */ }))
 //!         .item(menu_item("Rename").action(Box::new(Rename)))
 //!         .separator()
 //!         .item(menu_item("Delete").destructive().disabled(!can_delete))
 //! })
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 //!
 //! Entries are built once, when the menu opens, so they see the state at the

--- a/src/elements/dialog.rs
+++ b/src/elements/dialog.rs
@@ -5,11 +5,13 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use gpuikit::elements::dialog::{dialog, DialogState};
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, div, prelude::*};
 //! use gpuikit::elements::button::button;
+//! use gpuikit::elements::dialog::{DialogState, dialog};
 //! use gpuikit::layout::h_stack;
-//!
+//! # struct D;
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 //! let dialog_state = cx.new(|_cx| DialogState::new(
 //!     dialog("confirm-dialog")
 //!         .title("Are you sure?")
@@ -28,6 +30,11 @@
 //!
 //! // Open the dialog
 //! dialog_state.update(cx, |state, cx| state.open(window, cx));
+//! # dialog_state
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 
 use crate::a11y::{A11y, Announce};
@@ -163,11 +170,20 @@ impl Dialog {
     /// is already on screen, and two ways to say no in the same corner is one
     /// too many.
     ///
-    /// ```ignore
+    /// ```
+    /// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+    /// use gpuikit::elements::dialog::{DialogState, dialog};
+    /// # struct D;
+    /// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    /// # cx.new(|_cx| DialogState::new(
     /// dialog("delete-project")
     ///     .confirm("Delete this project?", "Its 42 tasks are deleted with it. This cannot be undone.")
     ///     .confirm_label("Delete")
     ///     .on_confirm(|_window, _cx| { /* … */ })
+    /// # ))}}
+    /// # let mut tcx = gpui::TestAppContext::single();
+    /// # tcx.update(gpuikit::init);
+    /// # let _ = tcx.add_window_view(|_, _| D);
     /// ```
     pub fn confirm(
         mut self,
@@ -305,8 +321,17 @@ impl ControlSized for Dialog {
 ///
 /// Create using [`Dialog`] and wrap in an Entity:
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::elements::dialog::{DialogState, dialog};
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 /// let state = cx.new(|_cx| DialogState::new(dialog("my-dialog").title("Hello")));
+/// # state
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub struct DialogState {
     id: ElementId,
@@ -744,7 +769,8 @@ impl Render for DialogState {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use gpui::Application;
 /// use gpuikit::elements::dialog::bind_dialog_keys;
 ///
 /// fn main() {

--- a/src/elements/field.rs
+++ b/src/elements/field.rs
@@ -44,14 +44,23 @@ pub enum LabelPosition {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, Entity, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::elements::field::field;
+/// use gpuikit::elements::input::input;
 /// use gpuikit::traits::labelable::Labelable;
-///
+/// # use gpuikit::input::InputState;
+/// # struct D { username: Entity<InputState> }
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 /// field("username")
 ///     .label("Username")
 ///     .description("Enter your username")
 ///     .required(true)
 ///     .child(input(&self.username, cx))
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, cx| D { username: cx.new(InputState::new_singleline) });
 /// ```
 ///
 /// The child is any element. `input` takes the `Entity<InputState>` holding

--- a/src/elements/form.rs
+++ b/src/elements/form.rs
@@ -40,11 +40,8 @@
 //!
 //! # Reading it from a control
 //!
-//! One line in `render`, before the element's fields are moved:
-//!
-//! ```ignore
-//! let disabled = form::disabled_here(self.disabled);
-//! ```
+//! One line in `render`, before the element's fields are moved: bind
+//! [`disabled_here`]'s result and pass it down.
 //!
 //! `render` runs during `request_layout`, which is *inside* the scope. That is
 //! the only place a control should read it.
@@ -394,13 +391,25 @@ impl gpui::Element for WithFormContext {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, div, prelude::*};
+/// use gpuikit::elements::field::field;
+/// use gpuikit::elements::form::fieldset;
+/// use gpuikit::traits::disableable::Disableable;
+/// use gpuikit::traits::labelable::Labelable;
+/// # struct D { editable: bool }
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+/// # let (street_input, city_input) = (div(), div());
 /// fieldset("billing")
 ///     .legend("Billing address")
 ///     .error("This address could not be verified")
 ///     .disabled(!self.editable)
 ///     .child(field("street").label("Street").child(street_input))
 ///     .child(field("city").label("City").child(city_input))
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D { editable: true });
 /// ```
 ///
 /// The `disabled(!self.editable)` is the point: neither field, and neither

--- a/src/elements/list.rs
+++ b/src/elements/list.rs
@@ -5,8 +5,11 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, div, prelude::*};
 //! use gpuikit::elements::list::{List, ListEntry};
+//! # struct D;
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 //!
 //! let entries = vec![
 //!     ListEntry::header("Section A"),
@@ -18,6 +21,10 @@
 //!
 //! // In your Render impl:
 //! List::new("my-list", entries).render(window, cx)
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 
 use crate::theme::{ActiveTheme, Themeable};

--- a/src/elements/popover.rs
+++ b/src/elements/popover.rs
@@ -2,9 +2,13 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use gpuikit::elements::popover::{popover, PopoverState};
-//!
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+//! use gpuikit::elements::button::button;
+//! use gpuikit::elements::popover::{PopoverState, popover};
+//! use gpuikit::layout::v_stack;
+//! # struct D;
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 //! let popover_state = cx.new(|_cx| {
 //!     PopoverState::new(
 //!         popover("my-popover")
@@ -19,6 +23,11 @@
 //!             })
 //!     )
 //! });
+//! # popover_state
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 
 use crate::element_id::for_entity;
@@ -126,10 +135,20 @@ pub struct Popover {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, div, prelude::*};
+/// use gpuikit::elements::button::button;
+/// use gpuikit::elements::popover::{PopoverState, popover};
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+/// # cx.new(|_cx| PopoverState::new(
 /// popover("my-popover")
 ///     .trigger(|_window, _cx| button("open", "Open").into_any_element())
 ///     .content(|_window, _cx| div().child("Content").into_any_element())
+/// # ))}}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub fn popover(id: impl Into<ElementId>) -> Popover {
     Popover::new(id)
@@ -178,8 +197,17 @@ impl Popover {
 ///
 /// Create using [`Popover`] and wrap in an Entity:
 ///
-/// ```ignore
-/// let state = cx.new(|_cx| PopoverState::new(popover(...)));
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::elements::popover::{PopoverState, popover};
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+/// let state = cx.new(|_cx| PopoverState::new(popover("my-popover")));
+/// # state
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub struct PopoverState {
     id: ElementId,

--- a/src/elements/scroll_area.rs
+++ b/src/elements/scroll_area.rs
@@ -4,27 +4,36 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, div, prelude::*, px};
 //! use gpuikit::elements::scroll_area::scroll_area;
-//!
+//! # struct D;
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+//! # let (long_content, wide_content, large_content) = (div(), div(), div());
+//! # let _ =
 //! // Vertical scroll area with max height
 //! scroll_area("my-scroll-area")
 //!     .max_h(px(300.))
 //!     .vertical()
 //!     .child(long_content)
-//!
+//! # ;
+//! # let _ =
 //! // Horizontal scroll area
 //! scroll_area("horiz-scroll")
 //!     .max_w(px(400.))
 //!     .horizontal()
 //!     .child(wide_content)
-//!
+//! # ;
 //! // Both directions
 //! scroll_area("both-scroll")
 //!     .max_h(px(300.))
 //!     .max_w(px(400.))
 //!     .both()
 //!     .child(large_content)
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 
 use gpui::{
@@ -50,14 +59,6 @@ pub enum ScrollDirection {
 ///
 /// * `id` - Unique identifier for the scroll area
 ///
-/// # Example
-///
-/// ```ignore
-/// scroll_area("my-scroll-area")
-///     .max_h(px(300.))
-///     .vertical()
-///     .child(content)
-/// ```
 pub fn scroll_area(id: impl Into<ElementId>) -> ScrollArea {
     ScrollArea::new(id)
 }

--- a/src/elements/select.rs
+++ b/src/elements/select.rs
@@ -23,9 +23,12 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+//! use gpuikit::elements::select::{SelectState, select};
 //! use gpuikit::traits::disableable::Disableable;
-//!
+//! # struct D;
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 //! // Create a select with enum options
 //! #[derive(Clone, Debug, PartialEq)]
 //! enum Country { US, UK, CA }
@@ -49,6 +52,11 @@
 //!         .disabled(false)
 //!     )
 //! });
+//! # select_state
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 //!
 //! # Accessibility
@@ -208,7 +216,12 @@ pub struct Select<T: Clone + PartialEq + 'static> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::elements::select::{SelectState, select};
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+/// # cx.new(|_cx| SelectState::new(
 /// select(
 ///     "my-select",
 ///     "Option",
@@ -216,6 +229,10 @@ pub struct Select<T: Clone + PartialEq + 'static> {
 /// )
 /// .selected("a")
 /// .placeholder("Choose an option...")
+/// # ))}}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub fn select<T: Clone + PartialEq + 'static>(
     id: impl Into<ElementId>,
@@ -297,8 +314,17 @@ impl<T: Clone + PartialEq + 'static> ControlSized for Select<T> {
 ///
 /// Create using [`Select`] and wrap in an Entity:
 ///
-/// ```ignore
-/// let state = cx.new(|_cx| SelectState::new(select(...)));
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::elements::select::{SelectState, select};
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+/// let state = cx.new(|_cx| SelectState::new(select("size", "Size", vec![("s", "Small")])));
+/// # state
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub struct SelectState<T: Clone + PartialEq + 'static> {
     id: ElementId,

--- a/src/elements/sidebar.rs
+++ b/src/elements/sidebar.rs
@@ -27,7 +27,18 @@
 //! caller owns, which is what makes the width persistable and what lets the
 //! same collapse button live anywhere in the app.
 //!
-//! ```ignore
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, prelude::*, rems};
+//! use gpuikit::elements::icon_button::icon_button;
+//! use gpuikit::elements::list::{List, ListEntry};
+//! use gpuikit::elements::sidebar::{SidebarState, sidebar, sidebar_trigger};
+//! use gpuikit::icons::Icons;
+//! use gpuikit::layout::v_stack;
+//! use gpuikit::traits::labelable::Labelable;
+//! # struct D { nav_open: SidebarState }
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+//! # let entries: Vec<ListEntry> = Vec::new();
+//! # let toggle = |_: &gpui::ClickEvent, _: &mut Window, _: &mut gpui::App| {};
 //! sidebar("app-nav")
 //!     .label("Navigation")
 //!     .state(self.nav_open)
@@ -39,6 +50,10 @@
 //!     )
 //!     .child(sidebar_trigger("app-nav-trigger", self.nav_open).on_click(toggle))
 //!     .child(List::new("nav", entries).render(window, cx))
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D { nav_open: SidebarState::Expanded });
 //! ```
 //!
 //! The panel shows its children when expanded and only the rail when

--- a/src/elements/splitter.rs
+++ b/src/elements/splitter.rs
@@ -22,7 +22,15 @@
 //! [`on_resize`](Splitter::on_resize), which is what lets a layout be
 //! persisted, restored or reset from outside the element.
 //!
-//! ```ignore
+//! ```
+//! # use gpui::{AnyElement, Context, IntoElement, Render, Window, div, prelude::*, px};
+//! use gpuikit::elements::splitter::splitter;
+//! # struct D { ratio: f32 }
+//! # impl D {
+//! #     fn editor(&self, _cx: &mut Context<Self>) -> AnyElement { div().into_any_element() }
+//! #     fn preview(&self, _cx: &mut Context<Self>) -> AnyElement { div().into_any_element() }
+//! # }
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 //! splitter("editor-split", "Editor and preview", self.ratio)
 //!     .start(self.editor(cx))
 //!     .end(self.preview(cx))
@@ -32,6 +40,10 @@
 //!         this.ratio = *ratio;
 //!         cx.notify();
 //!     }))
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D { ratio: 0.5 });
 //! ```
 //!
 //! # The drawn line and the band you can hit

--- a/src/elements/switch.rs
+++ b/src/elements/switch.rs
@@ -26,10 +26,17 @@ pub struct SwitchChanged {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
 /// use gpuikit::elements::switch::switch;
-///
-/// switch("dark-mode", true).label("Dark Mode")
+/// use gpuikit::traits::labelable::Labelable;
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+/// cx.new(|_cx| switch("dark-mode", true).label("Dark Mode"))
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub struct Switch {
     id: ElementId,

--- a/src/elements/table.rs
+++ b/src/elements/table.rs
@@ -30,8 +30,14 @@
 //! has to re-derive its rows for sorting. `examples/showcase.rs`'s Table page
 //! demonstrates the intended shape.
 //!
-//! ```ignore
-//! use gpuikit::elements::table::{column, row, table, SortRequest};
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, div, prelude::*, px};
+//! use gpuikit::elements::table::{column, row, table};
+//! # #[derive(Clone)]
+//! # struct Repo { name: String, stars: u32 }
+//! # struct D { rows: Vec<Repo> }
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+//! # let (visible_rows, current_sort) = (self.rows.clone(), None);
 //!
 //! table("repositories")
 //!     .column(column("Repository", |repo: &Repo, _, _| {
@@ -44,6 +50,10 @@
 //!     .sorted_by(current_sort)
 //!     .on_sort(move |request, _, _| { /* re-sort your own rows */ })
 //!     .max_h(px(320.))
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D { rows: vec![Repo { name: "gpuikit".into(), stars: 1 }] });
 //! ```
 //!
 //! # Accessibility

--- a/src/elements/text_field.rs
+++ b/src/elements/text_field.rs
@@ -21,26 +21,48 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use gpuikit::elements::text_field::{text_field, Adornment};
+//! ```
+//! # use gpui::{Context, Entity, IntoElement, Render, Window, prelude::*};
 //! use gpuikit::DefaultIcons;
-//!
+//! use gpuikit::elements::text_field::{Adornment, text_field};
+//! # use gpuikit::input::InputState;
+//! # struct D { state: Entity<InputState> }
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+//! # let state = self.state.clone();
+//! # let _ =
 //! text_field(&state, cx)
 //!     .placeholder("Search")
 //!     .prefix(Adornment::icon(DefaultIcons::magnifying_glass()))
+//! # ;
 //!
 //! text_field(&state, cx)
 //!     .prefix(Adornment::text("https://"))
 //!     .suffix(Adornment::text(".com"))
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, cx| D { state: cx.new(InputState::new_singleline) });
 //! ```
 //!
 //! A button that acts on the field is composition, not a field feature:
 //!
-//! ```ignore
+//! ```
+//! # use gpui::{Context, Entity, IntoElement, Render, Window, prelude::*};
+//! use gpuikit::elements::button::button;
+//! use gpuikit::elements::text_field::text_field;
+//! use gpuikit::layout::h_stack;
+//! # use gpuikit::input::InputState;
+//! # struct D { state: Entity<InputState> }
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+//! # let state = self.state.clone();
 //! h_stack()
 //!     .gap_2()
 //!     .child(text_field(&state, cx))
 //!     .child(button("go", "Go"))
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, cx| D { state: cx.new(InputState::new_singleline) });
 //! ```
 //!
 //! [`Textarea`]: crate::elements::textarea::Textarea

--- a/src/elements/textarea.rs
+++ b/src/elements/textarea.rs
@@ -36,13 +36,23 @@ fn textarea_element_id(state_id: EntityId) -> ElementId {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::elements::textarea::textarea;
+/// use gpuikit::input::InputState;
+/// use gpuikit::traits::disableable::Disableable;
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 /// let state = cx.new(|cx| InputState::new_multiline(cx));
 ///
 /// textarea(&state, cx)
 ///     .placeholder("Enter your message...")
 ///     .rows(4)
 ///     .disabled(false)
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub fn textarea(state: &Entity<InputState>, cx: &App) -> Textarea {
     Textarea::new(state, cx)

--- a/src/elements/toast.rs
+++ b/src/elements/toast.rs
@@ -5,13 +5,12 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use gpuikit::elements::toast::{ToastExt, ToastPosition};
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+//! use gpuikit::elements::toast::{self, ToastExt};
 //! use std::time::Duration;
-//!
-//! // In init:
-//! toast::init(cx);
-//!
+//! # struct D;
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 //! // Usage anywhere:
 //! cx.toast("Changes saved").success().duration(Duration::from_secs(3)).show(window, cx);
 //!
@@ -20,6 +19,11 @@
 //!     .action("Undo", |_event, window, cx| { /* ... */ })
 //!     .duration(Duration::from_secs(5))
 //!     .show(window, cx);
+//! # gpui::Empty
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(|cx| { gpuikit::init(cx); toast::init(cx); });
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 
 use crate::element_id::{for_entity, scoped};
@@ -610,7 +614,8 @@ pub fn set_toast_position(cx: &mut App, position: ToastPosition) {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use gpui::Application;
 /// use gpuikit::elements::toast;
 ///
 /// fn main() {

--- a/src/elements/toggle_group.rs
+++ b/src/elements/toggle_group.rs
@@ -71,7 +71,11 @@ impl<T: Clone> Disableable for ToggleOption<T> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::elements::toggle_group::{ToggleGroupMode, toggle_group, toggle_option};
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 /// // Single-select mode (default)
 /// let single = toggle_group(
 ///     "alignment",
@@ -92,6 +96,11 @@ impl<T: Clone> Disableable for ToggleOption<T> {
 ///     ],
 /// ).mode(ToggleGroupMode::Multiple)
 ///  .selected(vec!["bold", "italic"]);
+/// # cx.new(|_cx| single)
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub struct ToggleGroup<T: Clone + PartialEq + 'static> {
     id: ElementId,

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -9,7 +9,7 @@ use gpui::{Svg, svg};
 /// All icons are 15x15 SVGs designed to work well at small sizes.
 ///
 /// # Example
-/// ```ignore
+/// ```
 /// use gpuikit::DefaultIcons;
 /// use gpuikit::elements::icon_button::icon_button;
 ///

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,15 +11,17 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use gpui::Context;
+//! ```
+//! # use gpui::AppContext as _;
 //! use gpuikit::input::{InputState, bind_input_keys};
-//!
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(|cx| {
 //! // Initialize keybindings (typically in app initialization)
 //! bind_input_keys(cx, None);
 //!
 //! // Create an input state
 //! let input = cx.new(|cx| InputState::new_singleline(cx));
+//! # });
 //! ```
 
 mod bidi;

--- a/src/input/bidi.rs
+++ b/src/input/bidi.rs
@@ -32,7 +32,7 @@ impl TextDirection {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use gpuikit::input::detect_base_direction;
 ///
 /// // English text is LTR

--- a/src/input/bindings.rs
+++ b/src/input/bindings.rs
@@ -366,7 +366,7 @@ impl InputBindings {
     ///
     /// Use this as a starting point when you want to override only specific bindings:
     ///
-    /// ```ignore
+    /// ```
     /// use gpui::KeyBinding;
     /// use gpuikit::input::bindings::{InputBindings, SelectAll, INPUT_CONTEXT};
     ///
@@ -525,35 +525,53 @@ impl InputBindings {
 ///
 /// Use all platform defaults:
 ///
-/// ```ignore
+/// ```
+/// # use gpuikit::input::bind_input_keys;
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(|cx| {
 /// bind_input_keys(cx, None);
+/// # });
 /// ```
 ///
 /// Unbind a specific key while keeping other defaults:
 ///
-/// ```ignore
+/// ```
+/// # use gpuikit::input::{InputBindings, bind_input_keys};
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(|cx| {
 /// bind_input_keys(cx, InputBindings {
 ///     up: None, // Unbind up arrow
 ///     ..Default::default()
 /// });
+/// # });
 /// ```
 ///
 /// Override a specific binding while keeping other defaults:
 ///
-/// ```ignore
+/// ```
+/// # use gpui::KeyBinding;
+/// # use gpuikit::input::bindings::{INPUT_CONTEXT, InputBindings, SelectAll, bind_input_keys};
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(|cx| {
 /// bind_input_keys(cx, InputBindings {
 ///     select_all: Some(KeyBinding::new("ctrl-shift-a", SelectAll, Some(INPUT_CONTEXT))),
 ///     ..Default::default()
 /// });
+/// # });
 /// ```
 ///
 /// Use [`InputBindings::empty()`] with [`merged_with_defaults()`](InputBindings::merged_with_defaults)
 /// if you only want to specify a few custom bindings and fill in the rest with defaults:
 ///
-/// ```ignore
+/// ```
+/// # use gpui::KeyBinding;
+/// # use gpuikit::input::bindings::{INPUT_CONTEXT, InputBindings, SelectAll, bind_input_keys};
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(|cx| {
 /// let mut bindings = InputBindings::empty();
 /// bindings.select_all = Some(KeyBinding::new("ctrl-shift-a", SelectAll, Some(INPUT_CONTEXT)));
 /// bind_input_keys(cx, bindings.merged_with_defaults());
+/// # });
 /// ```
 pub fn bind_input_keys(cx: &mut App, bindings: impl Into<Option<InputBindings>>) {
     let bindings = bindings.into().unwrap_or_default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! # Quick Start
 //!
-//! ```ignore
+//! ```no_run
 //! use gpui::Application;
 //! use gpuikit::init;
 //!
@@ -125,6 +125,17 @@ mod build_profile_guard;
 #[cfg(test)]
 mod undying_thread_guard;
 
+/// Tests for the rule that a rustdoc example which is not checked does not
+/// exist — no `` ```ignore `` anywhere in `src/`, and `no_run` only with a
+/// reason on record. rustdoc never compiles an `ignore`d block, so the crate's
+/// own Quick Start went on naming `Application::new()` long after that
+/// function stopped existing.
+///
+/// No runtime code, and nothing outside a test build. Its docs carry the
+/// hidden prelude a new example should copy.
+#[cfg(test)]
+mod doctest_fence_guard;
+
 /// Tests for the rule that runtime code stays runnable on
 /// `wasm32-unknown-unknown` — no `std::time::Instant`/`SystemTime`,
 /// `std::fs`, or `std::thread::spawn` outside an explicit allowlist of
@@ -144,7 +155,8 @@ pub struct Assets;
 /// Returns the gpuikit asset source, for `Application::with_assets`.
 ///
 /// # Example
-/// ```ignore
+/// ```no_run
+/// # use gpui::Application;
 /// Application::with_platform(gpui_platform::current_platform(false))
 ///     .with_assets(gpuikit::assets())
 ///     .run(|cx| {

--- a/src/markdown/code_highlight.rs
+++ b/src/markdown/code_highlight.rs
@@ -15,12 +15,6 @@
 //! [`MAX_HIGHLIGHT_BYTES`](self) all render exactly what they rendered
 //! before this module existed.
 //!
-//! ```ignore
-//! Application::with_platform(gpui_platform::current_platform(false)).run(|cx| {
-//!     gpuikit::init(cx);
-//!     gpuikit::markdown::init_code_highlighting(cx);
-//! });
-//! ```
 
 use std::ops::Range;
 
@@ -307,6 +301,14 @@ mod editor_bridge {
     /// document with no code in it should not pay for them.
     ///
     /// Calling it twice replaces the highlighter, discarding the cache.
+    ///
+    /// ```no_run
+    /// # use gpui::Application;
+    /// Application::with_platform(gpui_platform::current_platform(false)).run(|cx| {
+    ///     gpuikit::init(cx);
+    ///     gpuikit::markdown::init_code_highlighting(cx);
+    /// });
+    /// ```
     pub fn init_code_highlighting(cx: &mut App) {
         cx.set_global(GlobalCodeHighlighter(Rc::new(CodeHighlighter::new())));
     }

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -5,17 +5,25 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use gpuikit::markdown::{markdown, MarkdownStyle};
-//!
+//! ```
+//! # use gpui::{Context, IntoElement, Render, Window, div, prelude::*};
+//! use gpuikit::markdown::{MarkdownStyle, markdown};
+//! # struct D;
+//! # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+//! # let _ =
 //! // Simple usage - create markdown element inline
 //! div().child(markdown("# Hello\n\nThis is **bold** text.", cx))
+//! # ;
 //!
 //! // With custom style
 //! div().child(
 //!     markdown("# Hello", cx)
 //!         .style(MarkdownStyle::new().code_font("Monaco"))
 //! )
+//! # }}
+//! # let mut tcx = gpui::TestAppContext::single();
+//! # tcx.update(gpuikit::init);
+//! # let _ = tcx.add_window_view(|_, _| D);
 //! ```
 
 mod code_highlight;
@@ -78,8 +86,18 @@ fn run_element_id(index: usize) -> ElementId {
 /// new parse lands, so the document never blanks, and deltas arriving during a
 /// parse coalesce into a single follow-up parse rather than one each.
 ///
-/// ```ignore
+/// ```
+/// # use gpui::AppContext as _;
+/// use gpuikit::markdown::Markdown;
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let markdown = tcx.update(|cx| cx.new(|cx| Markdown::new("# Hello", cx)));
+/// # let delta = String::from(" world");
+/// # tcx.update(|cx| {
 /// markdown.update(cx, |markdown, cx| markdown.append(&delta, cx));
+/// # });
+/// # // The re-parse runs on the background executor; a test drives it by hand.
+/// # tcx.run_until_parked();
 /// ```
 pub struct Markdown {
     source: SharedString,

--- a/src/traits/accessible.rs
+++ b/src/traits/accessible.rs
@@ -12,7 +12,14 @@ use crate::a11y::A11y;
 /// first thing after `.id(…)`, since gpui only offers a role to an element
 /// that has an id.
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{App, ElementId, IntoElement, RenderOnce, Role, SharedString, Window, prelude::*};
+/// use gpuikit::a11y::{A11y, Announce};
+/// use gpuikit::layout::h_stack;
+/// use gpuikit::traits::accessible::Accessible;
+/// # #[derive(IntoElement)]
+/// struct Button { id: ElementId, label: SharedString }
+///
 /// impl Accessible for Button {
 ///     fn a11y(&self) -> A11y {
 ///         A11y::new(Role::Button).name(self.label.clone()).focusable()

--- a/src/traits/control_sized.rs
+++ b/src/traits/control_sized.rs
@@ -14,10 +14,21 @@ use crate::theme::ControlSize;
 /// ([`Themeable::control`](crate::theme::Themeable::control)), so a control
 /// never names a height of its own.
 ///
-/// ```ignore
+/// ```
+/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+/// use gpuikit::elements::badge::badge;
+/// use gpuikit::elements::button::button;
+/// use gpuikit::layout::h_stack;
+/// use gpuikit::traits::control_sized::ControlSized;
+/// # struct D;
+/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 /// h_stack()
 ///     .child(button("save", "Save").large())
 ///     .child(badge("2").large())
+/// # }}
+/// # let mut tcx = gpui::TestAppContext::single();
+/// # tcx.update(gpuikit::init);
+/// # let _ = tcx.add_window_view(|_, _| D);
 /// ```
 pub trait ControlSized: Sized {
     /// Put this control on the given rung.

--- a/src/traits/labelable.rs
+++ b/src/traits/labelable.rs
@@ -14,11 +14,20 @@ pub trait Labelable: Sized {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```
+    /// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
+    /// use gpuikit::elements::checkbox::checkbox;
     /// use gpuikit::traits::labelable::Labelable;
-    ///
-    /// checkbox("my-checkbox", false)
-    ///     .label("Accept terms and conditions")
+    /// # struct D;
+    /// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    /// cx.new(|_cx| {
+    ///     checkbox("my-checkbox", false)
+    ///         .label("Accept terms and conditions")
+    /// })
+    /// # }}
+    /// # let mut tcx = gpui::TestAppContext::single();
+    /// # tcx.update(gpuikit::init);
+    /// # let _ = tcx.add_window_view(|_, _| D);
     /// ```
     fn label(self, label: impl Into<SharedString>) -> Self;
 }

--- a/src/wasm_compat_guard.rs
+++ b/src/wasm_compat_guard.rs
@@ -99,6 +99,7 @@ const FORBIDDEN: &[ForbiddenApi] = &[
                 "test-only: source scan inside `#[cfg(test)] mod tests`",
             ),
             ("build_profile_guard.rs", "test-only guard module"),
+            ("doctest_fence_guard.rs", "test-only guard module"),
             ("release_input_validation.rs", "test-only guard module"),
             ("release_version_guard.rs", "test-only guard module"),
             ("undying_thread_guard.rs", "test-only guard module"),


### PR DESCRIPTION
Closes out the "every doc example compiles and runs" brief.

`src/` held 56 rustdoc examples. 55 were `` ```ignore ``, which rustdoc never
compiles, so CI's doctest job reported `1 passed; 55 ignored` and went green
while the examples on docs.rs drifted away from the crate. It now reports
**`47 passed; 0 ignored`**.

## Where the 55 went

| | Count |
|---|---|
| Became real doctests — compile **and draw** | 37 |
| Became `no_run` (call `Application::run`, which opens a window) | 5 |
| Deleted | 9 |
| Folded into another example | 4 |

The nine deletions are examples that documented nothing the signature did not:
seven `aspect_ratio` snippets restating the doc line directly above them
(`aspect_ratio_square()` under "Create a 1:1 square aspect ratio container"), a
verbatim duplicate of the `Accessible` trait's own example, one line restating
`disabled_here`'s signature inside prose that already explained it, and one
strict subset of the module example above it. Where the prose was doing the
work, the prose stays.

## What making them run found

Compiling an example is not the same as reading it carefully. I read all 55 for
the earlier fix PR and still missed these:

- **`Switch` and `Checkbox` implement `Render`** — they are entity views, not
  elements. Both examples showed the bare builder, `switch("dark-mode",
  true).label("Dark Mode")`, which does not typecheck anywhere it would
  actually be used. Both now show the `cx.new` a caller really needs.
- **`Markdown::append` re-parses on the background executor.** As a doctest it
  did not fail — it *hung*. The executor under `TestAppContext` is
  deterministic and runs nothing on its own, so the queued parse never
  finished and the binary never exited. The example now ends in
  `run_until_parked`, which is also exactly what a reader needs to know to test
  their own streaming code.

## The prelude

`gpui`'s `test-support` is already a dev-dependency and doctests link
dev-dependencies, so a doctest can build a whole app.

`VisualTestContext::draw` is a dead end: any element carrying an `.id()`
reaches `Window::current_view`, which unwraps an empty entity stack and panics.
That is every button and every stateful control. What works is a hidden view
whose `render` body *is* the example, driven by `add_window_view`, which draws
a real frame:

```rust
/// ```
/// # use gpui::{Context, IntoElement, Render, Window, prelude::*};
/// use gpuikit::elements::button::button;
/// # struct D;
/// # impl Render for D { fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
/// button("save", "Save")
/// # }}
/// # let mut tcx = gpui::TestAppContext::single();
/// # tcx.update(gpuikit::init);
/// # let _ = tcx.add_window_view(|_, _| D);
/// ```
```

Delete the hidden `gpuikit::init` line and the doctest panics — which is the
proof these render rather than merely construct. Assets are not needed; an
icon renders fine under the test platform.

Six hidden lines per example, uniform across the crate; the reader sees only
the builder call. `src/doctest_fence_guard.rs` documents the shape, plus the
variant for examples needing only an `App`.

## The guard

A third scan in the shape of `wasm_compat_guard`. It reads the opening fence of
every `//!` and `///` code block in `src/`:

| Fence | Rule |
|---|---|
| bare, `rust` | allowed — the goal state |
| `no_run` | allowed only with a `(file, reason)` entry |
| `ignore` | **never allowed, no allowlist** |
| `text` | allowed freely — not Rust, and it says so |
| `compile_fail` | allowed only with a `(file, reason)` entry |
| anything else | rejected by name |

`ignore` gets no escape hatch on purpose. Every other fence states something
true about its block; `ignore` only asks rustdoc to look away, which is the
outcome the whole exercise exists to prevent.

`compile_fail`'s list is empty and allowlisted on **cost**, not truth: rustdoc
does check those, but cannot fold one into the merged binary, so each is a
whole-program link of gpui — gpuikit#180's shape.

Every allowlist entry is asserted to still match, so none can go stale. A
second test feeds the scanner a fixture — a bare fence, a `text` fence, a
`no_run` fence, a `//` comment and a string literal that both look like fences
— so "found no `ignore` anywhere" cannot come from a scanner that reads
nothing.

Reintroducing one fails like this:

```
icons.rs:12 is a ```ignore example. rustdoc never compiles one, so nothing
keeps it true — this is the fence that let `Application::new()` sit in the
crate's own Quick Start after it stopped existing. There is no allowlist for
it. Make the example compile (see this module's docs for the hidden prelude),
mark it `no_run` and add an entry to `NO_RUN` ... or delete it
```

## Cost

Edition 2024's merged doctests are what make this affordable: **47 doctests
compile in 1.3 s, whole job 1.8 s at ~785 MB**, against `1 passed; 55 ignored`
in 7.9 s before. The doctest job gets cheaper *and* starts meaning something.

`scripts/run-tests.sh`'s comment about doctest summaries is corrected to match
what merging actually prints.

## Verified locally

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`,
`scripts/run-tests.sh --lib` (739 tests) and `--doc` (47), `cargo hack check
--each-feature` (8), `cargo doc` under `-D warnings`, `typos`, all eight
examples linked, and the wasm check on the pinned nightly.