### PR TITLE
Disambiguate gpuikit from gpui-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A UI toolkit for [gpui](https://www.gpui.rs) applications. Targeting a conceptua
 
 [See it in action &rarr;](https://nate.rip/gpuikit/)
 
+> Note, `gpuikit` is not [`gpui-kit`](https://raw.githubusercontent.com/iamnbutler/gpuikit/main/why.md)
+
 ![The gpuikit showcase](https://raw.githubusercontent.com/iamnbutler/gpuikit/main/.github/media/showcase.png)
 
 ## Getting started

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -2115,6 +2115,21 @@ impl Showcase {
                     .child(badge(build_stamp()).outline())
                     .child(badge(concat!("gpui ", env!("GPUI_VERSION"))).secondary()),
             )
+            // Disambiguation: `gpui-component` renamed to `gpui-kit` in Sept
+            // 2026, one character off this project. The note links to `why.md`,
+            // the same explainer the README points at. `open_url` opens the
+            // browser natively; on the hosted web build it is best-effort.
+            .child(
+                div()
+                    .id("why-not-gpui-kit")
+                    .cursor_pointer()
+                    .text_xs()
+                    .text_color(theme.accent())
+                    .child("gpuikit is not gpui-kit — here's why →")
+                    .on_click(|_, _window, cx| {
+                        cx.open_url("https://github.com/iamnbutler/gpuikit/blob/main/why.md")
+                    }),
+            )
             .child(h1("Components for gpui, composed."))
             .child(lead(
                 "Everything on this board is built from the kit: cards, a table, \

--- a/why.md
+++ b/why.md
@@ -1,0 +1,1 @@
+This is not [`gpui-kit`](https://gpui-kit.com/). I don't know why `gpui-component` decided to rename to one character difference from `gpuikit` on Sept 3rd, 2026 - `gpuikit` has been around since [Oct 4, 2023](https://github.com/iamnbutler/gpuikit/commit/4dd3fd1a0570ac9127e6c517dd82e86d1edf12db) 😅


### PR DESCRIPTION
`gpui-component` renamed itself to `gpui-kit` on Sept 3 2026 — one character off `gpuikit`, which has been around since [Oct 4 2023](https://github.com/iamnbutler/gpuikit/commit/4dd3fd1a0570ac9127e6c517dd82e86d1edf12db). This adds a short explainer and points to it from the two places a confused visitor lands.

## Changes
- **`why.md`** — the explainer, linking the original 2023 commit as proof of age.
- **`README.md`** — a one-line note under the hero link: `gpuikit` is not `gpui-kit`.
- **`examples/showcase.rs`** — a small accent-colored, clickable line at the top of the home hero (under the build/gpui badges), opening `why.md` via `cx.open_url`.

## Notes
- Native builds open the link reliably; on the hosted web build `open_url` is best-effort.
- The README points at the **raw** `why.md`; the demo link points at the **blob** (rendered) view for readability. Say the word if you'd rather they match.
- `cargo check --example showcase --features examples` passes.