### PR TITLE
Home page fixes from a first read of the board

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -253,7 +253,11 @@ const NAV_SECTIONS: &[NavSection] = &[
     (
         "Foundations",
         DefaultIcons::ruler_square,
-        &[("control-sizes", "Control Sizes")],
+        &[
+            ("theme", "Theme"),
+            ("typography", "Typography"),
+            ("control-sizes", "Control Sizes"),
+        ],
     ),
     (
         "Input",
@@ -277,7 +281,6 @@ const NAV_SECTIONS: &[NavSection] = &[
         &[
             ("avatar", "Avatar"),
             ("badge", "Badge"),
-            ("typography", "Typography"),
             ("loading", "Loading"),
             ("alert", "Alert"),
             ("tooltip", "Tooltip"),
@@ -316,7 +319,6 @@ const NAV_SECTIONS: &[NavSection] = &[
         DefaultIcons::file_text,
         &[("markdown", "Markdown"), ("editor", "Editor")],
     ),
-    ("System", DefaultIcons::gear, &[("theme", "Theme")]),
 ];
 
 /// One nav section: its label, the glyph its rail row draws when the sidebar
@@ -627,24 +629,15 @@ const REPOSITORIES: &[Repo] = &[
 /// They load through the `HttpClient` that `main` installs, which is the
 /// browser's Fetch on the web and nothing natively — see `main`.
 const PORTRAITS: [&str; 9] = [
-    // Venrick Azcueta
     "https://images.unsplash.com/photo-1631680900243-3c207cf5a481?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
-    // Alex Suprun
     "https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
-    // Giorgio Encinas
     "https://images.unsplash.com/photo-1655874819398-c6dfbec68ac7?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
-    // Alef Morais
     "https://images.unsplash.com/photo-1734830268394-6c4a1f165af1?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
-    // Khashayar Kouchpeydeh
     "https://images.unsplash.com/photo-1616840420121-7ad8ed885f11?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
-    // David Chang Kit
     "https://images.unsplash.com/photo-1719603785926-84d214438120?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
-    // Amir Seilsepour
     "https://images.unsplash.com/photo-1595152452543-e5fc28ebc2b8?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
-    // Albert Vinas
     "https://images.unsplash.com/photo-1757077538768-220e9591e060?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
-    // Abhishek Rai
-    "https://images.unsplash.com/photo-1784483323534-3460c079d0c1?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
+    "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=96&h=96&fit=crop&crop=faces&fm=jpg&q=70",
 ];
 
 /// Where a crew member is right now, for the Home page's manifest.
@@ -1872,25 +1865,13 @@ impl Showcase {
                  component in the sidebar to see every one of its variants on \
                  its own.",
             ))
+            // Wrapped in a row so the button hugs its label: a bare child of a
+            // `v_stack` stretches to the column's full width.
             .child(
-                h_stack()
-                    .flex_wrap()
-                    .gap_2()
-                    .items_center()
-                    .child(button("home-browse", "Browse the components").on_click({
-                        let cell = self.active_page.clone();
-                        move |_, window, _cx| {
-                            navigate_to(&cell, SharedString::from("button"), window)
-                        }
-                    }))
-                    .child(
-                        button("home-open-palette", "Search the components").on_click({
-                            let palette = self.command_palette.clone();
-                            move |_, window, cx| {
-                                palette.update(cx, |state, cx| state.open(window, cx));
-                            }
-                        }),
-                    ),
+                h_stack().child(button("home-browse", "Browse the components").on_click({
+                    let cell = self.active_page.clone();
+                    move |_, window, _cx| navigate_to(&cell, SharedString::from("button"), window)
+                })),
             );
 
         // The rows of the board wrap rather than overflow: the hosted showcase
@@ -1933,7 +1914,7 @@ impl Showcase {
                     h_stack()
                         .gap_2()
                         .items_center()
-                        .child(avatar(PORTRAITS[member.portrait]).size(px(24.)))
+                        .child(avatar(PORTRAITS[member.portrait]).size(px(18.)))
                         .child(member.name)
                         .into_any_element()
                 })
@@ -2206,25 +2187,14 @@ impl Showcase {
             );
 
         // --- Docking: Alert ---
-        let docking = h_stack()
-            .gap_3()
-            .items_center()
-            .child(
-                div().flex_1().min_w_0().child(
-                    alert("Cygnus NG-31 is holding on the R-bar. Approach needs a go from the commander and from Houston.")
-                        .id("home-docking-hold")
-                        .title("Hold at 200 m")
-                        .warning()
-                        .dismissible(true),
-                ),
-            )
-            .child(
-                button("home-docking-go", "Go for approach").on_click(|_, window, cx| {
-                    cx.toast("Cygnus NG-31 cleared to 30 m. Capture in 14 minutes.")
-                        .info()
-                        .show(window, cx);
-                }),
-            );
+        let docking = alert(
+            "Cygnus NG-31 is holding on the R-bar. Approach needs a go from the commander \
+             and from Houston.",
+        )
+        .id("home-docking-hold")
+        .title("Hold at 200 m")
+        .warning()
+        .dismissible(true);
 
         // --- Checklist: Checkbox, Progress ---
         let go_items = self


### PR DESCRIPTION
Follow-ups to #259, all from looking at the running page.

- **The hero's palette button is gone.** It opened the command palette, whose contents are the Command page's generic demo — Open File, Save, Quit. On a page about this kit that reads as filler. The remaining button now hugs its label; a bare child of a `v_stack` stretches to the full column width.
- **Table avatars 24px → 18px.** At 24 the face set the row height instead of the table's own rhythm.
- **The docking alert stands alone.** The "Go for approach" button beside it floated in the gutter at every width. Commit burn and Scrub already demonstrate `Toast`.
- **The Gateway ops portrait loads.** That photo id is recent enough that Unsplash's CDN served a 2.7 kB variant where the others are ~5 kB, and some edges drew nothing. Swapped for an older photo. Both decode identically as baseline JPEG, so this is a CDN variant issue rather than a decoder one.
- **Theme and Typography move to Foundations**, where they belong — everything else on the page is drawn in terms of them. That empties System, so the section goes.

### One correction

`PORTRAITS` carried a photographer name above each URL. I wrote those from memory and **cannot verify them** — `unsplash.com/photos/<id>` 404s for these ids and oEmbed returns nothing, so there is no way to check the names from here. Asserting an attribution I can't confirm is worse than omitting it, so the names are gone; the Unsplash License note and the photo ids stay.

### Verification

- `cargo fmt --check`, `typos`, `cargo check --example showcase --features examples`: clean.
- `cargo test --lib`: 588 passed.
- Viewed at 1400px in the browser: nav sections, table avatars, hero button width confirmed.
- **Not confirmed visually:** the Gateway ops avatar in the Comms → Scheduled tab. The browser pane went hidden before I could click through, and gpui draws to a canvas so there is no DOM to read instead. The URL itself is verified (200, 5.8 kB, a face).

### On the blank avatar at nate.rip

The Avatar page was still blank on the deployed site after #259. That build renders it correctly here on `127.0.0.1:8081`, and the `No HttpClient available` error is gone, so it is most likely a cached wasm bundle — worth a hard reload before treating it as a real failure.