### PR TITLE
Propose a theme extension system: ThemeExtension, and Theme::from_themeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **`ThemeExtension`: tokens gpuikit does not define.** A crate built on this
+  one invariably needs colours this one has never heard of — a diff view wants
+  an added and a removed fill, a terminal wants sixteen ANSI colours. Before
+  this there was nowhere to put them that a theme could see. An extension is a
+  struct of whatever the component needs plus a `derive` written in the
+  theme's own tokens, so *every* theme answers for it, including the six
+  bundled ones that predate the extension: `theme.extension::<DiffColors>()`
+  never fails and needs no `Option` at the call site. A theme author who
+  disagrees says so with `Theme::with_extension`. Values are keyed by
+  `TypeId`, so two extensions cannot collide, and an unset one is derived on
+  read rather than cached — read it once per render, not once per row.
+- **`Theme::from_themeable`, for a theme type of your own.** Implement
+  `Themeable` on your type and resolve it into a concrete `Theme`. The
+  snapshot is lossless and a test asserts it: `Theme` now carries an override
+  field for *every* token the trait defines, so the result answers identically
+  to its source, `control_scale` included. The global stays `Arc<Theme>`
+  deliberately — a theme changes when someone picks one and is read several
+  hundred times a frame, so resolving the vtable once here beats a dispatch on
+  every read. Behaviour does not survive the snapshot; a `Themeable` that
+  varies wants re-snapshotting when it moves.
+- **A Theme Extension page in the showcase**, which teaches both: the five
+  primitives behind live sliders, the dozen tokens that derive from them, what
+  overriding one does, installing the result, an extension defined by the
+  example rather than by the crate, and the Rust for the current state
+  regenerated as the controls move.
 - **The showcase opens on a Home page.** A mission-control board for a small
   lunar freight line — crew manifest, burn planner, life support, comms,
   docking, checklist, cargo, launch windows — built from nothing but the kit,
@@ -15,6 +40,17 @@ All notable changes to this project will be documented in this file.
   items go) are derived from that state on each frame. It is the first entry
   in the nav and the page a native run opens on; the URL hash still wins on
   the web.
+### Changed
+
+- **`Theme` gains five override fields and an `extensions` field.**
+  `placeholder_color`, `destructive_bg_color`, `destructive_bg_hover_color`,
+  `destructive_bg_active_color` and `destructive_fg_color` existed as
+  `Themeable` methods with no way to override them on a `Theme`; they are now
+  `Option<Hsla>` like every other token, which is what makes
+  `from_themeable` lossless. Themes built through `Theme::new` — which is all
+  of the bundled ones — are unaffected. A struct-literal `Theme { … }` has to
+  name the six new fields, the same way `controls` required.
+
 ### Fixed
 
 - **The hosted showcase loads remote images.** `Application::with_platform`

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -10,7 +10,7 @@ use gpuikit::a11y::FocusNavigation;
 use gpuikit::date::{Date, Weekday};
 use gpuikit::input::InputState;
 use gpuikit::markdown::{Markdown, MarkdownElement, preprocessing_available};
