### PR TITLE
Read the showcase's gpui version badge from Cargo.lock (it was a hardcoded "1.14")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ All notable changes to this project will be documented in this file.
   over the pure-Rust `fancy-regex`, and the web build asks for the feature —
   so the editor highlights in the browser as it does natively. (The unused
   `gpui_util` dependency the `editor` feature also pulled in is dropped.)
+- **The showcase's gpui version badge read a hand-written string.** The Home
+  page's header badge said `gpui 1.14` as a literal, so it stayed at 1.14 while
+  the dependency moved to 1.18 underneath it. A `build.rs` now reads the
+  resolved `gpui-unofficial` version out of `Cargo.lock` and the badge renders
+  that, baked in at compile time so it works in the wasm build too.
 
 ## [0.9.0] - 2026-09-04
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,41 @@
+//! Exposes the gpui version this crate actually resolved to as the
+//! `GPUI_VERSION` compile-time env var, so the showcase can render it instead
+//! of a hand-written string that drifts the moment the dependency is bumped.
+//!
+//! The version is read from `Cargo.lock`, which is the resolved truth rather
+//! than the requirement in `Cargo.toml` — and it is baked in at compile time,
+//! so it survives into the wasm build, which has no lockfile at runtime. When
+//! there is no lockfile (a downstream crate building gpuikit as a dependency),
+//! it falls back to `unknown`; only the `showcase` example reads the var, and
+//! that example is only ever built inside this repository.
+
+use std::path::Path;
+
+fn main() {
+    let lock = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock");
+    println!("cargo:rerun-if-changed={}", lock.display());
+
+    let version = std::fs::read_to_string(&lock)
+        .ok()
+        .and_then(|contents| gpui_version(&contents))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GPUI_VERSION={version}");
+}
+
+/// The `version` of the `gpui-unofficial` package in a `Cargo.lock`. Every
+/// `[[package]]` block lists `name` then `version` on consecutive lines, so
+/// the version wanted is the first `version = "…"` after the matching `name`.
+fn gpui_version(lock: &str) -> Option<String> {
+    let mut lines = lock.lines();
+    while let Some(line) = lines.next() {
+        if line.trim() == r#"name = "gpui-unofficial""# {
+            for next in lines.by_ref() {
+                if let Some(rest) = next.trim().strip_prefix("version = ") {
+                    return Some(rest.trim_matches('"').to_string());
+                }
+            }
+        }
+    }
+    None
+}

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -2098,7 +2098,7 @@ impl Showcase {
                 h_stack()
                     .gap_2()
                     .child(badge(build_stamp()).outline())
-                    .child(badge("gpui 1.14").secondary()),
+                    .child(badge(concat!("gpui ", env!("GPUI_VERSION"))).secondary()),
             )
             .child(h1("Components for gpui, composed."))
             .child(lead(


### PR DESCRIPTION
The Home page header renders a `gpui 1.14` badge — as a **literal string** (`badge("gpui 1.14")`). So it read 1.14 while the dependency had already moved to 1.17.2, and it would have kept saying 1.14 forever regardless of what gpui the showcase actually builds against. Spotted on the live site right after the 1.18 bump landed.

## The fix

A `build.rs` parses the resolved `gpui-unofficial` version out of `Cargo.lock` (the resolved truth, not the requirement in `Cargo.toml`) and emits it as `GPUI_VERSION`. The badge is now `badge(concat!("gpui ", env!("GPUI_VERSION")))`.

- **Baked in at compile time**, so it survives into the wasm build — which has no lockfile to read at runtime.
- **Reads the real dep**, so the next `cargo update`/bump moves the badge with it; nobody has to remember to edit a string.
- Falls back to `unknown` when there is no lockfile, which only happens for a downstream crate building gpuikit as a dependency — and that build never compiles the `showcase` example, the only place the var is read.

## Verification

- The build script emits `GPUI_VERSION=1.18.0` on this branch (confirmed via `cargo build -vv`).
- `cargo build --example showcase --features examples`, `cargo fmt --check`, `cargo clippy` (which checks the build script too): clean.

Once this and the 1.18 bump are both deployed, the badge on nate.rip/gpuikit reads `gpui 1.18.0`.
