### PR TITLE
The calendar's chevrons had never been visible

### DIFF
--- a/src/elements/calendar.rs
+++ b/src/elements/calendar.rs
@@ -452,7 +452,6 @@ impl Calendar {
             .justify_center()
             .size(side)
             .rounded(metrics.radius)
-            .text_color(fg)
             .cursor_pointer()
             .hover(move |style| style.bg(hover_bg))
             .on_click(cx.listener(move |this, _, _window, cx| {
@@ -463,7 +462,16 @@ impl Calendar {
                 this.focused_day = this.focused_day.add_months(delta);
                 cx.notify();
             }))
-            .child(icon.size(metrics.text_size))
+            // The colour goes on the `Svg`, not on this div. `svg()` paints
+            // through `if let Some(color) = style.text.color`, and that style
+            // is the element's *own* — `Interactivity::compute_style` starts
+            // from `Style::default()` and refines it with the element's base
+            // style, so nothing cascades in from an ancestor the way it does
+            // for text. A `text_color` on the parent therefore reaches the
+            // glyph not at all: it drew nothing, and these two chevrons had
+            // never once been visible. Every other icon in the crate already
+            // colours the `Svg` itself; `icon_button` does it for its own.
+            .child(icon.size(metrics.text_size).text_color(fg))
     }
 }
 


### PR DESCRIPTION
Reported from the showcase: *"I didn't even realize there was supposed to be chevrons here, they don't render."*

## Cause

`Calendar::month_button` set `.text_color(fg)` on the `div` wrapping the glyph rather than on the glyph. gpui's `svg()` paints inside

```rust
if let Some(color) = style.text.color
```

and that `style` is the element's **own**: `Interactivity::compute_style` starts from `Style::default()` and refines it with the element's base style. Nothing cascades in from an ancestor the way it does for text, so a `text_color` on the parent reaches an `Svg` not at all.

The element laid out, took its space, hovered, and handled clicks — and drew nothing. A silent no-op, not a rendering failure. That is why the buttons read as two blank squares beside the month name, and why this is not web-specific: they have never been visible on any platform.

## Fix

The colour moves onto the `Svg`. The `text_color` on the parent goes with it — the button has no text child, so it was styling nothing.

## Audit

I checked all 23 sites in `src/` that construct an icon. **This was the only one.**

| Site | Colour comes from |
|---|---|
| `alert`, `toast`, `text_field`, `select`, `sidebar` trigger | `.text_color()` on the `Svg` at the render site |
| `dialog` close, `sidebar` rail, `control_size_tests` | `icon_button`, which colours the icon it is handed |
| `alert`/`toast` `default_icon`, `sidebar` `glyph`, `Icons::icon` | `fn … -> Svg` factories; the caller colours it |
| **`calendar` prev/next** | **nothing — fixed here** |

## Verification

Built the web showcase from this commit and drove it: the chevrons draw either side of `August 2026`, and clicking the right one advances the grid to September 2026.

`cargo fmt --check` clean, 588 lib tests pass.