-use gpuikit::theme::{ActiveTheme, GlobalTheme, Theme, ThemeVariant, Themeable};
+use gpuikit::theme::{ActiveTheme, GlobalTheme, Theme, ThemeExtension, ThemeVariant, Themeable};
 use gpuikit::{
     DefaultIcons,
     elements::{
@@ -901,6 +901,61 @@ const TABLE_COLUMN_REPOSITORY: usize = 0;
 const TABLE_COLUMN_LANGUAGE: usize = 1;
 const TABLE_COLUMN_STARS: usize = 2;
 
+/// Two fills a diff view needs and gpuikit has no opinion about — declared
+/// here, in the example, which is the whole demonstration: the crate this
+/// type is defined in is not the crate that defines `Theme`.
+///
+/// `derive` is written in terms of the theme's own tokens, so every theme
+/// answers for it, including the six bundled ones that predate it.
+#[derive(Clone, PartialEq, Debug)]
+struct DiffColors {
+    added: Hsla,
+    removed: Hsla,
+}
+
+impl ThemeExtension for DiffColors {
+    fn derive(theme: &Theme) -> Self {
+        DiffColors {
+            added: theme.success().opacity(0.18),
+            removed: theme.danger().opacity(0.18),
+        }
+    }
+}
+
+/// The source listing under the page's extension section. Fixed, unlike the
+/// theme listing above it, because nothing on the page changes it.
+const EXTENSION_CODE: &str = r#"```rust
+use gpuikit::theme::{Theme, ThemeExtension, Themeable};
+
+#[derive(Clone)]
+struct DiffColors {
+    added: Hsla,
+    removed: Hsla,
+}
+
+impl ThemeExtension for DiffColors {
+    // What this looks like when a theme has not said otherwise. Written in
+    // the theme's own tokens, so it follows every theme rather than only
+    // the one it was written against.
+    fn derive(theme: &Theme) -> Self {
+        DiffColors {
+            added: theme.success().opacity(0.18),
+            removed: theme.danger().opacity(0.18),
+        }
+    }
+}
+
+// Any theme now answers for it, with no Option at the call site:
+let diff = cx.theme().extension::<DiffColors>();
+
+// And a theme author who disagrees says so:
+let theme = Theme::gruvbox_dark().with_extension(DiffColors {
+    added: hsla(0.33, 0.60, 0.20, 1.0),
+    removed: hsla(0.00, 0.60, 0.20, 1.0),
+});
+```
+"#;
+
 /// Where the Theme Extension page's controls start. Named because both the
 /// sliders and the code block under them are built from these, and a default
 /// changed in one place only would make the page's first frame disagree with
@@ -1160,6 +1215,7 @@ struct Showcase {
     theme_ext_variant: Entity<ToggleGroup<ThemeVariant>>,
     theme_ext_overrides: Entity<Switch>,
     theme_ext_code: Entity<Markdown>,
+    theme_ext_extension_code: Entity<Markdown>,
 }
 
 impl Showcase {
@@ -1755,6 +1811,8 @@ impl Showcase {
             )
         });
 
+        let theme_ext_extension_code = cx.new(|cx| Markdown::new(EXTENSION_CODE, cx));
+
         cx.observe(&theme_ext_base_hue, |this, _slider, cx| {
             this.refresh_theme_ext_code(cx);
             cx.notify();
@@ -1979,6 +2037,7 @@ impl Showcase {
             theme_ext_variant,
             theme_ext_overrides,
             theme_ext_code,
+            theme_ext_extension_code,
         }
     }
 
@@ -2690,6 +2749,55 @@ impl Showcase {
             .description("This is the page's current state, and it compiles as written.")
             .body(MarkdownElement::new(self.theme_ext_code.clone()));
 
+        // 6 — tokens this crate does not define, which is the other half of
+        // extension and the half a downstream component library needs.
+        let diff = demo.extension::<DiffColors>();
+        let gruvbox_diff = Theme::gruvbox_dark().extension::<DiffColors>();
+
+        let extension = card()
+            .title("6 · Tokens gpuikit does not define")
+            .description(
+                "A crate built on gpuikit needs colours this one has never heard of. A \
+                 ThemeExtension is a struct of them plus a rule for deriving them from any \
+                 theme, so every theme answers for it — including the bundled ones, which \
+                 predate it.",
+            )
+            .body(
+                v_stack()
+                    .gap_3()
+                    .child(swatch_columns(vec![
+                        ("DiffColors::added", diff.added),
+                        ("DiffColors::removed", diff.removed),
+                    ]))
+                    .child(div().text_xs().text_color(theme.fg_muted()).child(
+                        "Those follow the sliders above, because derive() is written in the \
+                         theme's own tokens. Under Gruvbox Dark, untouched, the same \
+                         extension resolves to:",
+                    ))
+                    .child(swatch_columns(vec![
+                        ("added", gruvbox_diff.added),
+                        ("removed", gruvbox_diff.removed),
+                    ]))
+                    .child(separator())
+                    .child(MarkdownElement::new(self.theme_ext_extension_code.clone())),
+            );
+
+        // And the answer to the other question: a theme type of your own.
+        let bring_your_own = card()
+            .title("7 · A theme type of your own")
+            .description(
+                "Implement Themeable on your own type and resolve it with \
+                 Theme::from_themeable, which reads every token once into a concrete Theme. \
+                 The snapshot is lossless — Theme carries an override field for every token \
+                 the trait defines — and it keeps the per-frame reads a field access rather \
+                 than a vtable dispatch, which is why the global stays concrete.",
+            )
+            .body(div().text_xs().text_color(theme.fg_muted()).child(
+                "Behaviour does not survive the snapshot: a Themeable whose danger() changes \
+                 with the time of day is one fixed colour afterwards, and wants \
+                 re-snapshotting when it moves.",
+            ));
+
         v_stack()
             .gap_6()
             .child(
@@ -2714,13 +2822,9 @@ impl Showcase {
             .child(overridden)
             .child(install)
             .child(code)
-            .child(card().title("What this does not do").description(
-                "Themeable is a trait, but it is not yet a plug-in point. \
-                         ActiveTheme::theme() hands back an Arc<Theme>, and GlobalTheme wraps \
-                         that same concrete struct, so implementing Themeable on a type of \
-                         your own will compile and then have nowhere to be installed. Extend \
-                         a theme by building a Theme, as above.",
-            ))
+            .child(heading("Extending the vocabulary"))
+            .child(extension)
+            .child(bring_your_own)
     }
 
     fn render_button_page(

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -4,13 +4,18 @@
 //! and — since a control's height is as much a design decision as its colour —
 //! the shared size scale in [`control`].
 //!
-//! Consumers can implement this trait for their own theme types.
+//! Consumers can implement this trait for their own theme types and resolve
+//! them with [`Theme::from_themeable`], and can add tokens of their own that
+//! every theme answers for with [`ThemeExtension`].
 
 pub mod control;
 
 pub use control::{ControlMetrics, ControlScale, ControlSize, TrackMetrics};
 
 use gpui::{App, BoxShadow, Global, Hsla, Pixels, SharedString, hsla, px};
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 /// How thick the ring around a keyboard-focused control is.
@@ -333,6 +338,119 @@ fn relative_luminance(color: Hsla) -> f32 {
     0.2126 * channel(rgba.r) + 0.7152 * channel(rgba.g) + 0.0722 * channel(rgba.b)
 }
 
+/// A cluster of theme tokens that gpuikit does not define.
+///
+/// The crate's own vocabulary is fixed: [`Themeable`] names about forty
+/// colours, and a crate built *on* gpuikit invariably needs a few more — a
+/// diff view wants an added and a removed fill, a terminal wants sixteen ANSI
+/// colours, a graph wants a series palette. Before this trait the only places
+/// to put them were a second global that no theme could see, or a fork.
+///
+/// An extension is a plain struct of whatever a component needs, plus one
+/// function saying what it looks like when nobody has said otherwise:
+///
+/// ```
+/// use gpui::Hsla;
+/// use gpuikit::theme::{Theme, ThemeExtension, Themeable};
+///
+/// #[derive(Clone)]
+/// struct DiffColors {
+///     added: Hsla,
+///     removed: Hsla,
+/// }
+///
+/// impl ThemeExtension for DiffColors {
+///     fn derive(theme: &Theme) -> Self {
+///         DiffColors {
+///             added: theme.success().opacity(0.18),
+///             removed: theme.danger().opacity(0.18),
+///         }
+///     }
+/// }
+///
+/// // Every theme now answers for it, including ones written before
+/// // `DiffColors` existed.
+/// let theme = Theme::gruvbox_dark();
+/// let diff = theme.extension::<DiffColors>();
+/// assert_eq!(diff.added, theme.success().opacity(0.18));
+/// ```
+///
+/// [`derive`](ThemeExtension::derive) is what makes this worth having. It is
+/// the same bargain the colour tokens strike: a theme is complete the moment
+/// its five primitives exist, and an author only writes down the parts they
+/// disagree with. A theme that has never heard of an extension still has
+/// coherent values for it, because they are computed from that theme's own
+/// colours.
+///
+/// A theme author who *does* disagree says so with
+/// [`Theme::with_extension`]:
+///
+/// ```
+/// # use gpui::{Hsla, hsla};
+/// # use gpuikit::theme::{Theme, ThemeExtension, Themeable};
+/// # #[derive(Clone)]
+/// # struct DiffColors { added: Hsla, removed: Hsla }
+/// # impl ThemeExtension for DiffColors {
+/// #     fn derive(theme: &Theme) -> Self {
+/// #         DiffColors { added: theme.success(), removed: theme.danger() }
+/// #     }
+/// # }
+/// let theme = Theme::gruvbox_dark().with_extension(DiffColors {
+///     added: hsla(0.33, 0.6, 0.2, 1.0),
+///     removed: hsla(0.0, 0.6, 0.2, 1.0),
+/// });
+/// assert_eq!(theme.extension::<DiffColors>().added, hsla(0.33, 0.6, 0.2, 1.0));
+/// ```
+///
+/// # Cost
+///
+/// [`Theme::extension`] returns by value, and derives on every read when the
+/// theme does not carry an explicit value. That is deliberate: caching would
+/// need interior mutability on a type that is otherwise plainly `Clone`, and
+/// the derivation is a few multiplications on colours already in cache. Read
+/// it once at the top of a render function, the way you would `cx.theme()`
+/// itself, rather than per row of a list.
+pub trait ThemeExtension: Clone + Send + Sync + 'static {
+    /// What this extension looks like under `theme` when the theme does not
+    /// name it.
+    ///
+    /// Write it in terms of `theme`'s own accessors — `success()`, `accent()`,
+    /// `surface()` — rather than fixed colours, or the extension will look
+    /// wrong on every theme but the one it was written against.
+    fn derive(theme: &Theme) -> Self;
+}
+
+/// The explicit extension values a [`Theme`] carries.
+///
+/// Opaque, and rarely named: build one through [`Theme::with_extension`] and
+/// read it through [`Theme::extension`]. It is a public field on `Theme` only
+/// because every other field is, so a struct literal is still possible.
+#[derive(Clone, Default)]
+pub struct ThemeExtensions(HashMap<TypeId, Arc<dyn Any + Send + Sync>>);
+
+impl ThemeExtensions {
+    /// The value stored for `T`, if a theme author set one.
+    fn get<T: ThemeExtension>(&self) -> Option<&T> {
+        self.0
+            .get(&TypeId::of::<T>())
+            .and_then(|value| value.downcast_ref::<T>())
+    }
+
+    /// Store `value` for `T`, replacing any previous one.
+    fn insert<T: ThemeExtension>(&mut self, value: T) {
+        self.0.insert(TypeId::of::<T>(), Arc::new(value));
+    }
+}
+
+/// Says how many extensions are set, not what they are: the values are
+/// `dyn Any`, so there is nothing to print. `Theme`'s derived `Debug` needs
+/// this to exist.
+impl fmt::Debug for ThemeExtensions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ThemeExtensions({} set)", self.0.len())
+    }
+}
+
 pub fn init(cx: &mut App) {
     cx.set_global(GlobalTheme::default());
 }
