### PR TITLE
A Theme Extension page, for writing a theme of your own

### DIFF
--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -4,13 +4,13 @@ use gpui::{
     AnyElement, App, AppContext, Bounds, ClipboardItem, Context, Entity, FocusHandle, FontWeight,
     Hsla, InteractiveElement, IntoElement, Menu, ParentElement, Render, Rgba, SharedString,
     StatefulInteractiveElement, Styled, TitlebarOptions, Window, WindowBounds, WindowOptions, div,
-    px, size,
+    hsla, px, size,
 };
 use gpuikit::a11y::FocusNavigation;
 use gpuikit::date::{Date, Weekday};
 use gpuikit::input::InputState;
 use gpuikit::markdown::{Markdown, MarkdownElement, preprocessing_available};
-use gpuikit::theme::{ActiveTheme, GlobalTheme, Theme, Themeable};
+use gpuikit::theme::{ActiveTheme, GlobalTheme, Theme, ThemeVariant, Themeable};
 use gpuikit::{
     DefaultIcons,
     elements::{
@@ -255,6 +255,7 @@ const NAV_SECTIONS: &[NavSection] = &[
         DefaultIcons::ruler_square,
         &[
             ("theme", "Theme"),
+            ("theme-extension", "Theme Extension"),
             ("typography", "Typography"),
             ("control-sizes", "Control Sizes"),
         ],
@@ -900,6 +901,117 @@ const TABLE_COLUMN_REPOSITORY: usize = 0;
 const TABLE_COLUMN_LANGUAGE: usize = 1;
 const TABLE_COLUMN_STARS: usize = 2;
 
+/// Where the Theme Extension page's controls start. Named because both the
+/// sliders and the code block under them are built from these, and a default
+/// changed in one place only would make the page's first frame disagree with
+/// its own source listing.
+const THEME_EXT_BASE_HUE: f32 = 220.0;
+const THEME_EXT_ACCENT_HUE: f32 = 292.0;
+const THEME_EXT_VARIANT: ThemeVariant = ThemeVariant::Dark;
+const THEME_EXT_OVERRIDES: bool = false;
+
+/// The theme the Theme Extension page builds, as a pure function of that
+/// page's four controls. Hues arrive in degrees, which is how the sliders are
+/// labelled; `hsla` wants turns.
+///
+/// This is the whole authoring story in one function: five colours go to
+/// `Theme::new`, and the roughly thirty-five other tokens derive from them
+/// unless a field is set. Nothing here is privileged — a consumer crate can
+/// write exactly this.
+fn demo_theme(base_hue: f32, accent_hue: f32, variant: ThemeVariant, overrides: bool) -> Theme {
+    let base = base_hue / 360.0;
+    let accent_h = accent_hue / 360.0;
+
+    let (fg, bg, surface, border, accent) = match variant {
+        ThemeVariant::Dark => (
+            hsla(base, 0.10, 0.86, 1.0),
+            hsla(base, 0.18, 0.10, 1.0),
+            hsla(base, 0.16, 0.16, 1.0),
+            hsla(base, 0.14, 0.28, 1.0),
+            hsla(accent_h, 0.70, 0.62, 1.0),
+        ),
+        ThemeVariant::Light => (
+            hsla(base, 0.30, 0.18, 1.0),
+            hsla(base, 0.28, 0.97, 1.0),
+            hsla(base, 0.34, 0.92, 1.0),
+            hsla(base, 0.20, 0.78, 1.0),
+            hsla(accent_h, 0.62, 0.42, 1.0),
+        ),
+    };
+
+    let mut theme = Theme::new("Aurora", variant, fg, bg, surface, border, accent);
+
+    // An override is one field, and only the tokens named here stop deriving.
+    if overrides {
+        theme.success_color = Some(hsla(0.42, 0.55, 0.45, 1.0));
+        theme.danger_color = Some(hsla(0.02, 0.72, 0.55, 1.0));
+        theme.button_bg_color = Some(accent.opacity(0.18));
+    }
+
+    theme
+}
+
+/// The Rust that produces the theme the page is currently showing, as a
+/// markdown fence. Regenerated whenever a control moves, so what the page
+/// draws and what the code block says cannot drift apart — and so the block
+/// can be copied into a real application unchanged.
+fn demo_theme_code(
+    base_hue: f32,
+    accent_hue: f32,
+    variant: ThemeVariant,
+    overrides: bool,
+) -> String {
+    let theme = demo_theme(base_hue, accent_hue, variant, overrides);
+    let variant_name = match variant {
+        ThemeVariant::Dark => "Dark",
+        ThemeVariant::Light => "Light",
+    };
+
+    let turns = |color: Hsla| format!("hsla({:.3}, {:.2}, {:.2}, 1.0)", color.h, color.s, color.l);
+
+    let override_block = if overrides {
+        format!(
+            "\n// Only these three stop deriving. Everything else still follows\n\
+             // the five above.\n\
+             theme.success_color = Some({});\n\
+             theme.danger_color = Some({});\n\
+             theme.button_bg_color = Some({});\n",
+            turns(theme.success()),
+            turns(theme.danger()),
+            turns(theme.button_bg()),
+        )
+    } else {
+        String::new()
+    };
+
+    format!(
+        "```rust\n\
+         use gpui::hsla;\n\
+         use gpuikit::theme::{{GlobalTheme, Theme, ThemeVariant}};\n\
+         use std::sync::Arc;\n\
+         \n\
+         let mut theme = Theme::new(\n\
+         \x20   \"Aurora\",\n\
+         \x20   ThemeVariant::{variant_name},\n\
+         \x20   {}, // fg\n\
+         \x20   {}, // bg\n\
+         \x20   {}, // surface\n\
+         \x20   {}, // border\n\
+         \x20   {}, // accent\n\
+         );\n\
+         {override_block}\n\
+         // Installing it is one global. Every gpuikit element reads it\n\
+         // through `cx.theme()` on the next frame.\n\
+         cx.set_global(GlobalTheme(Arc::new(theme)));\n\
+         ```\n",
+        turns(theme.fg()),
+        turns(theme.bg()),
+        turns(theme.surface()),
+        turns(theme.border()),
+        turns(theme.accent()),
+    )
+}
+
 struct Showcase {
     focus_handle: FocusHandle,
     active_page: Rc<RefCell<SharedString>>,
@@ -1041,6 +1153,13 @@ struct Showcase {
     home_launch_calendar: Entity<Calendar>,
     /// The day the launch calendar last reported.
     home_launch_window: Option<Date>,
+    /// The Theme Extension page's four controls, and the code block under
+    /// them that is regenerated from their values.
+    theme_ext_base_hue: Entity<Slider>,
+    theme_ext_accent_hue: Entity<Slider>,
+    theme_ext_variant: Entity<ToggleGroup<ThemeVariant>>,
+    theme_ext_overrides: Entity<Switch>,
+    theme_ext_code: Entity<Markdown>,
 }
 
 impl Showcase {
@@ -1598,6 +1717,65 @@ impl Showcase {
         cx.observe(&home_comms, |_this, _tabs, cx| cx.notify())
             .detach();
 
+        // The Theme Extension page. Its swatches and its code block are both
+        // derived from these four, so the page has to hear about each one.
+        let theme_ext_base_hue = cx.new(|_cx| {
+            slider("theme-ext-base-hue", THEME_EXT_BASE_HUE, 0.0..=360.0)
+                .label("Base hue")
+                .step(1.0)
+        });
+        let theme_ext_accent_hue = cx.new(|_cx| {
+            slider("theme-ext-accent-hue", THEME_EXT_ACCENT_HUE, 0.0..=360.0)
+                .label("Accent hue")
+                .step(1.0)
+        });
+        let theme_ext_variant = cx.new(|_cx| {
+            toggle_group(
+                "theme-ext-variant",
+                vec![
+                    toggle_option(ThemeVariant::Dark, "Dark"),
+                    toggle_option(ThemeVariant::Light, "Light"),
+                ],
+            )
+            .selected_value(THEME_EXT_VARIANT)
+        });
+        let theme_ext_overrides = cx.new(|_cx| {
+            switch("theme-ext-overrides", THEME_EXT_OVERRIDES)
+                .label("Override success, danger and button_bg")
+        });
+        let theme_ext_code = cx.new(|cx| {
+            Markdown::new(
+                demo_theme_code(
+                    THEME_EXT_BASE_HUE,
+                    THEME_EXT_ACCENT_HUE,
+                    THEME_EXT_VARIANT,
+                    THEME_EXT_OVERRIDES,
+                ),
+                cx,
+            )
+        });
+
+        cx.observe(&theme_ext_base_hue, |this, _slider, cx| {
+            this.refresh_theme_ext_code(cx);
+            cx.notify();
+        })
+        .detach();
+        cx.observe(&theme_ext_accent_hue, |this, _slider, cx| {
+            this.refresh_theme_ext_code(cx);
+            cx.notify();
+        })
+        .detach();
+        cx.observe(&theme_ext_variant, |this, _group, cx| {
+            this.refresh_theme_ext_code(cx);
+            cx.notify();
+        })
+        .detach();
+        cx.observe(&theme_ext_overrides, |this, _switch, cx| {
+            this.refresh_theme_ext_code(cx);
+            cx.notify();
+        })
+        .detach();
+
         // The URL decides on the web; native opens on Home.
         let active_page = Rc::new(RefCell::new(
             page_from_location().unwrap_or_else(|| SharedString::from("home")),
@@ -1796,6 +1974,11 @@ impl Showcase {
             home_cargo,
             home_launch_calendar,
             home_launch_window: Some(first_window),
+            theme_ext_base_hue,
+            theme_ext_accent_hue,
+            theme_ext_variant,
+            theme_ext_overrides,
+            theme_ext_code,
         }
     }
 
@@ -2317,6 +2500,227 @@ impl Showcase {
                         .child(v_stack().flex_1().min_w(px(300.)).child(calendar_card)),
                 ),
         )
+    }
+
+    // ----- Theme Extension -----
+
+    /// The four controls, read back as the arguments `demo_theme` takes.
+    fn theme_ext_settings(&self, cx: &App) -> (f32, f32, ThemeVariant, bool) {
+        (
+            self.theme_ext_base_hue.read(cx).value(),
+            self.theme_ext_accent_hue.read(cx).value(),
+            self.theme_ext_variant
+                .read(cx)
+                .get_selected()
+                .first()
+                .copied()
+                .unwrap_or(ThemeVariant::Dark),
+            self.theme_ext_overrides.read(cx).is_on(),
+        )
+    }
+
+    /// Rewrite the code block under the page. Called from the observers on
+    /// the four controls rather than from `render`: `set_source` notifies,
+    /// and notifying inside a render is how a frame loop starts.
+    fn refresh_theme_ext_code(&mut self, cx: &mut Context<Self>) {
+        let (base, accent, variant, overrides) = self.theme_ext_settings(cx);
+        let source = demo_theme_code(base, accent, variant, overrides);
+        self.theme_ext_code
+            .update(cx, |code, cx| code.set_source(source, cx));
+    }
+
+    /// How to write a theme of your own, with the theme being written on the
+    /// page and the code that produces it side by side.
+    ///
+    /// The page teaches the mechanism that actually ships: five primitives
+    /// into `Theme::new`, everything else derived by `Themeable`'s defaults,
+    /// and a public field per token for the ones you want to say yourself.
+    /// It is deliberately not a second colour reference — that is the Theme
+    /// page, which shows the tokens the *active* theme resolves to.
+    fn render_theme_extension_page(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
+        let theme = cx.theme().clone();
+        let (base_hue, accent_hue, variant, overrides) = self.theme_ext_settings(cx);
+        let demo = demo_theme(base_hue, accent_hue, variant, overrides);
+
+        let heading = |text: &'static str| {
+            div()
+                .text_sm()
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme.fg_muted())
+                .child(text)
+        };
+
+        // Two columns of swatches, so a long token list stays on one screen.
+        let swatch_columns = |rows: Vec<(&'static str, Hsla)>| {
+            let split = rows.len().div_ceil(2);
+            let (left, right) = rows.split_at(split);
+            h_stack()
+                .gap_8()
+                .items_start()
+                .child(
+                    v_stack().flex_1().min_w_0().children(
+                        left.iter()
+                            .map(|(name, color)| color_row(name, *color, &theme)),
+                    ),
+                )
+                .child(
+                    v_stack().flex_1().min_w_0().children(
+                        right
+                            .iter()
+                            .map(|(name, color)| color_row(name, *color, &theme)),
+                    ),
+                )
+        };
+
+        // 1 — the five arguments to `Theme::new`.
+        let primitives = card()
+            .title("1 · The five primitives")
+            .description(
+                "These are the whole of Theme::new's colour arguments. Move a slider and \
+                 watch what follows from them below.",
+            )
+            .body(
+                v_stack()
+                    .gap_4()
+                    .child(self.theme_ext_variant.clone())
+                    .child(self.theme_ext_base_hue.clone())
+                    .child(self.theme_ext_accent_hue.clone())
+                    .child(separator())
+                    .child(swatch_columns(vec![
+                        ("fg", demo.fg()),
+                        ("bg", demo.bg()),
+                        ("surface", demo.surface()),
+                        ("border", demo.border()),
+                        ("accent", demo.accent()),
+                    ])),
+            );
+
+        // 2 — what a theme author never writes.
+        let derived = card()
+            .title("2 · What derives for free")
+            .description(
+                "Not one of these was named above. Themeable gives every token a default \
+                 in terms of the five, so a theme is five colours long until you disagree \
+                 with one.",
+            )
+            .body(swatch_columns(vec![
+                ("fg_muted", demo.fg_muted()),
+                ("fg_disabled", demo.fg_disabled()),
+                ("surface_secondary", demo.surface_secondary()),
+                ("surface_tertiary", demo.surface_tertiary()),
+                ("border_secondary", demo.border_secondary()),
+                ("border_subtle", demo.border_subtle()),
+                ("outline", demo.outline()),
+                ("accent_bg", demo.accent_bg()),
+                ("accent_bg_hover", demo.accent_bg_hover()),
+                ("selection", demo.selection()),
+                ("input_bg", demo.input_bg()),
+                ("input_border", demo.input_border()),
+            ]));
+
+        // 3 — and how to disagree with one.
+        let overridden = card()
+            .title("3 · Overriding a token")
+            .description(
+                "Every token has a public Option<Hsla> field on Theme. Set one and it stops \
+                 deriving; leave it None and it keeps following the primitives.",
+            )
+            .body(
+                v_stack()
+                    .gap_3()
+                    .child(self.theme_ext_overrides.clone())
+                    .child(separator())
+                    .child(swatch_columns(vec![
+                        ("success", demo.success()),
+                        ("danger", demo.danger()),
+                        ("button_bg", demo.button_bg()),
+                        ("warning", demo.warning()),
+                    ]))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(theme.fg_muted())
+                            .child(if overrides {
+                                "success, danger and button_bg are set explicitly. warning is \
+                                 still derived, which is why it did not move."
+                            } else {
+                                "All four derive. Turn the switch on to set the first three."
+                            }),
+                    ),
+            );
+
+        // 4 — installing it, which is the part that is genuinely one line.
+        let install = card()
+            .title("4 · Install it")
+            .description(
+                "A theme is global state. Applying replaces it for the whole window, so the \
+                 showcase itself changes — that is the demonstration.",
+            )
+            .body(
+                h_stack()
+                    .flex_wrap()
+                    .gap_2()
+                    .items_center()
+                    .child(button("theme-ext-apply", "Apply this theme").on_click({
+                        let settings = (base_hue, accent_hue, variant, overrides);
+                        move |_, window, cx| {
+                            let (base, accent, variant, overrides) = settings;
+                            let theme = demo_theme(base, accent, variant, overrides);
+                            cx.set_global(GlobalTheme(Arc::new(theme)));
+                            window.refresh();
+                        }
+                    }))
+                    .child(
+                        button("theme-ext-restore", "Restore Gruvbox Dark").on_click(
+                            |_, window, cx| {
+                                cx.set_global(GlobalTheme(Arc::new(Theme::gruvbox_dark())));
+                                window.refresh();
+                            },
+                        ),
+                    ),
+            )
+            .footer(div().text_xs().text_color(theme.fg_muted()).child(
+                "The theme picker in the sidebar keeps its own selection, so it will \
+                         still name the last bundled theme after you apply this one.",
+            ));
+
+        // 5 — the whole thing as source, regenerated per change.
+        let code = card()
+            .title("5 · The code")
+            .description("This is the page's current state, and it compiles as written.")
+            .body(MarkdownElement::new(self.theme_ext_code.clone()));
+
+        v_stack()
+            .gap_6()
+            .child(
+                v_stack()
+                    .gap_2()
+                    .child(
+                        div()
+                            .text_lg()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.fg_muted())
+                            .child("Theme Extension"),
+                    )
+                    .child(p(
+                        "A gpuikit theme is a value, not a file format and not a plugin. \
+                              You build a Theme, you install it as a global, and every element \
+                              picks it up on the next frame.",
+                    )),
+            )
+            .child(heading("Authoring"))
+            .child(primitives)
+            .child(derived)
+            .child(overridden)
+            .child(install)
+            .child(code)
+            .child(card().title("What this does not do").description(
+                "Themeable is a trait, but it is not yet a plug-in point. \
+                         ActiveTheme::theme() hands back an Arc<Theme>, and GlobalTheme wraps \
+                         that same concrete struct, so implementing Themeable on a type of \
+                         your own will compile and then have nowhere to be installed. Extend \
+                         a theme by building a Theme, as above.",
+            ))
     }
 
     fn render_button_page(
@@ -5311,6 +5715,7 @@ impl Render for Showcase {
             "markdown" => self.render_markdown_page(cx).into_any_element(),
             "editor" => self.render_editor_page(cx).into_any_element(),
             "theme" => self.render_theme_page(cx).into_any_element(),
+            "theme-extension" => self.render_theme_extension_page(cx).into_any_element(),
             _ => div().child("Unknown page").into_any_element(),
         };
 


### PR DESCRIPTION
The Theme page is a colour reference — what the *active* theme resolves each token to. Nothing in the showcase answered the question a consumer actually has: how do I write one?

### The page

Five steps, each live:

1. **The five primitives** — the whole of `Theme::new`'s colour arguments, driven by two hue sliders and a Dark/Light toggle.
2. **What derives for free** — a dozen tokens computed from those five by `Themeable`'s defaults. None of them was named above; that is the point.
3. **Overriding a token** — a switch that sets three of the public `Option<Hsla>` fields, with `warning` left alongside to show what keeps deriving.
4. **Install it** — `cx.set_global(GlobalTheme(Arc::new(theme)))`, which restyles the showcase itself. That *is* the demonstration.
5. **The code** — the Rust that produces the current state, regenerated into a markdown fence whenever a control moves, so the listing cannot drift from what the page draws. It compiles as written.

### It also says what does not work

`Themeable` is object-safe and is used as `&dyn Themeable` inside `Alert` and `Toast` — but it is **not a plug-in point**. `ActiveTheme::theme()` returns `&Arc<Theme>`, and `GlobalTheme` wraps that same concrete struct, so implementing `Themeable` on a type of your own compiles and then has nowhere to be installed. A card at the bottom says so, which seems better than a reader finding out halfway through trying it.

If you'd rather that gap were closed instead of documented, that's a real API change (`Arc<dyn Themeable>` through `GlobalTheme` and `ActiveTheme`) and worth its own PR — say the word.

### Notes

- The page's starting values are consts, not literals, so the first frame and its own source listing cannot disagree.
- Applying a custom theme leaves the sidebar's theme `Select` naming the last bundled theme. Called out in the page's footer rather than papered over.
- No coverage row needed: `theme` is not an `elements` module, and the guards check `pub mod`s against `ELEMENT_COVERAGE`.

### Verification

- `cargo fmt --check`, `typos`, `cargo clippy --example showcase --features examples`: clean.
- `cargo test --lib`: 588 passed.
- Viewed at `#theme-extension` in the browser: nav entry, intro, the variant toggle, both sliders and the five primitive swatches all render, and the derived swatches show correct values (`fg_muted` = `fg` at 0.7 alpha).
- **Not confirmed visually:** sections 3–6, including the live code block. The browser pane went hidden before I could scroll, and gpui draws to a canvas so there is no DOM to read instead. Worth a scroll through before merging.