### PR TITLE
Render the editor on the web: syntect's fancy-regex backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ All notable changes to this project will be documented in this file.
   column's minimum width and a long description made the box wider than its
   container — an alert ran under the button beside it, a toast ran past its
   own 360px column — instead of wrapping.
+- **The Editor page renders on the web.** The hosted showcase compiled the
+  example with `--features examples` but not `editor`, so the browser saw the
+  page's "built without the editor feature" fallback instead of a live buffer.
+  It could not simply be switched on: syntect's default regex engine is
+  Oniguruma, a C library that does not build for `wasm32-unknown-unknown`.
+  The dependency now uses `default-fancy`, the same batteries-included preset
+  over the pure-Rust `fancy-regex`, and the web build asks for the feature —
+  so the editor highlights in the browser as it does natively. (The unused
+  `gpui_util` dependency the `editor` feature also pulled in is dropped.)
 
 ## [0.9.0] - 2026-09-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,7 +2458,6 @@ dependencies = [
  "anyhow",
  "gpui-platform-gpui-unofficial",
  "gpui-unofficial",
- "gpui-util-gpui-unofficial",
  "log",
  "mdstitch",
  "pretty_assertions",
@@ -3794,28 +3804,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "oo7"
@@ -5479,10 +5467,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
+ "fancy-regex",
  "flate2",
  "fnv",
  "once_cell",
- "onig",
  "plist",
  "regex-syntax",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,9 +108,13 @@ pulldown-cmark = { version = "0.13.4", default-features = false, features = ["si
 # half-written `**bold` does not flash as literal asterisks (optional)
 mdstitch = { version = "0.1", optional = true }
 
-# Editor dependencies (optional)
-syntect = { version = "5.3.0", optional = true }
-gpui_util = { package = "gpui-util-gpui-unofficial", version = "1.14.2", optional = true }
+# Editor dependencies (optional). syntect's default regex engine is Oniguruma,
+# a C library that does not build for wasm32-unknown-unknown; `default-fancy`
+# is the same batteries-included preset over the pure-Rust `fancy-regex`, so
+# the editor page highlights in the browser as well as natively.
+syntect = { version = "5.3.0", optional = true, default-features = false, features = [
+    "default-fancy",
+] }
 
 # Schema generation (optional)
 schemars = { version = "0.8", optional = true }
@@ -143,7 +147,7 @@ wasm-bindgen = "0.2"
 
 [features]
 default = []
-editor = ["dep:syntect", "dep:gpui_util"]
+editor = ["dep:syntect"]
 schema = ["dep:schemars"]
 # Compile Metal shaders at runtime instead of at build time (no Xcode Metal
 # toolchain required).

--- a/examples/showcase-web/Trunk.toml
+++ b/examples/showcase-web/Trunk.toml
@@ -9,7 +9,9 @@
 [build]
 target = "index.html"
 example = "showcase"
-features = ["examples"]
+# `editor` too: the Editor page renders a live, syntax-highlighted buffer, and
+# syntect's `default-fancy` backend (see Cargo.toml) builds for wasm.
+features = ["examples", "editor"]
 dist = "dist"
 
 # Trunk watches the config's own directory by default, which is not where


### PR DESCRIPTION
**Stacked on the theme-extension system PR** (base is that branch). The change here is just the editor-on-web fix.

The editor element already exists and the showcase already has an Editor page — but in the browser it fell back to its "built without the editor feature" placeholder. The hosted build compiled the example with `--features examples` and not `editor`.

It couldn't simply be switched on. syntect's default regex engine is Oniguruma, a C library that does not build for `wasm32-unknown-unknown`, so turning the feature on for the web build would break the build outright.

## The fix

- syntect now uses `default-fancy` — the same batteries-included preset over the pure-Rust `fancy-regex` backend instead of onig. Native builds are unaffected; the wasm build now compiles.
- The web `Trunk.toml` asks for the `editor` feature, so the browser gets the live, syntax-highlighted buffer the native run has always had.
- The `editor` feature also pulled in `gpui_util`, which nothing in the crate uses. Dropped.

## Verification

- `cargo check --example showcase --features examples,editor` (native): clean.
- `cargo check --lib --features editor --target wasm32-unknown-unknown` (nightly build-std): clean — syntect compiles for wasm, which is the thing the C backend made impossible.
- `cargo check --example showcase --features examples,editor --target wasm32-unknown-unknown -Z build-std` (the full example the browser runs): clean.
- `cargo clippy --example showcase --features examples,editor`, `cargo fmt --check`: clean.

The definitive gate is `.github/workflows/pages.yml` building and serving it; the type-checks above cover everything short of the bundle.