@@ -372,6 +490,11 @@ pub struct Theme {
     pub warning_color: Option<Hsla>,
     pub danger_color: Option<Hsla>,
     pub selection_color: Option<Hsla>,
+    pub placeholder_color: Option<Hsla>,
+    pub destructive_bg_color: Option<Hsla>,
+    pub destructive_bg_hover_color: Option<Hsla>,
+    pub destructive_bg_active_color: Option<Hsla>,
+    pub destructive_fg_color: Option<Hsla>,
     pub button_bg_color: Option<Hsla>,
     pub button_bg_hover_color: Option<Hsla>,
     pub button_bg_active_color: Option<Hsla>,
@@ -397,6 +520,10 @@ pub struct Theme {
     /// and `ControlScale::default()` is the crate's scale rather than an
     /// absence of one.
     pub controls: ControlScale,
+
+    /// Values a theme author set for extensions defined outside this crate.
+    /// Anything absent is derived on read — see [`ThemeExtension`].
+    pub extensions: ThemeExtensions,
 }
 
 impl Themeable for Theme {
@@ -471,7 +598,38 @@ impl Themeable for Theme {
             .unwrap_or_else(|| self.accent().opacity(0.3))
     }
     fn placeholder(&self) -> Hsla {
-        self.fg().opacity(0.5)
+        self.placeholder_color
+            .unwrap_or_else(|| self.fg().opacity(0.5))
+    }
+    // The four destructive tokens repeat their trait defaults rather than
+    // calling them: an impl cannot reach the default it is overriding, and
+    // they have to be overridable for `from_themeable` to be lossless.
+    fn destructive_bg(&self) -> Hsla {
+        self.destructive_bg_color.unwrap_or_else(|| self.danger())
+    }
+    fn destructive_bg_hover(&self) -> Hsla {
+        self.destructive_bg_hover_color.unwrap_or_else(|| {
+            let base = self.destructive_bg();
+            hsla(base.h, base.s, (base.l + 0.08).min(1.0), base.a)
+        })
+    }
+    fn destructive_bg_active(&self) -> Hsla {
+        self.destructive_bg_active_color.unwrap_or_else(|| {
+            let base = self.destructive_bg();
+            hsla(base.h, base.s, (base.l - 0.08).max(0.0), base.a)
+        })
+    }
+    fn destructive_fg(&self) -> Hsla {
+        self.destructive_fg_color.unwrap_or_else(|| {
+            let black = hsla(0.0, 0.0, 0.0, 1.0);
+            let white = hsla(0.0, 0.0, 1.0, 1.0);
+            let bg = self.destructive_bg();
+            if contrast_ratio(bg, white) >= contrast_ratio(bg, black) {
+                white
+            } else {
+                black
+            }
+        })
     }
     fn button_bg(&self) -> Hsla {
         self.button_bg_color.unwrap_or_else(|| self.surface())
@@ -581,6 +739,11 @@ impl Theme {
             warning_color: None,
             danger_color: None,
             selection_color: None,
+            placeholder_color: None,
+            destructive_bg_color: None,
+            destructive_bg_hover_color: None,
+            destructive_bg_active_color: None,
+            destructive_fg_color: None,
             button_bg_color: None,
             button_bg_hover_color: None,
             button_bg_active_color: None,
@@ -602,6 +765,7 @@ impl Theme {
             badge_amber_color: None,
             badge_gray_color: None,
             controls: ControlScale::default(),
+            extensions: ThemeExtensions::default(),
         }
     }
 
@@ -811,6 +975,131 @@ impl Theme {
         theme
     }
 
+    /// This theme's values for the extension `T`.
+    ///
+    /// Returns what a theme author set with [`with_extension`](Theme::with_extension),
+    /// or [`ThemeExtension::derive`] applied to this theme when they set
+    /// nothing — so this never fails and never needs an `Option` at the call
+    /// site. See [`ThemeExtension`] for the cost of calling it.
+    pub fn extension<T: ThemeExtension>(&self) -> T {
+        self.extensions
+            .get::<T>()
+            .cloned()
+            .unwrap_or_else(|| T::derive(self))
+    }
+
+    /// This theme, carrying `value` for the extension `T`.
+    ///
+    /// Chainable, so a theme and its extensions read as one expression.
+    pub fn with_extension<T: ThemeExtension>(mut self, value: T) -> Self {
+        self.extensions.insert(value);
+        self
+    }
+
+    /// Whether a value for `T` was set explicitly, rather than derived.
+    ///
+    /// Only a theme editor needs this — a component should call
+    /// [`extension`](Theme::extension) and not care which it got.
+    pub fn has_extension<T: ThemeExtension>(&self) -> bool {
+        self.extensions.get::<T>().is_some()
+    }
+
+    /// Resolve any [`Themeable`] into a concrete `Theme`.
+    ///
+    /// This is how a type of your own becomes the active theme. Implement
+    /// `Themeable` on it, snapshot it here, and install the result the usual
+    /// way:
+    ///
+    /// ```
+    /// # use gpui::{Hsla, hsla};
+    /// use gpuikit::theme::{Theme, ThemeVariant, Themeable};
+    ///
+    /// struct BrandTheme;
+    ///
+    /// impl Themeable for BrandTheme {
+    ///     fn fg(&self) -> Hsla { hsla(0.0, 0.0, 0.9, 1.0) }
+    ///     fn bg(&self) -> Hsla { hsla(0.6, 0.2, 0.1, 1.0) }
+    ///     fn surface(&self) -> Hsla { hsla(0.6, 0.2, 0.16, 1.0) }
+    ///     fn border(&self) -> Hsla { hsla(0.6, 0.2, 0.3, 1.0) }
+    ///     fn accent(&self) -> Hsla { hsla(0.9, 0.7, 0.6, 1.0) }
+    /// }
+    ///
+    /// let theme = Theme::from_themeable("Brand", ThemeVariant::Dark, &BrandTheme);
+    /// assert_eq!(theme.accent(), BrandTheme.accent());
+    /// ```
+    ///
+    /// # Why a snapshot, and not `Arc<dyn Themeable>`
+    ///
+    /// A theme changes when someone picks a new one. It is *read* several
+    /// hundred times per frame, by every element that draws. Making the global
+    /// a trait object would put a vtable dispatch on each of those reads to buy
+    /// flexibility at the one moment it is not needed. Resolving every token
+    /// once, here, pays that cost a single time and leaves the hot path a field
+    /// read.
+    ///
+    /// The snapshot is lossless: `Theme` carries an override field for every
+    /// token `Themeable` defines, and this sets all of them, so the result
+    /// answers identically to its source. `control_scale` comes across too.
+    /// What does *not* come across is behaviour — a `Themeable` whose
+    /// `danger()` varies with the time of day is a fixed colour once
+    /// snapshotted, and should be re-snapshotted when it changes.
+    pub fn from_themeable(
+        name: impl Into<SharedString>,
+        variant: ThemeVariant,
+        source: &dyn Themeable,
+    ) -> Self {
+        Theme {
+            name: name.into(),
+            variant,
+            fg_color: source.fg(),
+            bg_color: source.bg(),
+            surface_color: source.surface(),
+            border_color: source.border(),
+            accent_color: source.accent(),
+            fg_muted_color: Some(source.fg_muted()),
+            fg_disabled_color: Some(source.fg_disabled()),
+            surface_secondary_color: Some(source.surface_secondary()),
+            surface_tertiary_color: Some(source.surface_tertiary()),
+            border_secondary_color: Some(source.border_secondary()),
+            border_subtle_color: Some(source.border_subtle()),
+            outline_color: Some(source.outline()),
+            accent_bg_color: Some(source.accent_bg()),
+            accent_bg_hover_color: Some(source.accent_bg_hover()),
+            info_color: Some(source.info()),
+            success_color: Some(source.success()),
+            warning_color: Some(source.warning()),
+            danger_color: Some(source.danger()),
+            selection_color: Some(source.selection()),
+            placeholder_color: Some(source.placeholder()),
+            destructive_bg_color: Some(source.destructive_bg()),
+            destructive_bg_hover_color: Some(source.destructive_bg_hover()),
+            destructive_bg_active_color: Some(source.destructive_bg_active()),
+            destructive_fg_color: Some(source.destructive_fg()),
+            button_bg_color: Some(source.button_bg()),
+            button_bg_hover_color: Some(source.button_bg_hover()),
+            button_bg_active_color: Some(source.button_bg_active()),
+            button_border_color: Some(source.button_border()),
+            input_bg_color: Some(source.input_bg()),
+            input_border_color: Some(source.input_border()),
+            input_border_hover_color: Some(source.input_border_hover()),
+            input_border_focused_color: Some(source.input_border_focused()),
+            input_text_color: Some(source.input_text()),
+            input_placeholder_color: Some(source.input_placeholder()),
+            input_selection_color: Some(source.input_selection()),
+            input_cursor_color: Some(source.input_cursor()),
+            overlay_color: Some(source.overlay()),
+            badge_blue_color: Some(source.badge_blue()),
+            badge_gold_color: Some(source.badge_gold()),
+            badge_red_color: Some(source.badge_red()),
+            badge_green_color: Some(source.badge_green()),
+            badge_teal_color: Some(source.badge_teal()),
+            badge_amber_color: Some(source.badge_amber()),
+            badge_gray_color: Some(source.badge_gray()),
+            controls: source.control_scale(),
+            extensions: ThemeExtensions::default(),
+        }
+    }
+
     pub fn get_global(cx: &App) -> &Arc<Theme> {
         &cx.global::<GlobalTheme>().0
     }
@@ -885,6 +1174,331 @@ pub fn parse_hex(hex: &str) -> Hsla {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every token `Themeable` defines, read off a theme. The round-trip test
+    /// below compares two themes through this, so a token missing here is a
+    /// token the test silently stops checking — keep it in step with the
+    /// trait.
+    fn every_token(theme: &dyn Themeable) -> Vec<(&'static str, Hsla)> {
+        vec![
+            ("fg", theme.fg()),
+            ("bg", theme.bg()),
+            ("surface", theme.surface()),
+            ("border", theme.border()),
+            ("accent", theme.accent()),
+            ("fg_muted", theme.fg_muted()),
+            ("fg_disabled", theme.fg_disabled()),
+            ("surface_secondary", theme.surface_secondary()),
+            ("surface_tertiary", theme.surface_tertiary()),
+            ("border_secondary", theme.border_secondary()),
+            ("border_subtle", theme.border_subtle()),
+            ("outline", theme.outline()),
+            ("accent_bg", theme.accent_bg()),
+            ("accent_bg_hover", theme.accent_bg_hover()),
+            ("info", theme.info()),
+            ("success", theme.success()),
+            ("warning", theme.warning()),
+            ("danger", theme.danger()),
+            ("selection", theme.selection()),
+            ("placeholder", theme.placeholder()),
+            ("overlay", theme.overlay()),
+            ("button_bg", theme.button_bg()),
+            ("button_bg_hover", theme.button_bg_hover()),
+            ("button_bg_active", theme.button_bg_active()),
+            ("button_border", theme.button_border()),
+            ("destructive_bg", theme.destructive_bg()),
+            ("destructive_bg_hover", theme.destructive_bg_hover()),
+            ("destructive_bg_active", theme.destructive_bg_active()),
+            ("destructive_fg", theme.destructive_fg()),
+            ("input_bg", theme.input_bg()),
+            ("input_border", theme.input_border()),
+            ("input_border_hover", theme.input_border_hover()),
+            ("input_border_focused", theme.input_border_focused()),
+            ("input_text", theme.input_text()),
+            ("input_placeholder", theme.input_placeholder()),
+            ("input_selection", theme.input_selection()),
+            ("input_cursor", theme.input_cursor()),
+            ("badge_blue", theme.badge_blue()),
+            ("badge_gold", theme.badge_gold()),
+            ("badge_red", theme.badge_red()),
+            ("badge_green", theme.badge_green()),
+            ("badge_teal", theme.badge_teal()),
+            ("badge_amber", theme.badge_amber()),
+            ("badge_gray", theme.badge_gray()),
+        ]
+    }
+
+    /// A `Themeable` that is not `Theme`, with a value for every token that
+    /// differs from what the defaults would derive — so a snapshot that
+    /// dropped any one of them would be caught.
+    struct LoudTheme;
+
+    impl Themeable for LoudTheme {
+        fn fg(&self) -> Hsla {
+            hsla(0.11, 0.11, 0.11, 1.0)
+        }
+        fn bg(&self) -> Hsla {
+            hsla(0.12, 0.12, 0.12, 1.0)
+        }
+        fn surface(&self) -> Hsla {
+            hsla(0.13, 0.13, 0.13, 1.0)
+        }
+        fn border(&self) -> Hsla {
+            hsla(0.14, 0.14, 0.14, 1.0)
+        }
+        fn accent(&self) -> Hsla {
+            hsla(0.15, 0.15, 0.15, 1.0)
+        }
+        // Every remaining token, said explicitly and distinctly.
+        fn fg_muted(&self) -> Hsla {
+            hsla(0.21, 0.5, 0.5, 1.0)
+        }
+        fn fg_disabled(&self) -> Hsla {
+            hsla(0.22, 0.5, 0.5, 1.0)
+        }
+        fn surface_secondary(&self) -> Hsla {
+            hsla(0.23, 0.5, 0.5, 1.0)
+        }
+        fn surface_tertiary(&self) -> Hsla {
+            hsla(0.24, 0.5, 0.5, 1.0)
+        }
+        fn border_secondary(&self) -> Hsla {
+            hsla(0.25, 0.5, 0.5, 1.0)
+        }
+        fn border_subtle(&self) -> Hsla {
+            hsla(0.26, 0.5, 0.5, 1.0)
+        }
+        fn outline(&self) -> Hsla {
+            hsla(0.27, 0.5, 0.5, 1.0)
+        }
+        fn accent_bg(&self) -> Hsla {
+            hsla(0.28, 0.5, 0.5, 1.0)
+        }
+        fn accent_bg_hover(&self) -> Hsla {
+            hsla(0.29, 0.5, 0.5, 1.0)
+        }
+        fn info(&self) -> Hsla {
+            hsla(0.30, 0.5, 0.5, 1.0)
+        }
+        fn success(&self) -> Hsla {
+            hsla(0.31, 0.5, 0.5, 1.0)
+        }
+        fn warning(&self) -> Hsla {
+            hsla(0.32, 0.5, 0.5, 1.0)
+        }
+        fn danger(&self) -> Hsla {
+            hsla(0.33, 0.5, 0.5, 1.0)
+        }
+        fn selection(&self) -> Hsla {
+            hsla(0.34, 0.5, 0.5, 1.0)
+        }
+        fn placeholder(&self) -> Hsla {
+            hsla(0.35, 0.5, 0.5, 1.0)
+        }
+        fn overlay(&self) -> Hsla {
+            hsla(0.36, 0.5, 0.5, 1.0)
+        }
+        fn button_bg(&self) -> Hsla {
+            hsla(0.37, 0.5, 0.5, 1.0)
+        }
+        fn button_bg_hover(&self) -> Hsla {
+            hsla(0.38, 0.5, 0.5, 1.0)
+        }
+        fn button_bg_active(&self) -> Hsla {
+            hsla(0.39, 0.5, 0.5, 1.0)
+        }
+        fn button_border(&self) -> Hsla {
+            hsla(0.40, 0.5, 0.5, 1.0)
+        }
+        fn destructive_bg(&self) -> Hsla {
+            hsla(0.41, 0.5, 0.5, 1.0)
+        }
+        fn destructive_bg_hover(&self) -> Hsla {
+            hsla(0.42, 0.5, 0.5, 1.0)
+        }
+        fn destructive_bg_active(&self) -> Hsla {
+            hsla(0.43, 0.5, 0.5, 1.0)
+        }
+        fn destructive_fg(&self) -> Hsla {
+            hsla(0.44, 0.5, 0.5, 1.0)
+        }
+        fn input_bg(&self) -> Hsla {
+            hsla(0.45, 0.5, 0.5, 1.0)
+        }
+        fn input_border(&self) -> Hsla {
+            hsla(0.46, 0.5, 0.5, 1.0)
+        }
+        fn input_border_hover(&self) -> Hsla {
+            hsla(0.47, 0.5, 0.5, 1.0)
+        }
+        fn input_border_focused(&self) -> Hsla {
+            hsla(0.48, 0.5, 0.5, 1.0)
+        }
+        fn input_text(&self) -> Hsla {
+            hsla(0.49, 0.5, 0.5, 1.0)
+        }
+        fn input_placeholder(&self) -> Hsla {
+            hsla(0.50, 0.5, 0.5, 1.0)
+        }
+        fn input_selection(&self) -> Hsla {
+            hsla(0.51, 0.5, 0.5, 1.0)
+        }
+        fn input_cursor(&self) -> Hsla {
+            hsla(0.52, 0.5, 0.5, 1.0)
+        }
+        fn badge_blue(&self) -> Hsla {
+            hsla(0.53, 0.5, 0.5, 1.0)
+        }
+        fn badge_gold(&self) -> Hsla {
+            hsla(0.54, 0.5, 0.5, 1.0)
+        }
+        fn badge_red(&self) -> Hsla {
+            hsla(0.55, 0.5, 0.5, 1.0)
+        }
+        fn badge_green(&self) -> Hsla {
+            hsla(0.56, 0.5, 0.5, 1.0)
+        }
+        fn badge_teal(&self) -> Hsla {
+            hsla(0.57, 0.5, 0.5, 1.0)
+        }
+        fn badge_amber(&self) -> Hsla {
+            hsla(0.58, 0.5, 0.5, 1.0)
+        }
+        fn badge_gray(&self) -> Hsla {
+            hsla(0.59, 0.5, 0.5, 1.0)
+        }
+    }
+
+    /// The claim `from_themeable`'s docs make: the snapshot answers exactly
+    /// what its source did, for every token, including the ones a `Theme`
+    /// gained a field for only so that this could be true.
+    #[test]
+    fn from_themeable_is_lossless() {
+        let snapshot = Theme::from_themeable("Loud", ThemeVariant::Dark, &LoudTheme);
+
+        for ((name, source), (_, resolved)) in every_token(&LoudTheme)
+            .into_iter()
+            .zip(every_token(&snapshot))
+        {
+            assert_eq!(
+                source, resolved,
+                "`{name}` did not survive from_themeable: Theme has no override field for it, \
+                 so the snapshot fell back to deriving it"
+            );
+        }
+    }
+
+    /// The same, for the bundled themes: snapshotting one has to be a no-op.
+    #[test]
+    fn snapshotting_a_theme_changes_nothing() {
+        for theme in [
+            Theme::gruvbox_dark(),
+            Theme::gruvbox_light(),
+            Theme::catppuccin_latte(),
+            Theme::catppuccin_mocha(),
+        ] {
+            let snapshot = Theme::from_themeable(theme.name.clone(), theme.variant, &theme);
+            for ((name, before), (_, after)) in
+                every_token(&theme).into_iter().zip(every_token(&snapshot))
+            {
+                assert_eq!(
+                    before, after,
+                    "`{name}` changed when {} was snapshotted",
+                    theme.name
+                );
+            }
+            assert_eq!(theme.control_scale(), snapshot.control_scale());
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct DiffColors {
+        added: Hsla,
+        removed: Hsla,
+    }
+
+    impl ThemeExtension for DiffColors {
+        fn derive(theme: &Theme) -> Self {
+            DiffColors {
+                added: theme.success().opacity(0.18),
+                removed: theme.danger().opacity(0.18),
+            }
+        }
+    }
+
+    /// A theme that has never heard of an extension still answers for it, in
+    /// its own colours. This is the whole point of `derive`.
+    #[test]
+    fn an_unset_extension_derives_from_the_theme() {
+        let dark = Theme::gruvbox_dark();
+        let light = Theme::gruvbox_light();
+
+        assert_eq!(
+            dark.extension::<DiffColors>(),
+            DiffColors {
+                added: dark.success().opacity(0.18),
+                removed: dark.danger().opacity(0.18),
+            }
+        );
+        // And it follows the theme, rather than being one fixed pair.
+        assert_ne!(
+            dark.extension::<DiffColors>(),
+            light.extension::<DiffColors>()
+        );
+        assert!(!dark.has_extension::<DiffColors>());
+    }
+
+    #[test]
+    fn an_explicit_extension_wins_over_derivation() {
+        let loud = DiffColors {
+            added: hsla(0.1, 1.0, 0.5, 1.0),
+            removed: hsla(0.9, 1.0, 0.5, 1.0),
+        };
+        let theme = Theme::gruvbox_dark().with_extension(loud.clone());
+
+        assert!(theme.has_extension::<DiffColors>());
+        assert_eq!(theme.extension::<DiffColors>(), loud);
+    }
+
+    /// Two extensions do not collide, and setting one leaves the other
+    /// deriving.
+    #[test]
+    fn extensions_are_keyed_by_type() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct Series(Hsla);
+        impl ThemeExtension for Series {
+            fn derive(theme: &Theme) -> Self {
+                Series(theme.accent())
+            }
+        }
+
+        let theme = Theme::gruvbox_dark().with_extension(Series(hsla(0.5, 1.0, 0.5, 1.0)));
+
+        assert_eq!(
+            theme.extension::<Series>(),
+            Series(hsla(0.5, 1.0, 0.5, 1.0))
+        );
+        assert!(!theme.has_extension::<DiffColors>());
+        assert_eq!(
+            theme.extension::<DiffColors>(),
+            DiffColors::derive(&theme),
+            "setting one extension must not disturb another"
+        );
+    }
+
+    /// Extensions ride along with the theme they were set on.
+    #[test]
+    fn extensions_survive_a_clone() {
+        let theme = Theme::gruvbox_dark().with_extension(DiffColors {
+            added: hsla(0.1, 1.0, 0.5, 1.0),
+            removed: hsla(0.9, 1.0, 0.5, 1.0),
+        });
+        let copy = theme.clone();
+        assert_eq!(
+            copy.extension::<DiffColors>(),
+            theme.extension::<DiffColors>()
+        );
+    }
 
     #[test]
     fn test_default_theme() {


### PR DESCRIPTION
**Stacked on #263** — base is that branch, so the diff here is just the theme system. Merge #263 first and this rebases onto main cleanly.

You asked for a `ThemeExt` trait "or such". Digging in, "extensible themes" turned out to be two separate questions, and I think they want different answers.

## Question 1: can I add tokens gpuikit doesn't define?

This had no answer at all, and I think it's the more important one. A crate built on gpuikit needs colours this crate has never heard of — a diff view wants added/removed fills, a terminal wants sixteen ANSI colours, a chart wants a series palette. The only options were a second global no theme could see, or a fork.

```rust
#[derive(Clone)]
struct DiffColors { added: Hsla, removed: Hsla }

impl ThemeExtension for DiffColors {
    fn derive(theme: &Theme) -> Self {
        DiffColors {
            added: theme.success().opacity(0.18),
            removed: theme.danger().opacity(0.18),
        }
    }
}

let diff = cx.theme().extension::<DiffColors>();          // never fails, no Option
let theme = Theme::gruvbox_dark().with_extension(loud);   // …unless you disagree
```

`derive` is the part that earns its keep. It's the same bargain the colour tokens already strike — a theme is complete from five primitives, and an author writes down only what they disagree with — so **every** theme answers for an extension, including the six bundled ones that predate it. Keyed by `TypeId`, so two extensions can't collide.

**Cost:** returns by value and derives on each read when unset. Caching would need interior mutability on a type that's otherwise plainly `Clone`, to save a few multiplications. Documented as "read it once per render, not once per row." Easy to revisit if it ever shows up in a profile.

## Question 2: can my own type be the active theme?

This had a *wrong* answer, which #263's page had to apologise for. `Themeable` is object-safe but was never installable.

I deliberately did **not** make the global `Arc<dyn Themeable>`. A theme changes when someone picks one; it's read several hundred times a frame by every element that draws. That trade buys flexibility at the one moment it isn't needed and charges a vtable dispatch on every read. `Theme::from_themeable` resolves the trait once instead:

```rust
let theme = Theme::from_themeable("Brand", ThemeVariant::Dark, &BrandTheme);
```

**This is the part worth arguing with.** If you'd rather have true dynamic dispatch, say so — it's a coherent position, just a different trade, and it'd be a bigger break (`cx.theme()` returns `&Arc<Theme>` today and callers use it as a value).

## A bug this turned up

For the snapshot to be honest it has to be lossless, and it wasn't. `placeholder` and the four `destructive_*` tokens were `Themeable` methods with **no override field on `Theme`** — so a custom implementation's versions of them were silently dropped, and no `Theme` could override them either. They're `Option<Hsla>` now like every other token.

`from_themeable_is_lossless` walks all 44 tokens against a `Themeable` that sets every one distinctly, so this can't regress quietly.

## Breaking

A struct-literal `Theme { … }` must name six new fields (`extensions` plus the five above) — exactly what `controls` required in 0.9. Everything built through `Theme::new`, which is all the bundled themes, is unaffected. I kept `extensions` a **public** field with an opaque type rather than private, so struct literals stay possible at all; say if you'd rather force `Theme::new`.

## Verification

- `cargo test --lib`: **594 passed** (6 new — lossless round-trip, bundled-theme snapshot no-op, derive-when-unset, explicit-wins, keyed-by-type, survives-clone).
- `cargo clippy --lib --example showcase --features examples`, `cargo fmt --check`, `typos`: clean.
- The three new rustdoc examples use bare fences, so CI's doctest job compiles and runs them. I did not run `cargo test --doc` locally — it's known to lock this machine — so I transcribed all three into a throwaway `tests/` file and `cargo check`ed them as a consumer would, then deleted it. CI is the real check.
- **Not confirmed visually:** the page's new sections 6 and 7. Sections 1–2 render (screenshot verified), but the browser pane refuses scroll actions and gpui draws to a canvas, so there's no DOM to read instead.

## Open questions for you

1. Snapshot vs `Arc<dyn Themeable>` — the main one.
2. Derive-on-read vs caching extension values.
3. `extensions` public-and-opaque vs private (forcing `Theme::new`).
4. Worth a `cx.theme_extension::<T>()` shorthand on `ActiveTheme`, or is `cx.theme().extension::<T>()` fine?